### PR TITLE
Ensure second menu level is always full height

### DIFF
--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -130,6 +130,10 @@
   }
 }
 
+.header__menu-second {
+  height: 100%;
+}
+
 .header__menu-search {
   display: flex;
   align-items: center;

--- a/src/stories/Blocks/status-userprofile/statusUserprofile.stories.tsx
+++ b/src/stories/Blocks/status-userprofile/statusUserprofile.stories.tsx
@@ -37,6 +37,7 @@ export default {
           },
           title: "Afleveret for sent",
           showDot: true,
+          href: "/",
         },
         {
           label: {
@@ -49,6 +50,7 @@ export default {
           },
           title: "Afleveres snart",
           showDot: true,
+          href: "/",
         },
         {
           number: {
@@ -57,6 +59,7 @@ export default {
           },
           title: "Længere afleveringstid",
           showDot: false,
+          href: "/",
         },
       ],
     },
@@ -84,6 +87,7 @@ export default {
           },
           title: "Klar til dig",
           showDot: true,
+          href: "/",
         },
         {
           number: {
@@ -92,6 +96,7 @@ export default {
           },
           title: "Stadig i kø",
           showDot: false,
+          href: "/",
         },
       ],
     },

--- a/src/stories/Blocks/status-userprofile/statusUserprofile.tsx
+++ b/src/stories/Blocks/status-userprofile/statusUserprofile.tsx
@@ -30,6 +30,7 @@ export const StatusUserprofile = (props: StatusUserprofileProps) => {
                 number={item.number}
                 label={item.label}
                 showDot={item.showDot}
+                href={item.href}
               />
             </div>
           ))
@@ -51,6 +52,7 @@ export const StatusUserprofile = (props: StatusUserprofileProps) => {
                 number={item.number}
                 label={item.label}
                 showDot={item.showDot}
+                href={item.href}
               />
             </div>
           ))

--- a/src/stories/Library/autosuggest-text/autosuggest-text.scss
+++ b/src/stories/Library/autosuggest-text/autosuggest-text.scss
@@ -5,11 +5,11 @@
   left: 0;
   right: 0;
   top: calc(100% + 1px);
-    
+  z-index: 1;
+
   @include breakpoint-m {
     padding-top: 16px;
   }
-  
 
   &__text {
     height: 40px;
@@ -20,7 +20,7 @@
       background-color: $c-global-secondary;
       cursor: pointer;
     }
-  
+    
     &--highlight {
       background-color: $c-global-secondary;
     }


### PR DESCRIPTION
Despite the grid layout of the header which ensures that first and
second level are always full height we need to ensure that this is
the case for the second level. We mount our search app into the menu
and thus the mount point is injected between .header__menu and 
.header__menu-second.

The mount point will then get the full height but it will be missing
for .header__menu-second.

Explicitly set full height to ensure that the search bar takes up
the entire element and the search string is neatly center aligned
vertically.

Before:

![Log ind | DPL CMS — (Private Browsing) 2022-08-03 16-35-24](https://user-images.githubusercontent.com/73966/182635562-1784fede-f84b-4780-9a20-78a46fdafd3a.png)

After:

![Log ind | DPL CMS — (Private Browsing) 2022-08-03 16-35-59](https://user-images.githubusercontent.com/73966/182635637-358eb093-4e2b-44f6-a225-282882f4cfe9.png)

