### PR TITLE
Color component modifications

### DIFF
--- a/src/stories/arrows/icon-arrow-accent/ArrowAccent.stories.tsx
+++ b/src/stories/arrows/icon-arrow-accent/ArrowAccent.stories.tsx
@@ -15,6 +15,7 @@ const StoryBase: Meta = {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=282%3A3763",
     },
+    layout: "centered",
   },
 };
 

--- a/src/stories/arrows/icon-arrow-ui/ArrowUI.stories.tsx
+++ b/src/stories/arrows/icon-arrow-ui/ArrowUI.stories.tsx
@@ -25,6 +25,7 @@ const StoryBase: StoryBaseType<IconArrowProps> = {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=264%3A3146",
     },
+    layout: "centered",
   },
 };
 

--- a/src/stories/breakpoints/Breakpoints.stories.tsx
+++ b/src/stories/breakpoints/Breakpoints.stories.tsx
@@ -14,6 +14,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=255%3A2080",
     },
+    layout: "centered",
   },
 } as Meta;
 

--- a/src/stories/button/Button.stories.tsx
+++ b/src/stories/button/Button.stories.tsx
@@ -25,6 +25,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=296%3A5345",
     },
+    layout: "centered",
   },
 } as ComponentMeta<typeof Button>;
 

--- a/src/stories/colors/colors/Colors.stories.tsx
+++ b/src/stories/colors/colors/Colors.stories.tsx
@@ -2,18 +2,12 @@ import React from "react";
 import { withDesign } from "storybook-addon-designs";
 import { Meta } from "@storybook/react";
 
-import { Colors, ColorsProps } from "./Colors";
+import { Colors as ColorsComp } from "./Colors";
 
 export default {
-  title: "Atoms / Colors",
-  component: Colors,
+  title: "Atoms / Colors / Colors",
+  component: ColorsComp,
   decorators: [withDesign],
-  argTypes: {
-    identityColor: {
-      defaultValue: "#476e57",
-      control: { type: "color" },
-    },
-  },
   parameters: {
     design: {
       type: "figma",
@@ -23,4 +17,4 @@ export default {
   },
 } as Meta;
 
-export const Default = (props: ColorsProps) => <Colors {...props} />;
+export const Colors = () => <ColorsComp />;

--- a/src/stories/colors/colors/Colors.tsx
+++ b/src/stories/colors/colors/Colors.tsx
@@ -1,0 +1,232 @@
+import "../../../styles/css/base.css";
+
+export const Colors = () => {
+  return (
+    <div>
+      {colorClasses.map((color) => (
+        <div className="internal-colors-container">
+          <h1 className="text-header-h3">{color.colorTitle}</h1>
+          <div className="internal-colors-wrapper">
+            {color.colorItems.map((colorItem) => (
+              <div>
+                <div
+                  className={
+                    "internal-colors-box " +
+                    (colorItem.classNameBg || colorItem.className)
+                  }
+                />
+                <pre>
+                  <code>.{colorItem.className}</code>
+                </pre>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      <div>
+        <h1 className="text-header-h3">CSS-klasser</h1>
+        <p className="text-body-medium-regular mt-24">
+          Der er lavet en række css-klasser til henholdvis baggrundsfarver (bg),
+          kanter (border), og tekst (color), som er til at finde i
+          <code>scss/color-classes.scss</code> filen. Klasserne bruger
+          henholdsvis <code>bg</code> / <code>border</code> / <code>color</code>
+          som prefix. <br />
+          Det er også muligt at bruge css-variabler fra
+          <code>scss/color-variables.scss</code> direkte i css-filerne.
+        </p>
+
+        <p className="text-body-medium-regular mt-16">
+          Eksempel: <br />
+          <code>div</code> med <code>.bg-global-secondary</code>, og
+          <code>p</code>-element med <code>.color-primary-black</code>:
+        </p>
+        <div className="bg-global-secondary p-32 mt-16">
+          <p className="color-primary-black text-header-h2">Nyt på hylderne</p>
+        </div>
+
+        <div>
+          <div className="internal-colors-wrapper">
+            <div>
+              <p className="text-body-large mb-8">Background classes</p>
+              {bgClasses.map((bgClass) => (
+                <div className="internal-spacing-css-inner">
+                  <div className="internal-spacing-css-inner-prefix p-8">
+                    <pre>
+                      <code>{`.${bgClass.classPrefix}`}</code>
+                    </pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div>
+              <p className="text-body-large mb-8">Border classes</p>
+              {borderClasses.map((borderClass) => (
+                <div className="internal-spacing-css-inner">
+                  <div className="internal-spacing-css-inner-prefix p-8">
+                    <pre>
+                      <code>{`.${borderClass.classPrefix}`}</code>
+                    </pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div>
+              <p className="text-body-large mb-8">Color (text) classes</p>
+              {textColorClasses.map((textColorClass) => (
+                <div className="internal-spacing-css-inner">
+                  <div className="internal-spacing-css-inner-prefix p-8">
+                    <pre>
+                      <code>{`.${textColorClass.classPrefix}`}</code>
+                    </pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type ColorClasses = {
+  colorTitle: string;
+  colorItems: {
+    className: string;
+    classNameBg?: string;
+  }[];
+}[];
+const colorClasses: ColorClasses = [
+  {
+    colorTitle: "Globale farver",
+    colorItems: [
+      {
+        className: "bg-global-primary",
+      },
+      {
+        className: "bg-global-secondary",
+      },
+      {
+        className: "bg-global-tertiary-1",
+      },
+      {
+        className: "bg-global-tertiary-2",
+      },
+    ],
+  },
+  {
+    colorTitle: "Tekst farver",
+    colorItems: [
+      {
+        className: "color-primary-white",
+        classNameBg: "bg-color-primary-white",
+      },
+      {
+        className: "color-primary-black",
+        classNameBg: "bg-color-primary-black",
+      },
+      {
+        className: "color-secondary-gray",
+        classNameBg: "bg-color-secondary-gray",
+      },
+    ],
+  },
+  {
+    colorTitle: "Signal farver",
+    colorItems: [
+      {
+        className: "bg-signal-success",
+      },
+      {
+        className: "bg-signal-aware",
+      },
+      {
+        className: "bg-signal-alert",
+      },
+    ],
+  },
+];
+
+const bgClasses = [
+  {
+    classPrefix: "bg-global-primary",
+  },
+  {
+    classPrefix: "bg-global-secondary",
+  },
+  {
+    classPrefix: "bg-global-tertiary-1",
+  },
+  {
+    classPrefix: "bg-global-tertiary-2",
+  },
+  {
+    classPrefix: "bg-identity-primary",
+  },
+  {
+    classPrefix: "bg-identity-tint-{tint}",
+  },
+  {
+    classPrefix: "bg-signal-success",
+  },
+  {
+    classPrefix: "bg-signal-aware",
+  },
+  {
+    classPrefix: "bg-signal-alert",
+  },
+];
+
+const borderClasses = [
+  {
+    classPrefix: "border-global-primary",
+  },
+  {
+    classPrefix: "border-global-secondary",
+  },
+  {
+    classPrefix: "border-global-tertiary-1",
+  },
+  {
+    classPrefix: "border-global-tertiary-2",
+  },
+  {
+    classPrefix: "border-identity-primary",
+  },
+  {
+    classPrefix: "border-signal-success",
+  },
+  {
+    classPrefix: "border-signal-aware",
+  },
+  {
+    classPrefix: "border-signal-alert",
+  },
+];
+
+const textColorClasses = [
+  {
+    classPrefix: "color-identity-primary",
+  },
+  {
+    classPrefix: "color-primary-white",
+  },
+  {
+    classPrefix: "color-primary-black",
+  },
+  {
+    classPrefix: "color-primary-gray",
+  },
+  {
+    classPrefix: "color-signal-success",
+  },
+  {
+    classPrefix: "color-signal-aware",
+  },
+  {
+    classPrefix: "color-signal-alert",
+  },
+];

--- a/src/stories/colors/identity-color/IdentityColor.stories.tsx
+++ b/src/stories/colors/identity-color/IdentityColor.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { withDesign } from "storybook-addon-designs";
+import { Meta } from "@storybook/react";
+
+import { IdentityColor as IdentityColorComp, IdentityColorProps } from "./IdentityColor";
+
+export default {
+  title: "Atoms / Colors / Identity Color",
+  component: IdentityColorComp,
+  decorators: [withDesign],
+  argTypes: {
+    identityColor: {
+      defaultValue: "#476e57",
+      control: { type: "color" },
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=2%3A4",
+    },
+  },
+} as Meta;
+
+export const IdentityColor = (props: IdentityColorProps) => <IdentityColorComp {...props} />;

--- a/src/stories/colors/identity-color/IdentityColor.tsx
+++ b/src/stories/colors/identity-color/IdentityColor.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react";
-import "../../styles/css/base.css";
+import "../../../styles/css/base.css";
 
-export type ColorsProps = {
+export type IdentityColorProps = {
   identityColor: string;
 };
-export const Colors = ({ identityColor }: ColorsProps) => {
+export const IdentityColor = ({ identityColor }: IdentityColorProps) => {
   useEffect(() => {
     const { h, s, l } = hexToHSL(identityColor);
     document.documentElement.style.setProperty("--identity-color-h", `${h}`);
@@ -14,29 +14,6 @@ export const Colors = ({ identityColor }: ColorsProps) => {
 
   return (
     <div>
-      <div className="internal-colors-code">
-        <p>
-          To be able to change the primary identity color + tones, you will have
-          to set 3 variables in the <code>:root</code> element. With javascript,
-          you can achieve this by running the following commands (remember to
-          replace the <code>h</code>, <code>s</code> and <code>l</code> value):
-        </p>
-        <pre>
-          <code>
-            document.documentElement.style.setProperty("--identity-color-h",
-            [h]);
-          </code>
-          <code>
-            document.documentElement.style.setProperty("--identity-color-s",
-            [s]);
-          </code>
-          <code>
-            document.documentElement.style.setProperty("--identity-color-l",
-            [l]);
-          </code>
-        </pre>
-      </div>
-
       {colorClasses.map((color) => (
         <div className="internal-colors-container">
           <h1 className="text-header-h3">{color.colorTitle}</h1>
@@ -57,6 +34,45 @@ export const Colors = ({ identityColor }: ColorsProps) => {
           </div>
         </div>
       ))}
+
+      <div className="internal-colors-code">
+        <p className="text-body-medium-regular">
+          Til at generere identitetsfarven/tonerne, er der brugt
+          <code>HSL</code> (Hue, Saturation, Lightness) farve værdier. <br />
+          For at ændre identitetsfarven/tonerne er det nødvendigt at sætte 3
+          variabler i <code>:root</code> elementet, som svarer til de 3 værdier
+          i <code>HSL</code>. <br />
+          Med javascript er det muligt at tilføje følgende linjer kode for at
+          ændre værdierne (husk at udskift <code>[h]</code>, <code>[s]</code>,
+          og <code>[l]</code>):
+        </p>
+        {/* <p className="mt-24">
+          To be able to change the primary identity color + tones, you will have
+          to set 3 variables in the <code>:root</code> element. With javascript,
+          you can achieve this by running the following commands (remember to
+          replace the <code>h</code>, <code>s</code> and <code>l</code> value):
+        </p> */}
+        <pre>
+          <code>
+            document.documentElement.style.setProperty("--identity-color-h",
+            [h]);
+          </code>
+          <code>
+            document.documentElement.style.setProperty("--identity-color-s",
+            [s]);
+          </code>
+          <code>
+            document.documentElement.style.setProperty("--identity-color-l",
+            [l]);
+          </code>
+        </pre>
+        <p className="text-body-medium-regular mt-24">
+          I addon panelet kan du under "Controls" skifte farve med farvehjulet
+          og se de forskellige toner blive genereret med det samme. Det er dog
+          kun til visuelt brug og ændrer ikke noget i den bagvedliggende kode.
+          <br />
+        </p>
+      </div>
     </div>
   );
 };
@@ -117,23 +133,6 @@ type ColorClasses = {
 }[];
 const colorClasses: ColorClasses = [
   {
-    colorTitle: "Globale farver",
-    colorItems: [
-      {
-        className: "bg-global-primary",
-      },
-      {
-        className: "bg-global-secondary",
-      },
-      {
-        className: "bg-global-tertiary-1",
-      },
-      {
-        className: "bg-global-tertiary-2",
-      },
-    ],
-  },
-  {
     colorTitle: "Identitetsfarver",
     colorItems: [
       {
@@ -158,37 +157,6 @@ const colorClasses: ColorClasses = [
       },
       {
         className: "bg-identity-tint-20",
-      },
-    ],
-  },
-  {
-    colorTitle: "Tekst farver",
-    colorItems: [
-      {
-        className: "color-primary-white",
-        classNameBg: "bg-color-primary-white",
-      },
-      {
-        className: "color-primary-black",
-        classNameBg: "bg-color-primary-black",
-      },
-      {
-        className: "color-secondary-gray",
-        classNameBg: "bg-color-secondary-gray",
-      },
-    ],
-  },
-  {
-    colorTitle: "Signal farver",
-    colorItems: [
-      {
-        className: "bg-signal-success",
-      },
-      {
-        className: "bg-signal-aware",
-      },
-      {
-        className: "bg-signal-alert",
       },
     ],
   },

--- a/src/stories/link-filters/LinkFilters.stories.tsx
+++ b/src/stories/link-filters/LinkFilters.stories.tsx
@@ -14,6 +14,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=274%3A7545",
     },
+    layout: "centered",
   },
 } as Meta;
 

--- a/src/stories/links/Links.stories.tsx
+++ b/src/stories/links/Links.stories.tsx
@@ -23,6 +23,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=2%3A4",
     },
+    layout: "centered",
   },
 } as ComponentMeta<typeof LinksComp>;
 

--- a/src/stories/logo/Logo.stories.tsx
+++ b/src/stories/logo/Logo.stories.tsx
@@ -23,6 +23,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=264%3A2263",
     },
+    layout: "centered",
   },
 };
 

--- a/src/stories/pagefold/Pagefold.stories.tsx
+++ b/src/stories/pagefold/Pagefold.stories.tsx
@@ -38,6 +38,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=1354%3A7941",
     },
+    layout: "centered",
   },
 } as ComponentMeta<typeof PagefoldComp>;
 

--- a/src/stories/tag/Tag.stories.tsx
+++ b/src/stories/tag/Tag.stories.tsx
@@ -16,6 +16,7 @@ export default {
       url:
         "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=836%3A5757",
     },
+    layout: "centered",
   },
 };
 

--- a/src/styles/scss/color-classes.scss
+++ b/src/styles/scss/color-classes.scss
@@ -18,15 +18,19 @@
 
 // Border
 .border-global-primary {
-  border-color: $c-global-primary;
+  border: 1px solid $c-global-primary;
 }
 
 .border-global-secondary {
-  border-color: $c-global-secondary;
+  border: 1px solid $c-global-secondary;
 }
 
-.border-global-tertiary {
-  border-color: $c-global-tertiary-1;
+.border-global-tertiary-1 {
+  border: 1px solid $c-global-tertiary-1;
+}
+
+.border-global-tertiary-2 {
+  border: 1px solid $c-global-tertiary-2;
 }
 
 // *** Identity colors ***
@@ -37,12 +41,12 @@
 
 // Border
 .border-identity-primary {
-  border-color: $c-identity-primary;
+  border: 1px solid $c-identity-primary;
 }
 
 // Color
 .color-identity-primary {
-  border-color: $c-identity-primary;
+  color: $c-identity-primary;
 }
 
 // *** Identity color tints ***
@@ -81,6 +85,7 @@
   color: $c-text-secondary-gray;
 }
 
+// Only used internally for bg-color in Colors comp.
 .bg-color-primary-white {
   background-color: $c-text-primary-white;
 }
@@ -107,15 +112,15 @@
 
 // Border
 .border-signal-success {
-  border-color: $c-signal-success;
+  border: 1px solid $c-signal-success;
 }
 
 .border-signal-aware {
-  border-color: $c-signal-aware;
+  border: 1px solid $c-signal-aware;
 }
 
 .border-signal-alert {
-  border-color: $c-signal-alert;
+  border: 1px solid $c-signal-alert;
 }
 
 // Color
@@ -128,5 +133,3 @@
 .color-signal-alert {
   color: $c-signal-alert;
 }
-
-// Hover colors ??

--- a/src/styles/scss/color-variables.scss
+++ b/src/styles/scss/color-variables.scss
@@ -1,3 +1,4 @@
+// Global colors
 $c-global-primary: #f6f5f0;
 $c-global-secondary: #eee9e5;
 $c-global-tertiary-1: #dbdbdb;
@@ -19,6 +20,7 @@ $c-signal-alert: #d5364a;
 
 // *** CSS variables for identity color tints ***
 :root {
+  // Identity color tones
   --identity-color-h: 145;
   --identity-color-s: 22%;
   --identity-color-l: 35%;
@@ -33,4 +35,16 @@ $c-signal-alert: #d5364a;
     calc(var(--identity-color-s) - 1%),
     calc(var(--identity-color-l) - 8%)
   );
+
+  // Global colors
+  --c-global-primary: #f6f5f0;
+  --c-global-secondary: #eee9e5;
+  --c-global-tertiary-1: #dbdbdb;
+  --c-global-tertiary-2: #949494;
+  --c-text-primary-white: #fff;
+  --c-text-primary-black: #000;
+  --c-text-secondary-gray: #484848;
+  --c-signal-success: #3aaa36;
+  --c-signal-aware: #f7bf42;
+  --c-signal-alert: #d5364a;
 }


### PR DESCRIPTION
- Split up colors comp. into two sub-stories
- Add description/documentation for colors
- Other: add "layout: centered" on components where it makes sense

****

<img width="1061" alt="Screenshot 2021-10-04 at 14 53 22" src="https://user-images.githubusercontent.com/31202787/135854934-578b6fca-b309-4318-aba4-409db282a0a5.png">

****

<img width="1055" alt="Screenshot 2021-10-04 at 14 53 34" src="https://user-images.githubusercontent.com/31202787/135854946-7078652f-09e1-4d87-b160-494d61289c9c.png">


