### PR TITLE
Add Search Result Page and its sub components.

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -51,6 +51,11 @@
 @import "./src/stories/Library/material-header/material-periodikum-select";
 @import "./src/stories/Library/material-description/material-description";
 @import "./src/stories/Library/material-series-line/material-series-line";
+@import "./src/stories/Library/search-result-page/search-result-info";
+@import "./src/stories/Library/search-result-page/search-result-page";
+@import "./src/stories/Library/search-result-page/search-result-pager";
+@import "./src/stories/Library/search-result-page/search-result-title";
+@import "./src/stories/Library/search-result-page/search-result-zero";
 
 
 // Blocks

--- a/src/stories/Library/search-result-page/SearchResultInfo.tsx
+++ b/src/stories/Library/search-result-page/SearchResultInfo.tsx
@@ -1,0 +1,19 @@
+export type SearchResultInfoProps = {
+  linkName: string;
+  linkTotalResults: string;
+};
+
+export const SearchResultInfo = ({
+  linkName,
+  linkTotalResults,
+}: SearchResultInfoProps) => {
+  return (
+    <h2 className="text-body-medium-regular search-result-info">
+      Vis i stedet resultater fra{" "}
+      <a className="link-tag text-body-medium-medium" href="/">
+        {linkName}
+      </a>{" "}
+      ({linkTotalResults})
+    </h2>
+  );
+};

--- a/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
@@ -1,0 +1,49 @@
+import { withDesign } from "storybook-addon-designs";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { SearchResultPage } from "./SearchResultPage";
+
+export default {
+  title: "Blocks / Search Result Page",
+  component: SearchResultPage,
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "",
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: "text" },
+      defaultValue: "harry potter",
+    },
+    totalResults: {
+      control: { type: "text" },
+      defaultValue: "3.576",
+    },
+    linkName: {
+      control: { type: "text" },
+      defaultValue: "bibliotekets hjemmeside",
+    },
+    linkTotalResults: {
+      control: { type: "text" },
+      defaultValue: "8",
+    },
+    currentResults: {
+      control: { type: "text" },
+      defaultValue: "10",
+    },
+
+    zeroResult: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+  },
+} as ComponentMeta<typeof SearchResultPage>;
+
+const Template: ComponentStory<typeof SearchResultPage> = (args) => {
+  return <SearchResultPage {...args} />;
+};
+
+export const Item = Template.bind({});
+Item.args = {};

--- a/src/stories/Library/search-result-page/SearchResultPage.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPage.tsx
@@ -1,0 +1,132 @@
+import { SearchResultItem } from "../search-result-item/SearchResultItem";
+import { SearchResultInfo } from "./SearchResultInfo";
+import SearchResultPager from "./SearchResultPager";
+import { SearchResultTitle } from "./SearchResultTitle";
+import { SearchResultZero } from "./SearchResultZero";
+
+export type SearchResultPageProps = {
+  title: string;
+  currentResults: string;
+  totalResults: string;
+  linkName: string;
+  linkTotalResults: string;
+  zeroResult: boolean;
+};
+
+const SearchResult = [
+  {
+    materialUrl: "images/book_cover_1.jpg",
+    heartFill: false,
+    title: "Audrey Hepburn",
+    author: "Sánchez Vegara, Amaia Arrazola",
+    year: "2018",
+    seriesNumber: "3",
+    series: "Små mennesker, store drømme",
+  },
+  {
+    materialUrl: "images/book_cover_2.jpg",
+    heartFill: false,
+    title: "De uadskillelige",
+    author: "Simone de Beauvoir",
+    year: "2020",
+  },
+  {
+    materialUrl: "images/book_cover_3.jpg",
+    heartFill: true,
+    title: "Døgnkioskmennesket",
+    author: "Sayaka Murata",
+    year: "2019",
+  },
+  {
+    materialUrl: "images/book_cover_4.jpg",
+    heartFill: false,
+    title: "Testamente",
+    author: "Nina Wähä (f. 1979)",
+    year: "2019",
+  },
+  {
+    materialUrl: "images/book_cover_5.jpg",
+    heartFill: false,
+    title: "Sønnen (Norsk)",
+    author: "Jo Nesbø",
+    year: "2014",
+  },
+  {
+    materialUrl: "images/book_cover_6.jpg",
+    heartFill: false,
+    title: "Den bæredygtige stat",
+    author: "Rasmus Willig, Anders Blok",
+    year: "2020",
+  },
+  {
+    materialUrl: "images/book_cover_7.jpg",
+    heartFill: false,
+    title: "Den lille bog om dansk design - for børn og barnlige sjæle",
+    author: "Marie Hugsted",
+    year: "2018",
+  },
+  {
+    materialUrl: "images/book_cover_8.jpg",
+    heartFill: false,
+    title: "Den lille prins (Ved Henrik Ægidius)",
+    author: "Antoine de Saint-Exupéry",
+    year: "2016",
+  },
+  {
+    materialUrl: "images/book_cover_9.jpg",
+    heartFill: false,
+    title: "Yayoi Kusama",
+    author: "",
+    year: "2014",
+  },
+  {
+    materialUrl: "images/book_cover_10.jpg",
+    heartFill: false,
+    title: "Kvinde kend din historie - spejl dig i fortiden",
+    author: "Gry Jexen",
+    year: "2021",
+  },
+];
+
+const SearchResultList = SearchResult.map((item) => {
+  return <SearchResultItem {...item} />;
+});
+
+export const SearchResultPage = ({
+  title,
+  linkName,
+  linkTotalResults,
+  currentResults,
+  totalResults,
+  zeroResult,
+}: SearchResultPageProps) => {
+  return (
+    <div className="search-result-page">
+      <SearchResultTitle
+        title={title}
+        totalResults={zeroResult ? "0" : totalResults}
+        zeroResult={zeroResult}
+      />
+      {zeroResult ? (
+        <SearchResultZero
+          searchHelpTitle="Prøv lorem ipsum... [hjælp til søgning]"
+          linkName="bibliotekvagten.dk"
+        />
+      ) : (
+        <>
+          <SearchResultInfo
+            linkName={linkName}
+            linkTotalResults={linkTotalResults}
+          />
+          <div className="search-result-page__list my-32">
+            {SearchResultList}
+          </div>
+          <SearchResultPager
+            currentResults={currentResults}
+            totalResults={totalResults}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/stories/Library/search-result-page/SearchResultPager.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPager.tsx
@@ -21,7 +21,6 @@ const SearchResultPager = ({
         collapsible={false}
         size="medium"
         variant="outline"
-        onClick={() => console.log("onClick")}
       />
     </div>
   );

--- a/src/stories/Library/search-result-page/SearchResultPager.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPager.tsx
@@ -1,0 +1,30 @@
+import { Button } from "../Buttons/button/Button";
+
+interface SearchResultPagerProps {
+  currentResults: string;
+  totalResults: string;
+}
+
+const SearchResultPager = ({
+  currentResults,
+  totalResults,
+}: SearchResultPagerProps) => {
+  return (
+    <div className="search-result-pager">
+      <p className="text-small-caption search-result-pager__title">
+        {`Viser ${currentResults} ud af ${totalResults} resultater`}
+      </p>
+      <Button
+        label="VIS FLERE"
+        disabled={false}
+        buttonType="none"
+        collapsible={false}
+        size="medium"
+        variant="outline"
+        onClick={() => console.log("onClick")}
+      />
+    </div>
+  );
+};
+
+export default SearchResultPager;

--- a/src/stories/Library/search-result-page/SearchResultTitle.tsx
+++ b/src/stories/Library/search-result-page/SearchResultTitle.tsx
@@ -1,0 +1,25 @@
+export type SearchResultTitleProps = {
+  title: string;
+  totalResults: string;
+  zeroResult: boolean;
+};
+
+export const SearchResultTitle = ({
+  title,
+  totalResults,
+  zeroResult,
+}: SearchResultTitleProps) => {
+  if (zeroResult) {
+    return (
+      <h1 className="text-header-h2 mb-16 search-result-title">
+        Din søgning gav 0 resultater
+      </h1>
+    );
+  }
+
+  return (
+    <h1 className="text-header-h2 mb-16 search-result-title">
+      {`Viser resultater for “${title}” (${totalResults})`}
+    </h1>
+  );
+};

--- a/src/stories/Library/search-result-page/SearchResultZero.tsx
+++ b/src/stories/Library/search-result-page/SearchResultZero.tsx
@@ -1,0 +1,21 @@
+export type SearchResultZeroProps = {
+  searchHelpTitle?: string;
+  linkName: string;
+};
+
+export const SearchResultZero = ({
+  searchHelpTitle,
+  linkName,
+}: // totalResults,
+SearchResultZeroProps) => {
+  return (
+    <div className="text-body-medium-regular mt-24 mb-112 search-result-zero">
+      <p>{searchHelpTitle}</p>
+      <br />
+      <p> Har du brug for hjælp?</p>
+      <p>
+        Spørg os på biblioteket eller få hjælp på <a href="/">{linkName}</a>
+      </p>
+    </div>
+  );
+};

--- a/src/stories/Library/search-result-page/search-result-info.scss
+++ b/src/stories/Library/search-result-page/search-result-info.scss
@@ -1,0 +1,2 @@
+.search-result-info {
+}

--- a/src/stories/Library/search-result-page/search-result-page.scss
+++ b/src/stories/Library/search-result-page/search-result-page.scss
@@ -1,5 +1,5 @@
 .search-result-page {
-  background: #f6f5f0;
+  background: $c-global-primary;
   padding: 16px;
 
   @include breakpoint-m {

--- a/src/stories/Library/search-result-page/search-result-page.scss
+++ b/src/stories/Library/search-result-page/search-result-page.scss
@@ -1,0 +1,13 @@
+.search-result-page {
+  background: #f6f5f0;
+  padding: 16px;
+
+  @include breakpoint-m {
+    padding: 157px;
+  }
+
+  &__list {
+    display: grid;
+    gap: 16px;
+  }
+}

--- a/src/stories/Library/search-result-page/search-result-pager.scss
+++ b/src/stories/Library/search-result-page/search-result-pager.scss
@@ -1,0 +1,17 @@
+.search-result-pager {
+  &__title {
+    text-align: center;
+    margin-top: 24px;
+    margin-bottom: 16px;
+  }
+}
+
+// Override button css (Center + Width)
+.search-result-pager > .btn-primary {
+  margin: 0 auto;
+  width: 100%;
+
+  @include breakpoint-s {
+    max-width: 253px;
+  }
+}

--- a/src/stories/Library/search-result-page/search-result-title.scss
+++ b/src/stories/Library/search-result-page/search-result-title.scss
@@ -1,0 +1,2 @@
+.search-result-title {
+}

--- a/src/stories/Library/search-result-page/search-result-zero.scss
+++ b/src/stories/Library/search-result-page/search-result-zero.scss
@@ -1,0 +1,7 @@
+.search-result-zero {
+  border: 1px dashed #484848;
+  height: 240px;
+  display: grid;
+  place-content: center;
+  text-align: center;
+}

--- a/src/stories/Library/search-result-page/search-result-zero.scss
+++ b/src/stories/Library/search-result-page/search-result-zero.scss
@@ -1,5 +1,5 @@
 .search-result-zero {
-  border: 1px dashed #484848;
+  border: 1px dashed $c-text-secondary-gray;
   height: 240px;
   display: grid;
   place-content: center;


### PR DESCRIPTION
This PR adds a collection of components used for search results page.

The components are shows as a page in a storybook component called search-result-page.

The primary task of the page component is to position each atom/component correctly in relation to one another.

You can see the search result page here:
Design in Figma: https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=4557%3A15899
Component in Storybook: search-result-page

The component has props to change the title, link and total result number. This allows users to see how text will wrap when text length increases. It is also possible to toggle zero result to see the page if it does not succeed in finding results.