### PR TITLE
Change material cover render

### DIFF
--- a/src/stories/material/Material.stories.tsx
+++ b/src/stories/material/Material.stories.tsx
@@ -6,7 +6,40 @@ export default {
   title: "Atoms / Material",
   component: Material,
   decorators: [withDesign],
-  argTypes: {},
+  argTypes: {
+    size: {
+      name: "Image size",
+      control: "radio",
+    },
+    tint: {
+      name: "Background color tint",
+      control: "radio",
+    },
+    animate: {
+      name: "Use animation",
+      control: "boolean",
+    },
+    materialUrl: {
+      name: "Material URL",
+      control: "text",
+    },
+    materialDescription: {
+      name: "Material description",
+      control: "text",
+    },
+    url: {
+      name: "Cover URL",
+      control: "text",
+    },
+  },
+  args: {
+    size: "small",
+    animate: false,
+    url: "images/book_cover_3.jpg",
+    tint: "120",
+    materialUrl: "https://www.google.com",
+    materialDescription: "/",
+  },
   parameters: {},
 } as ComponentMeta<typeof Material>;
 
@@ -15,25 +48,27 @@ const Template: ComponentStory<typeof Material> = (args) => (
 );
 
 export const MaterialVisible = Template.bind({});
-MaterialVisible.args = {
-  url: "images/book_cover_3.jpg",
-  size: "small",
-  animate: false,
-  tint: "120",
-};
+MaterialVisible.args = {};
 
 export const MaterialNotVisible = Template.bind({});
 MaterialNotVisible.args = {
   url: "",
-  size: "small",
-  animate: false,
   tint: "60",
+  materialUrl: "",
 };
 
 export const MaterialAnimated = Template.bind({});
 MaterialAnimated.args = {
-  url: "images/book_cover_3.jpg",
+  animate: true,
+  tint: "80",
+  materialUrl: "",
+};
+
+export const MaterialLinked = Template.bind({});
+MaterialLinked.args = {
   animate: true,
   size: "small",
   tint: "80",
+  materialUrl: "/",
+  materialDescription: "Cover of Audrey Hepburn",
 };

--- a/src/stories/material/Material.tsx
+++ b/src/stories/material/Material.tsx
@@ -5,10 +5,12 @@ export type MaterialProps = {
   animate: boolean;
   size: "small" | "medium" | "large";
   tint?: "20" | "40" | "60" | "80" | "120";
+  materialUrl?: string;
+  materialDescription?: string;
 };
 
 export const Material = (props: MaterialProps) => {
-  const { size, animate, url, tint } = props;
+  const { size, animate, url, tint, materialUrl, materialDescription } = props;
 
   type TintClassesType = {
     [key: string]: string;
@@ -32,15 +34,23 @@ export const Material = (props: MaterialProps) => {
     ),
   };
 
+  const materialCover = url && (
+    <img src={url} alt={materialDescription || ""} />
+  );
+
   return (
     <div className="material-container">
-      <a className={classes.wrapper}>
-        <img
-          src={url}
-          alt=""
-          onError={(e) => (e.currentTarget.style["display"] = "none")}
-        />
-      </a>
+      {/**
+       * Images inside links must have an non-empty alt text to meet accessibility requirements.
+       * Only render the material as a link if we have both an url and a description.
+       */}
+      {materialUrl && materialDescription ? (
+        <a href={materialUrl} className={classes.wrapper}>
+          {materialCover}
+        </a>
+      ) : (
+        <span className={classes.wrapper}>{materialCover}</span>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR is to make sure that the dpl-react and dpl-design system are as similar as possible.

This change contains
- Adds the same logic as used in dpl-react to determine if it is a tag or a span image to display in 
- Change the storybook to have the right props and setup