### PR TITLE
Setup-node dep problem + failing favourite button a11y check

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
       - run: npm ci
 
       - name: Compile styles

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,9 +10,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
       - run: npm ci
 
       - name: Building
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
           registry-url: "https://npm.pkg.github.com"
           scope: "@${{ github.repository_owner }}"
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
       - run: npm ci
 
       - name: Run stylelint
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
       - run: npm ci
 
       - name: Run eslint
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: '.nvmrc'
 
       - run: npm ci
 

--- a/src/stories/button-favourite/ButtonFavourite.tsx
+++ b/src/stories/button-favourite/ButtonFavourite.tsx
@@ -6,7 +6,7 @@ interface ButtonFavouriteProps {
 
 export const ButtonFavourite = ({ fill }: ButtonFavouriteProps) => {
   return (
-    <button className="button-favourite">
+    <button type="button" aria-label="Add to favourites" className="button-favourite">
       <IconFavourite fill={fill} />
     </button>
   );


### PR DESCRIPTION
#### Link to issue

None

#### Description

All our Github Actions are failing. Probably because of:
https://github.com/npm/cli/issues/4998
Fixed it by using .nvmrc on setup-node tasks.

Also discovered failing a11y test on favourite button.


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.


