### PR TITLE
Material App + Material Header

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -32,6 +32,7 @@
 @import "./src/stories/button-favourite/button-favourite";
 @import "./src/stories/autosuggest-material/autosuggest-material";
 @import "./src/stories/material-app/material-app";
+@import "./src/stories/material-header/material-header";
 
 @import "./src/stories/list-reservation/list-reservation";
 @import "./src/stories/list-dashboard/list-dashboard";

--- a/base.scss
+++ b/base.scss
@@ -33,6 +33,7 @@
 @import "./src/stories/autosuggest-material/autosuggest-material";
 @import "./src/stories/material-app/material-app";
 @import "./src/stories/material-header/material-header";
+@import "./src/stories/material-header/material-periodikum-select";
 
 @import "./src/stories/list-reservation/list-reservation";
 @import "./src/stories/list-dashboard/list-dashboard";

--- a/base.scss
+++ b/base.scss
@@ -31,6 +31,7 @@
 @import "./src/stories/autosuggest-text/autosuggest-text";
 @import "./src/stories/button-favourite/button-favourite";
 @import "./src/stories/autosuggest-material/autosuggest-material";
+@import "./src/stories/material-app/material-app";
 
 @import "./src/stories/list-reservation/list-reservation";
 @import "./src/stories/list-dashboard/list-dashboard";

--- a/public/icons/basic/icon-select-arrow.svg
+++ b/public/icons/basic/icon-select-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="5" viewBox="0 0 6 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.75821 0.708313L3 3.95101L1.24179 0.708313L4.75821 0.708313Z" fill="black" stroke="black"/>
+</svg>

--- a/src/stories/material-app/material-app.scss
+++ b/src/stories/material-app/material-app.scss
@@ -1,0 +1,3 @@
+.material-app {
+  // source can not be empty
+}

--- a/src/stories/material-app/material-app.stories.tsx
+++ b/src/stories/material-app/material-app.stories.tsx
@@ -1,0 +1,35 @@
+import { withDesign } from "storybook-addon-designs";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import MaterialApp from "./material-app";
+
+export default {
+  title: "Components / Material App",
+  component: MaterialApp,
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=416%3A12503",
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: "text" },
+    },
+    author: {
+      control: { type: "text" },
+    },
+  },
+} as ComponentMeta<typeof MaterialApp>;
+
+const Template: ComponentStory<typeof MaterialApp> = (args) => {
+  return <MaterialApp {...args} />;
+};
+
+export const Item = Template.bind({});
+Item.args = {
+  title: "Audrey Hepburn",
+  author: "James Joyce (2013)",
+  periodikum: false,
+};

--- a/src/stories/material-app/material-app.stories.tsx
+++ b/src/stories/material-app/material-app.stories.tsx
@@ -20,6 +20,9 @@ export default {
     author: {
       control: { type: "text" },
     },
+    periodikum: {
+      control: { type: "boolean" },
+    },
   },
 } as ComponentMeta<typeof MaterialApp>;
 

--- a/src/stories/material-app/material-app.stories.tsx
+++ b/src/stories/material-app/material-app.stories.tsx
@@ -23,6 +23,9 @@ export default {
     periodikum: {
       control: { type: "boolean" },
     },
+    ctaText: {
+      control: { type: "text" },
+    },
   },
 } as ComponentMeta<typeof MaterialApp>;
 
@@ -35,4 +38,5 @@ Item.args = {
   title: "Audrey Hepburn",
   author: "James Joyce (2013)",
   periodikum: false,
+  ctaText: "Vi har 8 eksemplarer og 21 står i kø",
 };

--- a/src/stories/material-app/material-app.tsx
+++ b/src/stories/material-app/material-app.tsx
@@ -6,16 +6,23 @@ export interface MaterialAppProps {
   title: string;
   author: string;
   periodikum?: boolean;
+  ctaText?: string;
 }
 
 const MaterialApp: React.FC<MaterialAppProps> = ({
   title,
   author,
   periodikum,
+  ctaText,
 }) => {
   return (
     <div className="material-app">
-      <MaterialHeader title={title} author={author} periodikum={periodikum} />
+      <MaterialHeader
+        title={title}
+        author={author}
+        periodikum={periodikum}
+        ctaText={ctaText}
+      />
     </div>
   );
 };

--- a/src/stories/material-app/material-app.tsx
+++ b/src/stories/material-app/material-app.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import MaterialHeader from "../material-header/material-header";
+
+export interface MaterialAppProps {
+  title: string;
+  author: string;
+}
+
+const MaterialApp: React.FC<MaterialAppProps> = ({
+  title,
+  author,
+  periodikum,
+}) => {
+  return (
+    <div className="material-app">
+      <MaterialHeader title={title} author={author} />
+    </div>
+  );
+};
+
+export default MaterialApp;

--- a/src/stories/material-app/material-app.tsx
+++ b/src/stories/material-app/material-app.tsx
@@ -5,6 +5,7 @@ import MaterialHeader from "../material-header/material-header";
 export interface MaterialAppProps {
   title: string;
   author: string;
+  periodikum?: boolean;
 }
 
 const MaterialApp: React.FC<MaterialAppProps> = ({
@@ -14,7 +15,7 @@ const MaterialApp: React.FC<MaterialAppProps> = ({
 }) => {
   return (
     <div className="material-app">
-      <MaterialHeader title={title} author={author} />
+      <MaterialHeader title={title} author={author} periodikum={periodikum} />
     </div>
   );
 };

--- a/src/stories/material-header/material-header-text.tsx
+++ b/src/stories/material-header/material-header-text.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface MaterialHeaderTextProps {
+  title: string;
+  author: string;
+}
+
+const MaterialHeaderText = ({ title, author }: MaterialHeaderTextProps) => {
+  return (
+    <>
+      <h1 className="text-header-h1 mb-16">{title}</h1>
+      <p className="text-body-large">
+        <span>Af </span>
+        {author}
+      </p>
+    </>
+  );
+};
+
+export default MaterialHeaderText;

--- a/src/stories/material-header/material-header.scss
+++ b/src/stories/material-header/material-header.scss
@@ -1,0 +1,55 @@
+.material-header {
+  border-bottom: 1px solid $c-global-tertiary-1;
+  padding-bottom: 56px;
+  @include breakpoint-m {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    padding-bottom: 0;
+  }
+
+  .button-favourite {
+    display: inline-flex;
+  }
+
+  &__cover {
+    padding-top: 65px;
+    padding-bottom: 38px;
+    display: grid;
+    place-content: center;
+
+    @include breakpoint-m {
+      padding: 0;
+    }
+  }
+
+  &__content {
+    padding: 16px;
+    @include breakpoint-m {
+      padding: 112px; // TODO: this is just a guess
+      grid-column: 1/2;
+      grid-row: 1/2;
+      border-right: 1px solid $c-global-tertiary-1;
+    }
+  }
+
+  // spaceing for availability-label
+  &__availability-label {
+    margin-top: 38px;
+    margin-bottom: 48px;
+    margin-bottom: 56px;
+    display: flex;
+    align-content: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  // Spacing between button
+  &__button > * + * {
+    margin-top: 8px;
+  }
+
+  // set all buttons to the full width
+  &__button button {
+    width: 100%;
+  }
+}

--- a/src/stories/material-header/material-header.tsx
+++ b/src/stories/material-header/material-header.tsx
@@ -10,12 +10,14 @@ interface MaterialHeaderProps {
   title: string;
   author: string;
   periodikum?: boolean;
+  ctaText?: string;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   title,
   author,
   periodikum,
+  ctaText,
 }) => {
   return (
     <header className="material-header">
@@ -52,6 +54,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             size="large"
           />
         </div>
+        {ctaText && <p className="mt-16 text-small-caption">{ctaText}</p>}
       </div>
     </header>
   );

--- a/src/stories/material-header/material-header.tsx
+++ b/src/stories/material-header/material-header.tsx
@@ -4,10 +4,12 @@ import { ButtonFavourite } from "../button-favourite/ButtonFavourite";
 import { Button } from "../button/Button";
 import { Material } from "../material/Material";
 import MaterialHeaderText from "./material-header-text";
+import MaterialPeriodikumSelect from "./material-periodikum-select";
 
 interface MaterialHeaderProps {
   title: string;
   author: string;
+  periodikum?: boolean;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -34,7 +36,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         {periodikum && <MaterialPeriodikumSelect />}
         <div className="material-header__button">
           <Button
-            label="RESERVER BOG"
+            label={periodikum ? "RESERVER MAGASIN" : "RESERVER BOG"}
             buttonType="none"
             variant="filled"
             disabled={false}

--- a/src/stories/material-header/material-header.tsx
+++ b/src/stories/material-header/material-header.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { AvailabilityLabel } from "../availability-label/AvailabilityLabel";
+import { ButtonFavourite } from "../button-favourite/ButtonFavourite";
+import { Button } from "../button/Button";
+import { Material } from "../material/Material";
+import MaterialHeaderText from "./material-header-text";
+
+interface MaterialHeaderProps {
+  title: string;
+  author: string;
+}
+
+const MaterialHeader: React.FC<MaterialHeaderProps> = ({
+  title,
+  author,
+  periodikum,
+}) => {
+  return (
+    <header className="material-header">
+      <div className="material-header__cover">
+        <Material
+          url="images/book_cover_3.jpg"
+          size="large"
+          tint="120"
+          animate={true}
+        />
+      </div>
+      <div className="material-header__content">
+        <ButtonFavourite />
+        <MaterialHeaderText title={title} author={author} />
+        <div className="material-header__availability-label">
+          {listOfAvailabilityLabels}
+        </div>
+        {periodikum && <MaterialPeriodikumSelect />}
+        <div className="material-header__button">
+          <Button
+            label="RESERVER BOG"
+            buttonType="none"
+            variant="filled"
+            disabled={false}
+            collapsible={false}
+            size="large"
+          />
+          <Button
+            label="FIND PÅ HYLDEN"
+            buttonType="none"
+            variant="outline"
+            disabled={false}
+            collapsible={false}
+            size="large"
+          />
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default MaterialHeader;
+
+const listOfAvailabilityLabels = [
+  {
+    manifestation: "Bog",
+    availability: "Hjemme",
+    status: "selected",
+  } as const,
+  {
+    manifestation: "Bog",
+    availability: "Hjemme",
+    status: "available",
+  } as const,
+  {
+    manifestation: "Bog",
+    availability: "Hjemme",
+    status: "available",
+  } as const,
+  {
+    manifestation: "Bog",
+    availability: "Hjemme",
+    status: "available",
+  } as const,
+  {
+    manifestation: "Bog",
+    availability: "Hjemme",
+    status: "available",
+  } as const,
+].map((item) => <AvailabilityLabel {...item} />);

--- a/src/stories/material-header/material-periodikum-select.scss
+++ b/src/stories/material-header/material-periodikum-select.scss
@@ -1,0 +1,37 @@
+$icon-position: 10px;
+
+.material-periodikum {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 48px;
+}
+
+.material-periodikum-select {
+  display: flex;
+  gap: 8px;
+
+  &__border-container {
+    position: relative;
+
+    select {
+      border: transparent;
+      appearance: none;
+      background: transparent;
+      background-repeat: no-repeat;
+      background-size: 6px;
+      // This is a copy from  icons/basic/icon-select-arrow
+      background-image: url('data:image/svg+xml;utf8,<svg width="6" height="5" viewBox="0 0 6 5" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M4.75821 0.708313L3 3.95101L1.24179 0.708313L4.75821 0.708313Z" fill="black" stroke="black"/> </svg>');
+      background-position: 100%;
+      padding-right: $icon-position;
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      right: $icon-position;
+      bottom: -7px;
+      left: 0;
+      border-bottom: 1px solid #000;
+    }
+  }
+}

--- a/src/stories/material-header/material-periodikum-select.tsx
+++ b/src/stories/material-header/material-periodikum-select.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+const MaterialPeriodikumSelect: React.FC = () => {
+  const placeholderData = {
+    year: ["2017", "2018", "2019", "2020", "2021", "2022"],
+    weeks: ["30", "31", "32", "33", "34", "35"],
+  };
+
+  return (
+    <div className="text-small-caption material-periodikum ">
+      <div className="material-periodikum-select">
+        <label htmlFor="year">Årgang</label>
+        <div className="material-periodikum-select__border-container">
+          <select id="year">
+            {placeholderData.year.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="material-periodikum-select">
+        <label htmlFor="weeks">Uge</label>
+        <div className="material-periodikum-select__border-container">
+          <select id="weeks">
+            {placeholderData.weeks.map((week) => (
+              <option key={week} value={week}>
+                {week}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MaterialPeriodikumSelect;


### PR DESCRIPTION
This PR introduces a Material App "page" story, that contains Material Header.

The purpose of this is to create css classes that place all components in order and with correct spacing to each other.

**Mobil**
<img width="1728" alt="Skærmbillede 2022-07-06 kl  15 21 26" src="https://user-images.githubusercontent.com/49920322/177560320-14645dd2-236b-4da5-903d-f56d949a5757.png">
**Desktop**
<img width="1728" alt="Skærmbillede 2022-07-06 kl  15 21 35" src="https://user-images.githubusercontent.com/49920322/177560309-bcf3faae-f19d-4877-9f9d-7369f3c6fa2b.png">
**With period select**
<img width="1728" alt="Skærmbillede 2022-07-06 kl  15 21 39" src="https://user-images.githubusercontent.com/49920322/177560284-136398c1-3fd5-4360-8bbf-9408c4ceaddf.png">


