### PR TITLE
Introduce and use a new shared class for inverting icons

### DIFF
--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -22,7 +22,7 @@ export const Disclosure: React.FC<DisclosureProps> = ({
       >
         <div className="disclosure__icon bg-identity-tint-120 m-24">
           <img
-            className="disclosure__icon"
+            className="disclosure__icon invert"
             src={`icons/collection/${icon}.svg`}
             alt="various-icon"
           />

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -22,7 +22,6 @@
 
     & > img {
       width: 24px;
-      filter: invert(1);
     }
   }
 

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -114,3 +114,7 @@
 .capitalize-first:first-letter {
   text-transform: uppercase;
 }
+
+.invert {
+  filter: invert(1);
+}


### PR DESCRIPTION
### Description
We have many icons used throughout the project. They are normally black,
but sometimes we need them to be white. We prefer not to set SVG's
directly into the code if we use them many places, but rather refer to
the original svg files as background sources for image tags. (If in the
future we want to change icon x to icon y we only have to exchange the
source file instead of hunting every instance in the code.) 
Thus we need this class.

### Additional comments
The chromatic test is not ✅-ed because the visual changes to the app were
not caused by this PR. ([Chromatic + cross-fork PRs i designsystemet](https://dpl.zulipchat.com/#narrow/stream/323076-CMS-NEXT/topic/Chromatic.20.2B.20cross-fork.20PRs.20i.20designsystemet))
The plan is to merge this PR in without approving these changes in Chromatic.