### PR TITLE
Add shared Chromatic project token to GitHub Actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,8 +22,4 @@ jobs:
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        # Forks may not have a CHROMATIC_PROJECT_TOKEN secret set
-        # making the action fail unrelated to the change at hand.
-        # Make it not fail.
-        continue-on-error: true
+          projectToken: c6b96f9648b6


### PR DESCRIPTION
This way we should be able to use Chromatic across forks without
forcing contributors to add the project token as a secret. This 
should allow us to merge contributions with increased confidence.

Exposing tokens like this may not seem like a good idea but it is an
approach suggested by Chromatic:
https://www.chromatic.com/docs/custom-ci-provider#run-chromatic-on-external-forks-of-open-source-projects

Sharing project-token‘s allows contributors and others to run 
Chromatic. They’ll be able to use our snapshots. They will not be 
able to get access to our account, settings, or accept baselines. 
This is an acceptable tradeoff for us.