### PR TITLE
Fix link width

### DIFF
--- a/src/stories/Library/links/links.scss
+++ b/src/stories/Library/links/links.scss
@@ -2,6 +2,7 @@
   text-decoration: none;
   color: $c-text-primary-black;
   display: inline-block;
+  width: fit-content;
 
   @extend %text-body-medium-regular-placeholder;
 }


### PR DESCRIPTION
https://platform.dandigbib.org/issues/5398

Fix so links wont obtain the full width of its container, but instead stay the width of its content.

Before:
![Screenshot 2022-07-27 at 13 20 04](https://user-images.githubusercontent.com/332915/181235304-9478f40b-3088-427f-8bcf-aa7c45803409.png)

After:
![Screenshot 2022-07-27 at 13 19 28](https://user-images.githubusercontent.com/332915/181235309-af3f5431-b401-44f6-8ac6-4ff2516d9a41.png)

