### PR TITLE
5389: add hide label modifier to checkbox

### DIFF
--- a/src/stories/Library/Forms/checkbox/Checkbox.stories.tsx
+++ b/src/stories/Library/Forms/checkbox/Checkbox.stories.tsx
@@ -46,6 +46,13 @@ Unchecked.args = {
   validation: "Error error error",
 };
 
+export const hiddenLabel = Template.bind({});
+hiddenLabel.args = {
+  isChecked: true,
+  label: "Checkbox",
+  hiddenLabel: true,
+};
+
 // Show multiple checkboxes to make it easier to test keyboard navigation.
 const Several: ComponentStory<typeof Checkbox> = (args) => (
   <>

--- a/src/stories/Library/Forms/checkbox/Checkbox.tsx
+++ b/src/stories/Library/Forms/checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ export type CheckboxProps = {
   ariaLabel?: string;
   validation?: string;
   callback?: (isChecked: boolean) => void;
+  hiddenLabel: boolean;
 };
 
 export const Checkbox: React.FC<CheckboxProps> = ({
@@ -14,6 +15,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   ariaLabel,
   callback,
   validation,
+  hiddenLabel = false,
 }) => {
   const checkboxId = useRef(`checkbox_id__${Math.random()}`);
   const [checked, setChecked] = useState(isChecked);
@@ -50,7 +52,11 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         </span>
         <div>
           {label && (
-            <span className="checkbox__text text-small-caption color-secondary-gray">
+            <span
+              className={`checkbox__text text-small-caption color-secondary-gray ${
+                hiddenLabel ? "checkbox__text--hide-visually" : ""
+              }`}
+            >
               {label}
             </span>
           )}

--- a/src/stories/Library/Forms/checkbox/checkbox.scss
+++ b/src/stories/Library/Forms/checkbox/checkbox.scss
@@ -52,6 +52,10 @@
   &--validation {
     color: $c-signal-alert;
   }
+
+  &--hide-visually {
+    @extend .hide-visually;
+  }
 }
 
 .checkbox__label:hover .checkbox__icon:first-child {

--- a/src/stories/Library/Forms/checkbox/checkbox.scss
+++ b/src/stories/Library/Forms/checkbox/checkbox.scss
@@ -54,7 +54,7 @@
   }
 
   &--hide-visually {
-    @extend .hide-visually;
+    @extend .hide-visually !optional;
   }
 }
 

--- a/src/stories/Library/Lists/list-empty/ListEmpty.stories.tsx
+++ b/src/stories/Library/Lists/list-empty/ListEmpty.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { withDesign } from "storybook-addon-designs";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import ListEmpty from "./ListEmpty";

--- a/src/stories/Library/Lists/list-materials/ListMaterials.tsx
+++ b/src/stories/Library/Lists/list-materials/ListMaterials.tsx
@@ -34,6 +34,7 @@ export const ListMaterials: React.FC<ListMaterialsProps> = ({
       {canBeRenewed && (
         <div className="list-materials__checkbox mr-32">
           <Checkbox
+            hiddenLabel={false}
             isChecked={isItChecked}
             callback={handleToggle}
             ariaLabel="Vælg materiale"

--- a/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
+++ b/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
@@ -203,6 +203,7 @@ export const ModalLoan: React.FC<ModalLoanProps> = ({
 
         <div className="modal-loan__buttons">
           <Checkbox
+            hiddenLabel={false}
             isChecked={isAllChecked}
             callback={handleToggleAll}
             label="Vælg alle med mulighed for fornyelse"


### PR DESCRIPTION
<img width="190" alt="image" src="https://user-images.githubusercontent.com/15377965/178805167-48dc7552-8aa1-4ac2-af19-f0c7c89208d4.png">

Its is to be used in the lists in the modal with checkboxes. So the label is supposed to say something like "select material", and only be 'visible' for screen readers. 