### PR TITLE
DDF feedback fixes

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -34,6 +34,7 @@
 @import "./src/stories/modal-loan/modal-loan";
 @import "./src/stories/modal-search/modal-search";
 @import "./src/stories/modal-text/modal-text";
+@import "./src/stories/modal-pause/modal-pause";
 
 @import "./src/stories/material/material";
 @import "./src/stories/material-banner/material-banner";

--- a/src/stories/checkbox/Checkbox.stories.tsx
+++ b/src/stories/checkbox/Checkbox.stories.tsx
@@ -7,7 +7,15 @@ export default {
   title: "Atoms / Checkbox",
   component: Checkbox,
   decorators: [withDesign],
-  argTypes: {},
+  argTypes: {
+    // We disable the isChecked control, since it is not possible to
+    // get the states from the React component to work with Storybook controls.
+    isChecked: { 
+      control: {
+        disable: true
+      }
+    }
+  },
   parameters: {},
 } as ComponentMeta<typeof Checkbox>;
 

--- a/src/stories/dropdown/Dropdown.stories.tsx
+++ b/src/stories/dropdown/Dropdown.stories.tsx
@@ -10,6 +10,11 @@ export default {
   title: "Components / Dropdown",
   component: DropdownComp,
   decorators: [withDesign],
+  argTypes: {
+    arrowIcon: {
+      defaultValue: "triangles",
+    },
+  },
   parameters: {
     design: {
       type: "figma",
@@ -50,4 +55,5 @@ export const Dropdown = Template.bind({});
 Dropdown.args = {
   list,
   ariaLabel: "Dropdown with different artists",
+  arrowIcon: "triangles",
 };

--- a/src/stories/dropdown/Dropdown.tsx
+++ b/src/stories/dropdown/Dropdown.tsx
@@ -8,9 +8,43 @@ export type DropdownItem = {
 export type DropdownProps = {
   list: DropdownItem[];
   ariaLabel: string;
+  arrowIcon: "triangles" | "chevron";
 };
 
 export const Dropdown = (props: DropdownProps) => {
+  const { arrowIcon } = props;
+
+  const Icon = () => {
+    if (arrowIcon === "triangles") {
+      return (
+        <span>
+          <img
+            className="dropdown__arrow"
+            src="icons/basic/icon-triangle.svg"
+            alt=""
+          />
+          <img
+            className="dropdown__arrow dropdown__arrow--bottom"
+            src="icons/basic/icon-triangle.svg"
+            alt=""
+          />
+        </span>
+      );
+    }
+
+    if (arrowIcon === "chevron") {
+      return (
+        <img
+          className="dropdown__arrow"
+          src="icons/collection/ExpandMore.svg"
+          alt=""
+        />
+      );
+    }
+
+    return null;
+  };
+
   return (
     <div className="dropdown">
       <select className="dropdown__select" aria-label={props.ariaLabel}>
@@ -21,16 +55,7 @@ export const Dropdown = (props: DropdownProps) => {
         ))}
       </select>
       <div className="dropdown__arrows">
-        <img
-          className="dropdown__arrow"
-          src="icons/basic/icon-triangle.svg"
-          alt=""
-        />
-        <img
-          className="dropdown__arrow dropdown__arrow--bottom"
-          src="icons/basic/icon-triangle.svg"
-          alt=""
-        />
+        <Icon />
       </div>
     </div>
   );

--- a/src/stories/dropdown/dropdown.scss
+++ b/src/stories/dropdown/dropdown.scss
@@ -6,7 +6,7 @@
 .dropdown__select {
   appearance: none;
   -webkit-appearance: none;
-  min-width: 200px;
+  min-width: 230px;
   width: 100%;
   height: 50px;
   padding: 0 20px;

--- a/src/stories/footer/Footer.tsx
+++ b/src/stories/footer/Footer.tsx
@@ -25,7 +25,7 @@ export const Footer = () => {
           </div>
           <Accordion list={list} />
           <div className="footer__widgets mt-48">
-            <Dropdown list={dropdownList} ariaLabel="dropdown" />
+            <Dropdown list={dropdownList} ariaLabel="dropdown" arrowIcon="triangles" />
             <Logo fallback={false} libraryName={""} altText={"logo"} />
           </div>
           <div className="footer__separator mt-24"></div>
@@ -173,7 +173,7 @@ export const Footer = () => {
           </div>
 
           <div className="footer__widgets mt-80">
-            <Dropdown list={dropdownList} ariaLabel="dropdown" />
+            <Dropdown list={dropdownList} ariaLabel="dropdown" arrowIcon="triangles" />
             <Logo fallback={false} libraryName={""} altText={"logo"} />
           </div>
 

--- a/src/stories/list-details/ListDetails.stories.tsx
+++ b/src/stories/list-details/ListDetails.stories.tsx
@@ -45,6 +45,7 @@ ItemDropdown.args = {
   icon: "icons/collection/Ebook.svg",
   menu: {
     ariaLabel: "dropdown",
+    arrowIcon: "chevron",
     list: [
       {
         href: "",

--- a/src/stories/list-details/ListDetails.tsx
+++ b/src/stories/list-details/ListDetails.tsx
@@ -25,7 +25,7 @@ export const ListDetails = (props: ListDetailsProps) => {
         </div>
         <div className="list-details__menu">
           {props.menu && (
-            <Dropdown ariaLabel={props.menu.ariaLabel} list={props.menu.list} />
+            <Dropdown ariaLabel={props.menu.ariaLabel} list={props.menu.list} arrowIcon="chevron" />
           )}
           {props.link && (
             <Links href={props.link.url} linkText={props.link.label} />

--- a/src/stories/list-materials/ListMaterials.stories.tsx
+++ b/src/stories/list-materials/ListMaterials.stories.tsx
@@ -6,7 +6,15 @@ export default {
   title: "Components / List - Materials",
   component: ListMaterials,
   decorators: [withDesign],
-  argTypes: {},
+  // We disable the isChecked control, since it is not possible to
+  // get the states from the React component to work with Storybook controls.
+  argTypes: {
+    isChecked: { 
+      control: {
+        disable: true
+      }
+    }
+  },
   parameters: {
     design: {
       type: "figma",

--- a/src/stories/material-banner/MaterialBanner.tsx
+++ b/src/stories/material-banner/MaterialBanner.tsx
@@ -27,7 +27,7 @@ const dropdownList: DropdownItem[] = props.linkFilters.map(i => ({
           {props.showLinkfilters && (
             <div className="material-banner__menu">
               <LinkFilters filters={props.linkFilters} />
-              <Dropdown ariaLabel="Dropdown filter" list={dropdownList} />
+              <Dropdown ariaLabel="Dropdown filter" list={dropdownList} arrowIcon="triangles" />
             </div>
           )}
         </div>

--- a/src/stories/material-banner/material-banner.scss
+++ b/src/stories/material-banner/material-banner.scss
@@ -1,4 +1,5 @@
 .material-banner__header {
+  position: relative;
   padding: 24px;
 
   @include breakpoint-s {
@@ -23,15 +24,21 @@
 
 .material-banner__menu {
   margin-top: 16px;
+  padding-right: 20px;
 
   .link-filters {
     display: none;
   }
 
   @include breakpoint-m {
+    position: absolute;
+    top: 88px;
+    right: 20px;
+
     .dropdown {
       display: none;
     }
+
     .link-filters {
       display: flex;
     }
@@ -39,12 +46,6 @@
 
   .link-filters__tag-wrapper {
     position: relative;
-  }
-
-  @include breakpoint-m {
-    position: absolute;
-    top: 88px;
-    right: 20px;
   }
 
   @include breakpoint-l {

--- a/src/stories/material-card/MaterialCard.stories.tsx
+++ b/src/stories/material-card/MaterialCard.stories.tsx
@@ -6,7 +6,15 @@ export default {
   title: "Atoms / Material - Card",
   component: MaterialCard,
   decorators: [withDesign],
-  argTypes: {},
+  // We disable the isChecked control, since it is not possible to
+  // get the states from the React component to work with Storybook controls.
+  argTypes: {
+    isLiked: { 
+      control: {
+        disable: true
+      }
+    }
+  },
   parameters: {},
 } as ComponentMeta<typeof MaterialCard>;
 

--- a/src/stories/modal-pause/ModalPause.stories.tsx
+++ b/src/stories/modal-pause/ModalPause.stories.tsx
@@ -1,0 +1,32 @@
+import { withDesign } from "storybook-addon-designs";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ModalPause } from "./ModalPause";
+
+export default {
+  title: "Components / Modal - Pause",
+  component: ModalPause,
+  decorators: [withDesign],
+  argTypes: {},
+  parameters: {
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=2137%3A14335",
+    },
+  },
+} as ComponentMeta<typeof ModalPause>;
+
+const Template: ComponentStory<typeof ModalPause> = (args) => (
+  <ModalPause {...args} />
+);
+
+export const Pause = Template.bind({});
+Pause.args = {
+  showModal: true,
+  title: "Sæt reserveringer på pause",
+  subtitle:
+    "Sæt fysiske reserveringer på pause lorem ipsum quod maxime placeat facere possimus",
+  textWithLink:
+    "Bemærk der kan være en forsinkelse på, hvornår pausen begynder.",
+  linkText: "Læs mere",
+};

--- a/src/stories/modal-pause/ModalPause.tsx
+++ b/src/stories/modal-pause/ModalPause.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+
+import {
+  ModalCloseButton,
+  ModalFallbackButton,
+} from "../../components/ModalShared";
+import { Button } from "../button/Button";
+import { Links } from "../links/Links";
+
+export type ModalPauseProps = {
+  showModal: boolean;
+  title: string;
+  subtitle: string;
+  textWithLink: string;
+  linkText: string;
+};
+
+export const ModalPause = (props: ModalPauseProps) => {
+  const [showModal, setShow] = useState(props.showModal);
+
+  useEffect(() => {
+    setShow(props.showModal);
+  }, [props.showModal]);
+
+  const toggleModal = () => {
+    setShow(!showModal);
+  };
+
+  if (!showModal) {
+    return <ModalFallbackButton toggleModal={toggleModal} />;
+  }
+
+  return (
+    <div
+      className={`modal modal-pause ${
+        showModal ? "modal-show" : ""
+      } modal-padding `}
+    >
+      <ModalCloseButton toggleModal={toggleModal} />
+      <div className="modal-pause__container">
+        <h3 className="text-header-h3">{props.title}</h3>
+        <div className="mt-48 color-secondary-gray">
+          <p className="text-body-medium-regular">{props.subtitle}</p>
+        </div>
+
+        <div className="modal-pause__dropdowns mt-24">
+          <div className="datepickers">
+            <div className="datepicker">
+              <span className="datepicker-toggle">
+                <label htmlFor="startDate" className="text-body-medium-regular">Startdato</label>
+                <input type="date" name="startDate" id="startDate" className="datepicker-input" aria-label="startDate"/>
+              </span>
+            </div>
+
+            <div className="datepicker">
+              <span className="datepicker-toggle">
+                <label htmlFor="startDate" className="text-body-medium-regular">Slutdato</label>
+                <input type="date" name="endDate" id="endDate" className="datepicker-input" aria-label="endDate"/>
+              </span>
+            </div>
+          </div>
+        </div>
+        
+        <div className="modal_pause__text-link mt-24 color-secondary-gray">
+          <p className="text-body-small-regular">
+            {props.textWithLink} <Links href={"/"} linkText={props.linkText} />
+          </p>
+        </div>
+        <div className="modal-pause__button mt-48">
+          <Button
+            buttonType="default"
+            size="large"
+            variant="filled"
+            label="gem"
+            disabled={false}
+            collapsible={true}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/stories/modal-pause/modal-pause.scss
+++ b/src/stories/modal-pause/modal-pause.scss
@@ -1,0 +1,75 @@
+$modal-pause-container-width: 550px;
+
+.modal-pause {
+  flex-direction: column;
+  align-items: center;
+}
+
+.modal-pause__container {
+  margin: 0 24px;
+  padding-top: 96px;
+  max-width: $modal-pause-container-width;
+  width: 100%;
+
+  @include breakpoint-s {
+    margin: 0 45px;
+  }
+}
+
+.modal-pause__button {
+  display: grid;
+  justify-content: center;
+}
+
+.modal_pause__text-link {
+  .link-tag {
+    font-size: 14px;
+    padding-left: 5px;
+  }
+}
+
+.datepickers {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 80px;
+
+  input {
+    border: 1px solid $c-global-tertiary-1;
+    box-sizing: border-box;
+    background-color: $c-global-primary;
+    min-width: 200px;
+    height: 50px;
+    padding: 0 20px;
+    color: $c-text-secondary-gray;
+    @extend %text-button-placeholder;
+
+    @include breakpoint-s {
+      min-width: 250px;
+    }
+  }
+
+  .datepicker {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  [type="date"] {
+    background: $c-global-primary url("https://cdn1.iconfinder.com/data/icons/cc_mono_icon_set/blacks/16x16/calendar_2.png") 90% 50% no-repeat ;
+  }
+
+  [type="date"]::-webkit-inner-spin-button {
+    display: none;
+  }
+
+  [type="date"]::-webkit-calendar-picker-indicator {
+    opacity: 0;
+  }
+
+  .datepicker-toggle {
+    display: inline-block;
+    position: relative;
+    width: 18px;
+    height: 19px;
+  }
+}

--- a/src/stories/modal-search/ModalSearch.stories.tsx
+++ b/src/stories/modal-search/ModalSearch.stories.tsx
@@ -22,7 +22,5 @@ const Template: ComponentStory<typeof ModalSearch> = (args) => (
 
 export const Search = Template.bind({});
 Search.args = {
-  description: "Kan afleveres på alle Rudersdals biblioteker",
-  showExpired: true,
   showModal: true,
 };

--- a/src/stories/modal-search/ModalSearch.tsx
+++ b/src/stories/modal-search/ModalSearch.tsx
@@ -7,9 +7,7 @@ import {
 import { Button } from "../button/Button";
 
 export type ModalSearchProps = {
-  description: string;
   showModal: boolean;
-  showExpired: boolean;
 };
 
 export const ModalSearch = (props: ModalSearchProps) => {
@@ -35,7 +33,7 @@ export const ModalSearch = (props: ModalSearchProps) => {
     >
       <ModalCloseButton toggleModal={toggleModal} />
       <div className="modal-search__container">
-        <h2 className="text-header-h2">Gem søgning</h2>
+        <h3 className="text-header-h3">Gem søgning</h3>
         <div className="mt-48 color-secondary-gray">
           <p className="text-body-medium-regular">Navngiv din søgning</p>
         </div>

--- a/src/stories/modal-text/ModalText.stories.tsx
+++ b/src/stories/modal-text/ModalText.stories.tsx
@@ -1,12 +1,12 @@
 import { withDesign } from "storybook-addon-designs";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { ModalText } from "./ModalText";
+import { textContent } from "./ModalText";
 
 export default {
   title: "Components / Modal - Text",
   component: ModalText,
   decorators: [withDesign],
-  argTypes: {},
   parameters: {
     design: {
       type: "figma",
@@ -23,4 +23,9 @@ const Template: ComponentStory<typeof ModalText> = (args) => (
 export const Text = Template.bind({});
 Text.args = {
   showModal: true,
+  title: "Vilkår for brug og opbevaring af Data",
+  subtitle: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+  linkText: "Ikke nu",
+  btnLabel: "Giv samtykke",
+  textContent,
 };

--- a/src/stories/modal-text/ModalText.tsx
+++ b/src/stories/modal-text/ModalText.tsx
@@ -10,6 +10,14 @@ import { Links } from "../links/Links";
 
 export type ModalTextProps = {
   showModal: boolean;
+  title: string;
+  linkText: string;
+  btnLabel: string;
+  subtitle: string;
+  textContent: Array<{
+    title: string;
+    text: string;
+  }>;
 };
 
 export const ModalText = (props: ModalTextProps) => {
@@ -35,36 +43,36 @@ export const ModalText = (props: ModalTextProps) => {
     >
       <ModalCloseButton toggleModal={toggleModal} />
       <div className="modal-text__container color-secondary-gray">
-        <h2 className="text-header-h2">
-          Vilkår for brug og opbevaring af Data
-        </h2>
-        <p className="mt-48 text-body-large">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </p>
-        <div className="mt-48">
-          {textContent.map(([title, body]) => (
-            <div className="modal-text__content">
-              <p className="text-body-medium-regular">{title}</p>
-              <p className="text-links">{body}</p>
-            </div>
-          ))}
-        </div>
+        <h3 className="text-header-h3">
+          {props.title}
+        </h3>
+
+      <p className="mt-48 text-body-large">
+        {props.subtitle}
+      </p>
+
+      <div className="mt-48">
+        {props.textContent.map((row) => (
+          <div className="modal-text__content">
+            <p className="text-body-medium-regular">{row.title}</p>
+            <p className="text-links">{row.text}</p>
+          </div>
+        ))}
+      </div>
+
       </div>
       <div className="modal-text__buttons">
         <div className="modal-text__buttons-inner">
           <Links
             href={"/"}
-            linkText="Ikke nu"
+            linkText={props.linkText}
             classNames="color-secondary-gray"
           />
           <Button
             buttonType="default"
             size="large"
             variant="filled"
-            label="giv samtykke"
+            label={props.btnLabel}
             disabled={false}
             collapsible={true}
           />
@@ -74,19 +82,18 @@ export const ModalText = (props: ModalTextProps) => {
   );
 };
 
-const textContent = [
-  [
-    "Brug af data",
-    "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-  ],
-  [
-    "Dataforordning",
-    "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-  ],
-  [
-    "Lorem Ipsum",
-    `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
 
-    Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci`,
-  ],
-];
+export const textContent = [
+  {
+    title: "Brug bibliotekerne",
+    text: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+  },
+  {
+    title: "Dataforordning",
+    text: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+  },
+  {
+    title: "Lorem Ipsum",
+    text: "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci",
+  },
+]


### PR DESCRIPTION
This PR includes some changes/fixes for some of the components in dpl-design-system
- Removed props from Modal Search since they were not used for anything
- Add possibility for changing the text in the "Text Modal" in storybook
- Fix position error with link-filters in Material Banner/Modal Details
- Add option to choose icons on dropdown, since it should be able to change between two icons
- Create new component "Modal-pause" since it was missing
- Disable controls in checkbox and materialCard, since we can't get the states to work with controls in SB. The only help to find on the internet is to make states work with "Actions" - not "Controls".
- Add datepicker input to ModalPause component


The error with Chromatic is not from this PR. I have built the storybook locally and reviewed the changes there.