### PR TITLE
Rewrite SeriesLine to HorizontalTermLine

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -55,7 +55,7 @@
 @import "./src/stories/Library/reservation-header/reservation-header";
 @import "./src/stories/Library/material-header/material-periodikum-select";
 @import "./src/stories/Library/material-description/material-description";
-@import "./src/stories/Library/material-series-line/material-series-line";
+@import "./src/stories/Library/horizontal-term-line/horizontal-term-line";
 @import "./src/stories/Library/search-result-page/search-result-info";
 @import "./src/stories/Library/search-result-page/search-result-page";
 @import "./src/stories/Library/search-result-page/search-result-pager";

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,26 +1,26 @@
-export interface SeriesLineList {
+export interface HorizontalTermLineList {
   url: string;
   text: string;
 }
 
-export interface SeriesLineProps {
+export interface HorizontalTermLineProps {
   title: string;
   subTitle?: string;
-  linkList: SeriesLineList[];
+  linkList: HorizontalTermLineList[];
 }
 
-const SeriesLine: React.FC<SeriesLineProps> = ({
+const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   title,
   subTitle,
   linkList,
 }) => {
   return (
-    <div className="text-small-caption material-series-line">
+    <div className="text-small-caption horizontal-term-line">
       <p className="text-label-semibold">
         {`${title}`}{" "}
         {subTitle && <span className="text-small-caption">{subTitle} </span>}
       </p>
-      <ul className="material-series-line__list">
+      <ul className="horizontal-term-line__list">
         {linkList.map((link, index) => (
           <li>
             <a href="/" className="link-tag" key={index}>
@@ -33,4 +33,4 @@ const SeriesLine: React.FC<SeriesLineProps> = ({
   );
 };
 
-export default SeriesLine;
+export default HorizontalTermLine;

--- a/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
+++ b/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
@@ -1,6 +1,8 @@
-.material-series-line {
+.horizontal-term-line {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  white-space: nowrap;
   gap: $s-sm;
 
   // Set all text to the same font size even if other text classes have been used.

--- a/src/stories/Library/material-description/MaterialDescription.tsx
+++ b/src/stories/Library/material-description/MaterialDescription.tsx
@@ -1,6 +1,6 @@
-import SeriesLine from "../material-series-line/MaterialSeriesLine";
+import HorizontalTermLine from "../horizontal-term-line/HorizontalTermLine";
 
-const seriesLines = [
+const HorizontalTermLines = [
   {
     title: "Nr. 3",
     subTitle: "i serien",
@@ -54,7 +54,7 @@ const seriesLines = [
       },
     ],
   },
-].map((item) => <SeriesLine {...item} />);
+].map((item) => <HorizontalTermLine {...item} />);
 
 interface MaterialDescriptionProps {
   description?: string;
@@ -66,8 +66,12 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({
   return (
     <section className="material-description">
       <h2 className="text-header-h4 pb-24">Beskrivelse</h2>
-      <p className="text-body-large ">{description}</p>
-      <div className="material-description__links mt-32">{seriesLines}</div>
+      <p className="text-body-large material-description__content">
+        {description}
+      </p>
+      <div className="material-description__links mt-32">
+        {HorizontalTermLines}
+      </div>
     </section>
   );
 };

--- a/src/stories/Library/material-description/MaterialDescription.tsx
+++ b/src/stories/Library/material-description/MaterialDescription.tsx
@@ -1,6 +1,6 @@
 import HorizontalTermLine from "../horizontal-term-line/HorizontalTermLine";
 
-const HorizontalTermLines = [
+const horizontalTermLines = [
   {
     title: "Nr. 3",
     subTitle: "i serien",
@@ -54,7 +54,7 @@ const HorizontalTermLines = [
       },
     ],
   },
-].map((item) => <HorizontalTermLine {...item} />);
+];
 
 interface MaterialDescriptionProps {
   description?: string;
@@ -70,7 +70,9 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({
         {description}
       </p>
       <div className="material-description__links mt-32">
-        {HorizontalTermLines}
+        {horizontalTermLines.map((item) => (
+          <HorizontalTermLine {...item} />
+        ))}
       </div>
     </section>
   );

--- a/src/stories/Library/material-description/material-description.scss
+++ b/src/stories/Library/material-description/material-description.scss
@@ -1,8 +1,11 @@
 .material-description {
-  max-width: 750px;
   padding: $s-md;
   padding-top: $s-3xl;
   padding-bottom: $s-2xl;
+
+  &__content {
+      max-width: 750px;
+  }
 
   @include breakpoint-m {
     padding-top: $s-4xl;

--- a/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
@@ -31,7 +31,7 @@ export default {
       defaultValue: "2018",
     },
 
-    seriesLineData: {
+    horizontalTermLineData: {
       control: { type: "object" },
       defaultValue: {
         title: "Nr. 3",

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -2,16 +2,16 @@ import { AvailabilityLabel } from "../availability-label/AvailabilityLabel";
 import { Material } from "../material/Material";
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
 import { ButtonFavourite } from "../Buttons/button-favourite/ButtonFavourite";
-import MaterialLink, {
-  SeriesLineProps,
-} from "../material-series-line/MaterialSeriesLine";
+import HorizontalTermLine, {
+  HorizontalTermLineProps,
+} from "../horizontal-term-line/HorizontalTermLine";
 
 export type SearchResultItemProps = {
   heartFill?: boolean;
   title: string;
   author: string;
   year: string;
-  seriesLineData?: SeriesLineProps;
+  horizontalTermLineData?: HorizontalTermLineProps;
 };
 
 export const SearchResultItem = ({
@@ -19,7 +19,7 @@ export const SearchResultItem = ({
   title,
   author,
   year,
-  seriesLineData,
+  horizontalTermLineData,
 }: SearchResultItemProps) => {
   return (
     <a href="/" className="search-result-item arrow arrow__hover--right-small">
@@ -34,7 +34,9 @@ export const SearchResultItem = ({
       <div className="search-result-item__text">
         <div className="search-result-item__meta">
           <ButtonFavourite fill={heartFill} />
-          {seriesLineData && <MaterialLink {...seriesLineData} />}
+          {horizontalTermLineData && (
+            <HorizontalTermLine {...horizontalTermLineData} />
+          )}
         </div>
 
         <h2 className="search-result-item__title text-header-h4">{title}</h2>


### PR DESCRIPTION
This PR does two things

- Change the name of SeriesLine to HorizontalTermLine
The name has been changed because it is a reusable component and before it was prefix with: material-

- Change css width for material-description
Only material-description__content should have a max width


