### PR TITLE
Improve footer accessibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Use the node package manager to install project dependencies:
 npm install
 ```
 
+## Development
+
+To start developing run:
+
+```
+npm run dev
+```
+
+Components and CSS will be automatically recompiled when making changes in the
+source code.
+
 ## Usage
 
 You can download a `dist.zip` file with `latest` assets (or different tags) under "Releases", and unzip it somewhere within the web root of your project. The assets consist of javascript files, css styles and icons. You can find the html output for a given story under the HTML tab inside storybook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "storybook-addon-designs": "^6.1.0"
       },
       "engines": {
+        "node": ">=16",
         "npm": ">=7"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dpl-design-system",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.11.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "web-vitals": "^1.0.1"
   },
   "engines": {
+    "node": ">=16",
     "npm": ">=7"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "css:lint": "concurrently 'npm:css:stylelint' 'npm:css:prettier -- --check' --raw",
     "css:format": "concurrently 'npm:css:stylelint -- --fix' 'npm:css:prettier -- --write' --max-processes 1 --raw",
     "css:build": "sass base.scss:src/styles/css/base.css",
-    "css:watch": "npm run css:build -- --watch"
+    "css:watch": "npm run css:build -- --watch",
+    "dev": "concurrently --raw \"npm run storybook\" \"npm run css:watch\""
   },
   "browserslist": {
     "production": [

--- a/src/stories/footer/Footer.tsx
+++ b/src/stories/footer/Footer.tsx
@@ -9,7 +9,7 @@ import { FooterColumn } from "./FooterColumn";
 
 export const Footer = () => {
   return (
-    <div className="footer">
+    <footer className="footer">
       {/* Footer mobile */}
       <div className="footer--mobile">
         <Pagefold inherit={true} container={true} size="small">
@@ -223,7 +223,7 @@ export const Footer = () => {
           </div>
         </Pagefold>
       </div>
-    </div>
+    </footer>
   );
 };
 

--- a/src/stories/footer/Footer.tsx
+++ b/src/stories/footer/Footer.tsx
@@ -10,11 +10,12 @@ import { FooterColumn } from "./FooterColumn";
 export const Footer = () => {
   return (
     <footer className="footer">
+      <h2 className="hide-visually">Globale links</h2>
       {/* Footer mobile */}
       <div className="footer--mobile">
         <Pagefold inherit={true} container={true} size="small">
           <div>
-            <h4 className="text-header-h4 mb-16">Åbningstider</h4>
+            <h3 className="text-header-h4 mb-16">Åbningstider</h3>
             <p className="text-body-medium-regular mb-24">
               Bibliotekerne lorem ipsum consectetur, adipisci velit, sed quia
               non numquam eius modi tempora incidunt ut labore.
@@ -90,7 +91,7 @@ export const Footer = () => {
         <Pagefold inherit={true} container={true} size="medium">
           <div className="footer-column-wrapper">
             <div className="footer-column">
-              <h4 className="text-header-h4 mb-16">Åbningstider</h4>
+              <h3 className="text-header-h4 mb-16">Åbningstider</h3>
               <div className="footer-column">
                 <p className="text-body-medium-regular">
                   Bibliotekerne lorem ipsum consectetur, adipisci velit, sed
@@ -127,7 +128,7 @@ export const Footer = () => {
               ]}
             />
             <div className="footer-column">
-              <h4 className="text-header-h4 mb-16">Kontakt</h4>
+              <h3 className="text-header-h4 mb-16">Kontakt</h3>
               <p className="text-body-medium-regular">
                 Lyngby-Taarbæk Bibliotekerne <br />
                 Lyngby Hovedgade 28 <br />

--- a/src/stories/footer/FooterColumn.tsx
+++ b/src/stories/footer/FooterColumn.tsx
@@ -9,7 +9,7 @@ type FooterColumnProps = {
 export const FooterColumn = ({ title, links }: FooterColumnProps) => {
   return (
     <div className="footer-column">
-      <h4 className="text-header-h4">{title}</h4>
+      <h3 className="text-header-h4">{title}</h3>
       <ul>
         {links.map((link) => (
           <li className="footer-column--link">

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -2,3 +2,23 @@
   color: inherit;
   text-decoration: inherit;
 }
+
+/**
+ * Hide element visually but not from screen readers.
+ *
+ * https://www.accessibility-developer-guide.com/examples/hiding-elements/visually/
+ *
+ * The class is intentionally called .hide-visually and not .visually-hidden.
+ * Drupal which is a known consumer of the design system also has a
+ * .visually-hidden class where the implementation is a bit different.
+ * To avoid any conflicts we call our class something else.
+ *
+ * https://git.drupalcode.org/project/drupal/-/blob/9.2.x/core/modules/system/css/components/hidden.module.css#L18-33
+ */
+.hide-visually {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}


### PR DESCRIPTION
This improves the accessibility of the footer based on experiences when integrating the design system with https://github.com/danskernesdigitalebibliotek/dpl-cms/ and analysing a demo page with pa11y.

This reports the following errors:

```
 • Heading levels should only increase by one
   (https://dequeuniversity.com/rules/axe/4.3/heading-order?application=axeAPI)

   (html > body > div > div > div:nth-child(4) > div:nth-child(2) > div >
   div:nth-child(2) > div:nth-child(1) > h4)

   <h4 class="text-header-h4 mb-16">Åbningstider</h4>

 • All page content should be contained by landmarks
   (https://dequeuniversity.com/rules/axe/4.3/region?application=axeAPI)

   (html > body > div > div > div:nth-child(4) > div:nth-child(2))

   <div class="footer--desktop"> <div class="pagefold-paren...</div>
```

Also improve development setup a bit.

I suggest going through the commits one by one.