### PR TITLE
Fix/search-bar

### DIFF
--- a/src/stories/header/Header.tsx
+++ b/src/stories/header/Header.tsx
@@ -89,7 +89,7 @@ export const Header = (props: HeaderProps) => {
               </a>
             </div>
           </nav>
-          <div className="header__menu-second">
+          <div>
             <div className="header__menu-search">
               <form className="header__menu-search-form">
                 <input


### PR DESCRIPTION
Do not stack two wrapper divs over each other in the header component.
This breaks the design, and thus we got rid of one of the wrapper divs.