### PR TITLE
Reverting some of the deployment action cmds

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -59,8 +59,8 @@ jobs:
         # Values in package.json must match the current GitHub repository to
         # publish to it.
         run: |
-          yarn exec -- json -I -f package.json -e "this.name='@$GITHUB_REPOSITORY'"
-          yarn exec -- json -I -f package.json -e "this.repository='https://github.com/$GITHUB_REPOSITORY'"
+          npm exec -- json -I -f package.json -e "this.name='@$GITHUB_REPOSITORY'"
+          npm exec -- json -I -f package.json -e "this.repository='https://github.com/$GITHUB_REPOSITORY'"
 
       - name: Release branch
         if: startsWith(github.ref, 'refs/heads/')
@@ -70,10 +70,10 @@ jobs:
         # Using branch names as tags allows other projects to track unreleased
         # development.
         run: |
-          yarn version 0.0.0-$GITHUB_SHA --no-git-tag-version
+          npm version 0.0.0-$GITHUB_SHA --no-git-tag-version
           cat package.json
           NPM_TAG_NAME=$(echo $GITHUB_REF_NAME | tr -d [:space:] | tr -C [:alnum:] -)
-          yarn npm publish --tag $NPM_TAG_NAME
+          npm publish --tag $NPM_TAG_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,8 +81,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         # The latest tag follows tagged versions to follow NPM conventions.
         run: |
-          yarn version $GITHUB_REF_NAME --no-git-tag-version
+          npm version $GITHUB_REF_NAME --no-git-tag-version
           cat package.json
-          yarn npm publish --tag latest
+          npm publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the change to yarn, something started to go wrong when deploying
to the same version twice. This maybe fixes it?