### PR TITLE
5391: Add label text link

### DIFF
--- a/src/stories/Library/Forms/checkbox/Checkbox.stories.tsx
+++ b/src/stories/Library/Forms/checkbox/Checkbox.stories.tsx
@@ -12,6 +12,16 @@ export default {
         type: "text",
       },
     },
+    labelLinkText: {
+      control: {
+        type: "text",
+      },
+    },
+    labelLinkHref: {
+      control: {
+        type: "text",
+      },
+    },
     validation: {
       control: {
         type: "text",
@@ -37,6 +47,14 @@ export const Checked = Template.bind({});
 Checked.args = {
   isChecked: true,
   label: "Toggle this checkbox",
+};
+
+export const CheckedWithLink = Template.bind({});
+CheckedWithLink.args = {
+  isChecked: true,
+  label: "Toggle this checkbox",
+  labelLinkText: "Se betingelser",
+  labelLinkHref: "#",
 };
 
 export const Unchecked = Template.bind({});

--- a/src/stories/Library/Forms/checkbox/Checkbox.tsx
+++ b/src/stories/Library/Forms/checkbox/Checkbox.tsx
@@ -4,6 +4,8 @@ export type CheckboxProps = {
   isChecked: boolean;
   label?: string;
   ariaLabel?: string;
+  labelLinkText?: string;
+  labelLinkHref?: string;
   validation?: string;
   callback?: (isChecked: boolean) => void;
   hiddenLabel: boolean;
@@ -12,6 +14,8 @@ export type CheckboxProps = {
 export const Checkbox: React.FC<CheckboxProps> = ({
   isChecked,
   label,
+  labelLinkText,
+  labelLinkHref,
   ariaLabel,
   callback,
   validation,
@@ -64,6 +68,14 @@ export const Checkbox: React.FC<CheckboxProps> = ({
             <div className="checkbox__text text-small-caption checkbox__text--validation">
               {validation}
             </div>
+          )}
+          {labelLinkText && (
+            <a
+              href={labelLinkHref}
+              className="checkbox__text text-small-caption color-secondary-gray"
+            >
+              {labelLinkText}
+            </a>
           )}
         </div>
       </label>

--- a/src/stories/Library/Forms/checkbox/checkbox.scss
+++ b/src/stories/Library/Forms/checkbox/checkbox.scss
@@ -15,6 +15,7 @@
   overflow: hidden;
   transition: all 0.3s ease;
   display: flex;
+  align-items: center;
 }
 
 .checkbox__label .checkbox__icon {


### PR DESCRIPTION
https://platform.dandigbib.org/issues/5391

This pr adds the posibility of showing a link at the end of a checkboxs text label. For instance to use when accepting terms or similar.

![Screenshot 2022-08-10 at 16 04 37](https://user-images.githubusercontent.com/332915/183921999-d61c3410-224c-4c3b-bfa0-a95e47020346.png)

