### PR TITLE
Find on shelf modal

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -73,6 +73,7 @@
 @import "./src/stories/Library/shadows/shadows";
 @import "./src/stories/Library/boxed-text/boxed-text";
 @import "./src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf";
+@import "./src/stories/Library/Modals/modal-find-on-shelf/modal-find-on-shelf";
 
 // Blocks
 @import "./src/stories/Blocks/footer/footer";

--- a/base.scss
+++ b/base.scss
@@ -72,6 +72,7 @@
 @import "./src/stories/Library/review/review";
 @import "./src/stories/Library/shadows/shadows";
 @import "./src/stories/Library/boxed-text/boxed-text";
+@import "./src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf";
 
 // Blocks
 @import "./src/stories/Blocks/footer/footer";

--- a/src/stories/Blocks/material-manifestation-item/MaterialMainfestationItem.tsx
+++ b/src/stories/Blocks/material-manifestation-item/MaterialMainfestationItem.tsx
@@ -24,7 +24,7 @@ export const MaterialMainfestationItem = ({
     <div className="material-manifestation-item">
       <div className="material-manifestation-item__availability">
         <AvailabilityLabel
-          manifestation="Bog"
+          manifestationType="Bog"
           availability="Hjemme"
           status="available"
         />

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.stories.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.stories.tsx
@@ -22,6 +22,11 @@ export default {
       defaultValue: 1,
       control: { type: "number" },
     },
+    nrOfListItems: {
+      name: "Amount of lit items",
+      defaultValue: 2,
+      control: { type: "number" },
+    },
   },
   parameters: {
     design: {

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.stories.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import ListFindOnShelf, { ListFindOnShelfProps } from "./ListFindOnShelf";
+
+export default {
+  title: "Library / Lists / Find On Shelf",
+  component: ListFindOnShelf,
+  decorators: [withDesign],
+  argTypes: {
+    manifestationName: {
+      name: "Manifestation Name",
+      defaultValue: "Vejen til Jerusalem, 2008",
+      control: { type: "text" },
+    },
+    location: {
+      name: "Location",
+      defaultValue: "Voksen · Skønlitteratur · Standard · Guillou",
+      control: { type: "text" },
+    },
+    nrAvailable: {
+      name: "Amount of available manifestations",
+      defaultValue: 1,
+      control: { type: "number" },
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=4561%3A26097",
+    },
+  },
+} as ComponentMeta<typeof ListFindOnShelf>;
+
+const Template: ComponentStory<typeof ListFindOnShelf> = (
+  args: ListFindOnShelfProps
+) => <ListFindOnShelf {...args} />;
+
+export const FindOnShelf = Template.bind({});

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -1,0 +1,31 @@
+export type ListFindOnShelfProps = {
+  manifestationName: string;
+  location: string;
+  nrAvailable: number;
+};
+
+const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
+  manifestationName,
+  location,
+  nrAvailable,
+}) => {
+  return (
+    <ul className="find-on-shelf">
+      <li className="find-on-shelf__header-row text-small-caption">
+        <span>Materiale</span>
+        <span>Find det på hylden</span>
+        <span>Hjemme</span>
+      </li>
+      <li className="find-on-shelf__row text-body-medium-regular">
+        <span>{manifestationName}</span>
+        <span>{location}</span>
+        <span>
+          {nrAvailable}
+          <span className="hide-on-desktop"> hjemme</span>
+        </span>
+      </li>
+    </ul>
+  );
+};
+
+export default ListFindOnShelf;

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -16,18 +16,18 @@ const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
   return (
     <ul className="find-on-shelf">
       <li className="find-on-shelf__header-row text-small-caption">
-        <span className="find-on-shelf__material-title">Materiale</span>
+        <span className="find-on-shelf__material-header">Materiale</span>
         <span>Find det på hylden</span>
-        <span className="find-on-shelf__item-count-title">Hjemme</span>
+        <span className="find-on-shelf__item-count-header">Hjemme</span>
       </li>
       {numberArray.map((key) => {
         return (
           <li className="find-on-shelf__row text-body-medium-regular" key={key}>
-            <span className="find-on-shelf__material-title">
+            <span className="find-on-shelf__material-text">
               {manifestationName}
             </span>
-            <span>{location}</span>
-            <span>
+            <span className="find-on-shelf__location-text">{location}</span>
+            <span className="find-on-shelf__item-count-text">
               {nrAvailable}
               <span className="hide-on-desktop"> hjemme</span>
             </span>

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -2,13 +2,17 @@ export type ListFindOnShelfProps = {
   manifestationName: string;
   location: string;
   nrAvailable: number;
+  nrOfListItems: number;
 };
 
 const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
   manifestationName,
   location,
   nrAvailable,
+  nrOfListItems,
 }) => {
+  const numberArray = new Array(nrOfListItems).fill("item");
+
   return (
     <ul className="find-on-shelf">
       <li className="find-on-shelf__header-row text-small-caption">
@@ -16,14 +20,18 @@ const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
         <span>Find det på hylden</span>
         <span>Hjemme</span>
       </li>
-      <li className="find-on-shelf__row text-body-medium-regular">
-        <span>{manifestationName}</span>
-        <span>{location}</span>
-        <span>
-          {nrAvailable}
-          <span className="hide-on-desktop"> hjemme</span>
-        </span>
-      </li>
+      {numberArray.map((key) => {
+        return (
+          <li className="find-on-shelf__row text-body-medium-regular" key={key}>
+            <span>{manifestationName}</span>
+            <span>{location}</span>
+            <span>
+              {nrAvailable}
+              <span className="hide-on-desktop"> hjemme</span>
+            </span>
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -16,14 +16,16 @@ const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
   return (
     <ul className="find-on-shelf">
       <li className="find-on-shelf__header-row text-small-caption">
-        <span>Materiale</span>
+        <span className="find-on-shelf__material-title">Materiale</span>
         <span>Find det på hylden</span>
-        <span>Hjemme</span>
+        <span className="find-on-shelf__item-count-title">Hjemme</span>
       </li>
       {numberArray.map((key) => {
         return (
           <li className="find-on-shelf__row text-body-medium-regular" key={key}>
-            <span>{manifestationName}</span>
+            <span className="find-on-shelf__material-title">
+              {manifestationName}
+            </span>
             <span>{location}</span>
             <span>
               {nrAvailable}

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -26,7 +26,7 @@ const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
             <span className="find-on-shelf__material-text">
               {manifestationName}
             </span>
-            <span className="find-on-shelf__location-text">{location}</span>
+            <span>{location}</span>
             <span className="find-on-shelf__item-count-text">
               {nrAvailable}
               <span className="hide-on-desktop"> hjemme</span>

--- a/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
+++ b/src/stories/Library/Lists/list-find-on-shelf/ListFindOnShelf.tsx
@@ -29,7 +29,7 @@ const ListFindOnShelf: React.FC<ListFindOnShelfProps> = ({
             <span>{location}</span>
             <span className="find-on-shelf__item-count-text">
               {nrAvailable}
-              <span className="hide-on-desktop"> hjemme</span>
+              <span className="hide-visually--on-desktop"> hjemme</span>
             </span>
           </li>
         );

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -5,76 +5,69 @@
     display: none;
 
     @include breakpoint-s {
-      border-bottom: solid 1px $c-global-primary;
       display: flex;
       height: $s-xl;
       align-items: center;
-      padding-left: $s-xl;
-      margin-right: $s-md;
+      padding: 0 $s-md 0 $s-xl;
     }
   }
 
-  &__material-title {
+  &__material-header {
     width: 404px;
   }
 
-  &__item-count-title {
-    justify-self: flex-end;
-    margin-left: auto;
+  &__item-count-header {
+    @include breakpoint-s {
+      margin-left: auto;
+    }
   }
 
   &__row {
-    min-width: $s-6xl;
     display: flex;
     flex-direction: column;
-    border-bottom: solid 1px $c-global-primary;
+    border-top: solid 1px $c-global-primary;
+    padding: $s-lg $s-md;
 
     @include breakpoint-s {
+      padding: 0 $s-xl 0 $s-xl;
       flex-direction: row;
       min-height: 110px;
       align-items: center;
-      justify-content: flex-start;
     }
 
-    &:last-of-type {
-      border-bottom: none;
-    }
-
-    & > span {
-      margin: $s-md $s-md 0 $s-md;
-
-      &:first-of-type {
-        margin-top: $s-lg;
-      }
-
-      &:last-of-type {
-        margin-bottom: $s-lg;
-      }
-
+    & .hide-on-desktop {
       @include breakpoint-s {
-        margin: 0;
-        max-width: 600px;
-        text-overflow: ellipsis;
-        overflow-y: hidden;
-
-        &:first-of-type {
-          margin-left: $s-xl;
-          margin-top: inherit;
-        }
-
-        &:last-of-type {
-          margin-bottom: inherit;
-          margin-left: auto;
-          margin-right: $s-xl;
-          overflow-y: visible;
-        }
-      }
-
-      & .hide-on-desktop {
-        @include breakpoint-s {
-          display: none;
-        }
+        display: none;
       }
     }
   }
+
+  &__material-text {
+    max-width: 600px;
+
+    @include breakpoint-s {
+      // Both width and min-width need to be here to prevent flex shrink & stretch.
+      width: 404px;
+      min-width: 404px;
+      margin: 0;
+    }
+  }
+
+  &__location-text {
+    margin-top: $s-md;
+
+    @include breakpoint-s {
+      margin: 0;
+    }
+  }
+
+  &__item-count-text {
+    margin-top: $s-md;
+
+    @include breakpoint-s {
+      margin: 0 0 0 auto;
+      overflow-y: visible;
+    }
+  }
+
 }

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -13,11 +13,15 @@
     }
 
     & > span {
-      &:first-child {
+      &:first-of-type {
         margin-left: $s-lg;
         width: 404px;
+
+        @include breakpoint-s {
+          margin-left: $s-xl;
+        }
       }
-      &:last-child {
+      &:last-of-type {
         margin-right: $s-md;
         margin-left: auto;
       }
@@ -37,18 +41,18 @@
       justify-content: flex-start;
     }
 
-    &:last-child {
+    &:last-of-type {
       border-bottom: none;
     }
 
     & > span {
       margin: $s-md $s-md 0 $s-md;
 
-      &:first-child {
+      &:first-of-type {
         margin-top: $s-lg;
       }
 
-      &:last-child {
+      &:last-of-type {
         margin-bottom: $s-lg;
       }
 
@@ -58,16 +62,18 @@
         text-overflow: ellipsis;
         overflow-y: hidden;
 
-        &:first-child {
-          margin-left: $s-lg;
+        &:first-of-type {
+          margin-left: $s-xl;
           margin-top: inherit;
           width: 404px;
+          min-width: 404px;
         }
 
-        &:last-child {
+        &:last-of-type {
           margin-bottom: inherit;
           margin-left: auto;
           margin-right: $s-xl;
+          overflow-y: visible;
         }
       }
 

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -28,12 +28,17 @@
     min-width: $s-6xl;
     display: flex;
     flex-direction: column;
+    border-bottom: solid 1px $c-global-primary;
 
     @include breakpoint-s {
       flex-direction: row;
       min-height: 110px;
       align-items: center;
       justify-content: flex-start;
+    }
+
+    &:last-child {
+      border-bottom: none;
     }
 
     & > span {

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -8,24 +8,19 @@
       border-bottom: solid 1px $c-global-primary;
       display: flex;
       height: $s-xl;
-      justify-content: flex-start;
       align-items: center;
+      padding-left: $s-xl;
+      margin-right: $s-md;
     }
+  }
 
-    & > span {
-      &:first-of-type {
-        margin-left: $s-lg;
-        width: 404px;
+  &__material-title {
+    width: 404px;
+  }
 
-        @include breakpoint-s {
-          margin-left: $s-xl;
-        }
-      }
-      &:last-of-type {
-        margin-right: $s-md;
-        margin-left: auto;
-      }
-    }
+  &__item-count-title {
+    justify-self: flex-end;
+    margin-left: auto;
   }
 
   &__row {
@@ -65,8 +60,6 @@
         &:first-of-type {
           margin-left: $s-xl;
           margin-top: inherit;
-          width: 404px;
-          min-width: 404px;
         }
 
         &:last-of-type {

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -1,0 +1,76 @@
+.find-on-shelf {
+  background-color: $c-global-secondary;
+
+  &__header-row {
+    display: none;
+
+    @include breakpoint-s {
+      border-bottom: solid 1px $c-global-primary;
+      display: flex;
+      height: $s-xl;
+      justify-content: flex-start;
+      align-items: center;
+    }
+
+    & > span {
+      &:first-child {
+        margin-left: $s-lg;
+        width: 404px;
+      }
+      &:last-child {
+        margin-right: $s-md;
+        margin-left: auto;
+      }
+    }
+  }
+
+  &__row {
+    min-width: $s-6xl;
+    display: flex;
+    flex-direction: column;
+
+    @include breakpoint-s {
+      flex-direction: row;
+      min-height: 110px;
+      align-items: center;
+      justify-content: flex-start;
+    }
+
+    & > span {
+      margin: $s-md $s-md 0 $s-md;
+
+      &:first-child {
+        margin-top: $s-lg;
+      }
+
+      &:last-child {
+        margin-bottom: $s-lg;
+      }
+
+      @include breakpoint-s {
+        margin: 0;
+        max-width: 600px;
+        text-overflow: ellipsis;
+        overflow-y: hidden;
+
+        &:first-child {
+          margin-left: $s-lg;
+          margin-top: inherit;
+          width: 404px;
+        }
+
+        &:last-child {
+          margin-bottom: inherit;
+          margin-left: auto;
+          margin-right: $s-xl;
+        }
+      }
+
+      & .hide-on-desktop {
+        @include breakpoint-s {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -36,12 +36,6 @@
       align-items: center;
       gap: 0;
     }
-
-    & .hide-on-desktop {
-      @include breakpoint-s {
-        display: none;
-      }
-    }
   }
 
   &__material-text {

--- a/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
+++ b/src/stories/Library/Lists/list-find-on-shelf/list-find-on-shelf.scss
@@ -27,12 +27,14 @@
     flex-direction: column;
     border-top: solid 1px $c-global-primary;
     padding: $s-lg $s-md;
+    gap: $s-md;
 
     @include breakpoint-s {
       padding: 0 $s-xl 0 $s-xl;
       flex-direction: row;
       min-height: 110px;
       align-items: center;
+      gap: 0;
     }
 
     & .hide-on-desktop {
@@ -49,23 +51,13 @@
       // Both width and min-width need to be here to prevent flex shrink & stretch.
       width: 404px;
       min-width: 404px;
-      margin: 0;
-    }
-  }
-
-  &__location-text {
-    margin-top: $s-md;
-
-    @include breakpoint-s {
-      margin: 0;
     }
   }
 
   &__item-count-text {
-    margin-top: $s-md;
 
     @include breakpoint-s {
-      margin: 0 0 0 auto;
+      margin-left: auto;
       overflow-y: visible;
     }
   }

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.stories.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.stories.tsx
@@ -1,0 +1,48 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import ModalFindOnShelf, { ModalFindOnShelfProps } from "./ModalFindOnShelf";
+
+export default {
+  title: "Library / Modals / Find On Shelf",
+  component: ModalFindOnShelf,
+  decorators: [withDesign],
+  argTypes: {
+    workTitle: {
+      name: "Work title",
+      defaultValue: "Vejen til Jerusalem",
+      control: { type: "text" },
+    },
+    author: {
+      name: "Author",
+      defaultValue: "Jan Guillou",
+      control: { type: "text" },
+    },
+    nrOfbranches: {
+      name: "Amount of library branches",
+      defaultValue: 3,
+      control: { type: "number" },
+    },
+    nrOfManifestations: {
+      name: "Amount of manifestations per branch",
+      defaultValue: 2,
+      control: { type: "number" },
+    },
+    showModal: {
+      name: "Show modal?",
+      defaultValue: true,
+      control: { type: "boolean" },
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=4561%3A26097",
+    },
+  },
+} as ComponentMeta<typeof ModalFindOnShelf>;
+
+const Template: ComponentStory<typeof ModalFindOnShelf> = (
+  args: ModalFindOnShelfProps
+) => <ModalFindOnShelf {...args} />;
+
+export const FindOnShelf = Template.bind({});

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { Disclosure } from "../../disclosure/Disclosure";
+import { ModalCloseButton, ModalFallbackButton } from "../ModalShared";
+
+export type ModalFindOnShelfProps = {
+  workTitle: string;
+  author: string;
+  nrOfbranches: number;
+  nrOfManifestations: number;
+  showModal: boolean;
+};
+
+const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
+  workTitle,
+  author,
+  nrOfbranches,
+  nrOfManifestations,
+  showModal,
+}) => {
+  const branchesArray = new Array(nrOfbranches).fill("item");
+  const manifestationArray = new Array(nrOfManifestations).fill("item");
+  const [shoudShowModal, setShouldShowModal] = useState(showModal);
+
+  useEffect(() => {
+    setShouldShowModal(showModal);
+  }, [showModal]);
+
+  const toggleModal = () => {
+    setShouldShowModal(!showModal);
+  };
+
+  console.log(shoudShowModal);
+
+  if (!shoudShowModal) {
+    return <ModalFallbackButton toggleModal={toggleModal} />;
+  }
+
+  return (
+    <div
+      className={`modal modal-details modal-find-on-shelf ${
+        shoudShowModal ? "modal-show" : ""
+      }`}
+    >
+      <div className="modal__screen-reader-description" id="describemodal">
+        Denne modal dækker sidens indhold, og er en demo
+      </div>
+      <ModalCloseButton
+        idAriaDescribedBy="describemodal"
+        toggleModal={toggleModal}
+      />
+      <h1 className="text-header-h2 modal-find-on-shelf__headline">
+        {workTitle} / {author}
+      </h1>
+      <div className="text-small-caption modal-find-on-shelf__caption">
+        8 biblioteker har materialet
+      </div>
+      {branchesArray.map((branchKey) => {
+        return (
+          <Disclosure
+            withAvailability
+            headline="Bibliotek fliale navn"
+            icon="Various"
+            key={branchKey}
+          >
+            <ul className="find-on-shelf">
+              <li className="find-on-shelf__header-row text-small-caption">
+                <span>Materiale</span>
+                <span>Find det på hylden</span>
+                <span>Hjemme</span>
+              </li>
+              {manifestationArray.map((manifestKey) => {
+                return (
+                  <li
+                    className="find-on-shelf__row text-body-medium-regular"
+                    key={manifestKey}
+                  >
+                    <span>Vejen til Jerusalem, 2008</span>
+                    <span>Voksen · Skønlitteratur · Standard · Guillou</span>
+                    <span>
+                      12<span className="hide-on-desktop"> hjemme</span>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </Disclosure>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ModalFindOnShelf;

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Disclosure } from "../../disclosure/Disclosure";
+import ListFindOnShelf from "../../Lists/list-find-on-shelf/ListFindOnShelf";
 import { ModalCloseButton, ModalFallbackButton } from "../ModalShared";
 
 export type ModalFindOnShelfProps = {
@@ -60,27 +61,12 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
             icon="Various"
             key={branchKey}
           >
-            <ul className="find-on-shelf">
-              <li className="find-on-shelf__header-row text-small-caption">
-                <span>Materiale</span>
-                <span>Find det på hylden</span>
-                <span>Hjemme</span>
-              </li>
-              {manifestationArray.map((manifestKey) => {
-                return (
-                  <li
-                    className="find-on-shelf__row text-body-medium-regular"
-                    key={manifestKey}
-                  >
-                    <span>Vejen til Jerusalem, 2008</span>
-                    <span>Voksen · Skønlitteratur · Standard · Guillou</span>
-                    <span>
-                      12<span className="hide-on-desktop"> hjemme</span>
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
+            <ListFindOnShelf
+              manifestationName="Vejen til Jerusalem, 2008"
+              location="Voksen · Skønlitteratur · Standard · Guillou"
+              nrAvailable={13}
+              nrOfListItems={manifestationArray.length}
+            />
           </Disclosure>
         );
       })}

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -26,10 +26,8 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
   }, [showModal]);
 
   const toggleModal = () => {
-    setShouldShowModal(!showModal);
+    setShouldShowModal(!shoudShowModal);
   };
-
-  console.log(shoudShowModal);
 
   if (!shoudShowModal) {
     return <ModalFallbackButton toggleModal={toggleModal} />;

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -47,9 +47,9 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
         idAriaDescribedBy="describemodal"
         toggleModal={toggleModal}
       />
-      <h1 className="text-header-h2 modal-find-on-shelf__headline">
+      <h2 className="text-header-h2 modal-find-on-shelf__headline">
         {workTitle} / {author}
-      </h1>
+      </h2>
       <div className="text-small-caption modal-find-on-shelf__caption">
         8 biblioteker har materialet
       </div>

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -57,6 +57,7 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
         return (
           <Disclosure
             withAvailability
+            fullWidth
             headline="Bibliotek fliale navn"
             icon="Various"
             key={branchKey}

--- a/src/stories/Library/Modals/modal-find-on-shelf/modal-find-on-shelf.scss
+++ b/src/stories/Library/Modals/modal-find-on-shelf/modal-find-on-shelf.scss
@@ -22,9 +22,4 @@
       margin: 96px 0 $s-sm 16px;
     }
   }
-
-  .disclosure {
-    width: 100%;
-    margin: 0;
-  }
 }

--- a/src/stories/Library/Modals/modal-find-on-shelf/modal-find-on-shelf.scss
+++ b/src/stories/Library/Modals/modal-find-on-shelf/modal-find-on-shelf.scss
@@ -1,0 +1,30 @@
+.modal-find-on-shelf {
+  padding: 0;
+  overflow-y: scroll;
+  align-items: flex-start;
+
+  @include breakpoint-m {
+    padding: 0 215px $s-4xl 215px;
+  }
+
+  &__headline {
+    margin: 72px $s-md 0 $s-md;
+
+    @include breakpoint-m {
+      margin-top: $s-4xl;
+    }
+  }
+
+  &__caption {
+    margin: $s-2xl 0 $s-md $s-md;
+
+    @include breakpoint-m {
+      margin: 96px 0 $s-sm 16px;
+    }
+  }
+
+  .disclosure {
+    width: 100%;
+    margin: 0;
+  }
+}

--- a/src/stories/Library/availability-label/AvailabilityLabel.stories.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: AvailabilityLabel,
   decorators: [withDesign],
   argTypes: {
-    manifestation: {
+    manifestationType: {
       name: "Manifestation Type",
       options: ["Bog", "Ebog", "Lydbog (net)", "Lydbog (cd-mp3)", undefined],
       control: { disable: true },
@@ -33,21 +33,21 @@ const Template: ComponentStory<typeof AvailabilityLabel> = (args) => (
 
 export const Available = Template.bind({});
 Available.args = {
-  manifestation: "Bog",
+  manifestationType: "Bog",
   availability: "Hjemme",
   status: "available",
 };
 
 export const Selected = Template.bind({});
 Selected.args = {
-  manifestation: "Ebog",
+  manifestationType: "Ebog",
   availability: "Online",
   status: "selected",
 };
 
 export const Unavailable = Template.bind({});
 Unavailable.args = {
-  manifestation: "Lydbog (cd-mp3)",
+  manifestationType: "Lydbog (cd-mp3)",
   availability: "Udlånt",
   status: "unavailable",
 };
@@ -55,7 +55,7 @@ Unavailable.args = {
 export const WithoutManifestationType = Template.bind({});
 WithoutManifestationType.args = {
   // manifestation is defined here as undefined to perserve the controls order
-  manifestation: undefined,
+  manifestationType: undefined,
   availability: "Udlånt",
   status: "unavailable",
 };

--- a/src/stories/Library/availability-label/AvailabilityLabel.stories.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.stories.tsx
@@ -7,7 +7,23 @@ export default {
   title: "Library / Availability Label",
   component: AvailabilityLabel,
   decorators: [withDesign],
-  argTypes: {},
+  argTypes: {
+    manifestation: {
+      name: "Manifestation Type",
+      options: ["Bog", "Ebog", "Lydbog (net)", "Lydbog (cd-mp3)", undefined],
+      control: { disable: true },
+    },
+    availability: {
+      name: "Availability",
+      options: ["Hjemme", "Online", "Udlånt"],
+      control: { disable: true },
+    },
+    status: {
+      name: "Status",
+      options: ["available", "unavailable", "selected"],
+      control: { disable: true },
+    },
+  },
   parameters: {},
 } as ComponentMeta<typeof AvailabilityLabel>;
 
@@ -32,6 +48,14 @@ Selected.args = {
 export const Unavailable = Template.bind({});
 Unavailable.args = {
   manifestation: "Lydbog (cd-mp3)",
+  availability: "Udlånt",
+  status: "unavailable",
+};
+
+export const WithoutManifestationType = Template.bind({});
+WithoutManifestationType.args = {
+  // manifestation is defined here as undefined to perserve the controls order
+  manifestation: undefined,
   availability: "Udlånt",
   status: "unavailable",
 };

--- a/src/stories/Library/availability-label/AvailabilityLabel.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.tsx
@@ -2,8 +2,11 @@ import { AvailabilityLabelPropsType } from "../../availability-label/types";
 import { Pagefold } from "../pagefold/Pagefold";
 import { withAvailabilityProps } from "./abilityLabel.hoc";
 
-export const AvailabilityLabel = (props: AvailabilityLabelPropsType) => {
-  const { manifestation, availability, status } = props;
+export const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
+  manifestation,
+  availability,
+  status,
+}) => {
   const AvailabilityPagefold = withAvailabilityProps(Pagefold);
 
   return (
@@ -13,9 +16,18 @@ export const AvailabilityLabel = (props: AvailabilityLabelPropsType) => {
         src="icons/collection/Check.svg"
         alt="check-icon"
       />
-      <p className="text-label-semibold ml-24">{manifestation.toUpperCase()}</p>
-      <div className="availability-label--divider ml-4" />
-      <p className="text-label-normal ml-4 mr-8">{availability}</p>
+      {manifestation && (
+        <>
+          <p className="text-label-semibold ml-24">
+            {manifestation.toUpperCase()}
+          </p>
+          <div className="availability-label--divider ml-4" />
+          <p className="text-label-normal ml-4 mr-8">{availability}</p>
+        </>
+      )}
+      {!manifestation && (
+        <p className="text-label-normal ml-24 mr-8">{availability}</p>
+      )}
     </AvailabilityPagefold>
   );
 };

--- a/src/stories/Library/availability-label/AvailabilityLabel.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.tsx
@@ -3,7 +3,7 @@ import { Pagefold } from "../pagefold/Pagefold";
 import { withAvailabilityProps } from "./abilityLabel.hoc";
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
-  manifestation,
+  manifestationType,
   availability,
   status,
 }) => {
@@ -16,16 +16,16 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
         src="icons/collection/Check.svg"
         alt="check-icon"
       />
-      {manifestation && (
+      {manifestationType && (
         <>
           <p className="text-label-semibold ml-24">
-            {manifestation.toUpperCase()}
+            {manifestationType.toUpperCase()}
           </p>
           <div className="availability-label--divider ml-4" />
           <p className="text-label-normal ml-4 mr-8">{availability}</p>
         </>
       )}
-      {!manifestation && (
+      {!manifestationType && (
         <p className="text-label-normal ml-24 mr-8">{availability}</p>
       )}
     </AvailabilityPagefold>

--- a/src/stories/Library/disclosure/Disclosure.stories.tsx
+++ b/src/stories/Library/disclosure/Disclosure.stories.tsx
@@ -23,6 +23,11 @@ export default {
       options: ["Various", "Receipt", "Create", "Profile"],
       control: { type: "select" },
     },
+    withAvailability: {
+      name: "Is with availability label?",
+      defaultValue: false,
+      control: { disable: true },
+    },
   },
   parameters: {
     design: {
@@ -37,3 +42,8 @@ const Template: ComponentStory<typeof Disclosure> = (args: DisclosureProps) => (
 );
 
 export const Default = Template.bind({});
+
+export const WithAvailabilityLabel = Template.bind({});
+WithAvailabilityLabel.args = {
+  withAvailability: true,
+};

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -5,7 +5,7 @@ export type DisclosureProps = {
   headline: string;
   children: React.ReactNode | string;
   icon: "Various" | "Receipt" | "Create" | "Profile";
-  withAvailability: boolean;
+  withAvailability?: boolean;
 };
 
 export const Disclosure: React.FC<DisclosureProps> = ({

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -6,6 +6,7 @@ export type DisclosureProps = {
   children: React.ReactNode | string;
   icon: "Various" | "Receipt" | "Create" | "Profile";
   withAvailability?: boolean;
+  fullWidth?: boolean;
 };
 
 export const Disclosure: React.FC<DisclosureProps> = ({
@@ -13,10 +14,15 @@ export const Disclosure: React.FC<DisclosureProps> = ({
   children,
   icon,
   withAvailability,
+  fullWidth = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <details className="disclosure text-body-large">
+    <details
+      className={`disclosure text-body-large ${
+        fullWidth ? "disclosure--full-width" : ""
+      }`}
+    >
       <summary
         className="disclosure__headline text-body-large"
         onClick={() => {

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -39,10 +39,10 @@ export const Disclosure: React.FC<DisclosureProps> = ({
           </div>
         )}
         {!withAvailability && (
-          <span className="disclosure__headline__text">{headline}</span>
+          <span className="disclosure__text">{headline}</span>
         )}
         {withAvailability && (
-          <span className="disclosure__headline__text-shorter">{headline}</span>
+          <span className="disclosure__text--shorter">{headline}</span>
         )}
         {withAvailability && (
           <AvailabilityLabel availability="Hjemme" status="available" />

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -1,15 +1,18 @@
 import { useState } from "react";
+import { AvailabilityLabel } from "../availability-label/AvailabilityLabel";
 
 export type DisclosureProps = {
   headline: string;
   children: React.ReactNode | string;
   icon: "Various" | "Receipt" | "Create" | "Profile";
+  withAvailability: boolean;
 };
 
 export const Disclosure: React.FC<DisclosureProps> = ({
   headline,
   children,
   icon,
+  withAvailability,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
@@ -20,16 +23,30 @@ export const Disclosure: React.FC<DisclosureProps> = ({
           setIsOpen(!isOpen);
         }}
       >
-        <div className="disclosure__icon bg-identity-tint-120 m-24">
-          <img
-            className="disclosure__icon invert"
-            src={`icons/collection/${icon}.svg`}
-            alt="various-icon"
+        {!withAvailability && (
+          <div className="disclosure__icon bg-identity-tint-120">
+            <img
+              className="invert"
+              src={`icons/collection/${icon}.svg`}
+              alt="various-icon"
+            />
+          </div>
+        )}
+        {!withAvailability && (
+          <span className="disclosure__headline__text">{headline}</span>
+        )}
+        {withAvailability && (
+          <span className="disclosure__headline__text-shorter">{headline}</span>
+        )}
+        {withAvailability && (
+          <AvailabilityLabel
+            manifestation="Bog"
+            availability="Hjemme"
+            status="available"
           />
-        </div>
-        {headline}
+        )}
         <img
-          className={`disclosure__expand mr-24 noselect ${
+          className={`disclosure__expand noselect ${
             isOpen ? "disclosure__expand-open" : ""
           }`}
           src="icons/collection/ExpandMore.svg"

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -39,11 +39,7 @@ export const Disclosure: React.FC<DisclosureProps> = ({
           <span className="disclosure__headline__text-shorter">{headline}</span>
         )}
         {withAvailability && (
-          <AvailabilityLabel
-            manifestation="Bog"
-            availability="Hjemme"
-            status="available"
-          />
+          <AvailabilityLabel availability="Hjemme" status="available" />
         )}
         <img
           className={`disclosure__expand noselect ${

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -38,12 +38,13 @@ export const Disclosure: React.FC<DisclosureProps> = ({
             />
           </div>
         )}
-        {!withAvailability && (
-          <span className="disclosure__text">{headline}</span>
-        )}
-        {withAvailability && (
-          <span className="disclosure__text--shorter">{headline}</span>
-        )}
+        <span
+          className={`disclosure__text ${
+            withAvailability ? "disclosure__text--shorter" : ""
+          }`}
+        >
+          {headline}
+        </span>
         {withAvailability && (
           <AvailabilityLabel availability="Hjemme" status="available" />
         )}

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -11,6 +11,15 @@
     margin: 0 133px;
   }
 
+  &--full-width {
+    width: 100%;
+    margin: 0;
+
+    @include breakpoint-s {
+      margin: 0;
+    }
+  }
+
   &__headline {
     height: 88px;
     display: flex;

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -61,7 +61,7 @@
     margin-right: $s-md;
 
     @include breakpoint-s {
-      margin-left: -8px;
+      margin-left: -#{$s-sm};
       margin-right: $s-lg;
     }
 

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -7,10 +7,38 @@
   }
 
   &__headline {
+    height: 88px;
     display: flex;
     align-items: center;
-    justify-content: baseline;
+    justify-content: space-between;
     cursor: pointer;
+    padding-left: 16px;
+
+    @include breakpoint-m {
+      padding-left: 32px;
+    }
+
+    &__text {
+      width: 201px;
+      text-overflow: ellipsis;
+      max-height: 84px;
+      overflow-y: hidden;
+
+      @include breakpoint-m {
+        width: 685px;
+      }
+
+      &-shorter {
+        width: 197px;
+        text-overflow: ellipsis;
+        max-height: 84px;
+        overflow-y: hidden;
+
+        @include breakpoint-m {
+          width: 404px;
+        }
+      }
+    }
   }
 
   &__icon {
@@ -19,14 +47,29 @@
     border-radius: 20px;
     display: flex;
     justify-content: center;
+    margin-right: 16px;
+
+    @include breakpoint-m {
+      margin-left: -8px;
+      margin-right: 24px;
+    }
 
     & > img {
       width: 24px;
     }
   }
+  & .availability-label {
+    margin-left: 24px;
+  }
 
   &__expand {
     margin-left: auto;
+    margin-right: 16px;
+
+    @include breakpoint-m {
+      margin-right: 24px;
+    }
+
     &-open {
       transform: scaleY(-1);
     }

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -45,9 +45,6 @@
 
     &--shorter {
       width: 197px;
-      text-overflow: ellipsis;
-      max-height: 84px;
-      overflow-y: hidden;
 
       @include breakpoint-s {
         width: 404px;

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -12,10 +12,10 @@
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
-    padding-left: 16px;
+    padding-left: $s-md;
 
     @include breakpoint-m {
-      padding-left: 32px;
+      padding-left: $s-xl;
     }
 
     &__text {
@@ -47,27 +47,27 @@
     border-radius: 20px;
     display: flex;
     justify-content: center;
-    margin-right: 16px;
+    margin-right: $s-md;
 
     @include breakpoint-m {
       margin-left: -8px;
-      margin-right: 24px;
+      margin-right: $s-lg;
     }
 
     & > img {
-      width: 24px;
+      width: $s-lg;
     }
   }
   & .availability-label {
-    margin-left: 24px;
+    margin-left: $s-lg;
   }
 
   &__expand {
     margin-left: auto;
-    margin-right: 16px;
+    margin-right: $s-md;
 
     @include breakpoint-m {
-      margin-right: 24px;
+      margin-right: $s-lg;
     }
 
     &-open {

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -1,8 +1,13 @@
 .disclosure {
   width: auto;
   border: solid 1px $c-global-tertiary-1;
+  border-top: none;
 
-  @include breakpoint-m {
+  &:first-of-type {
+    border-top: solid 1px $c-global-tertiary-1;
+  }
+
+  @include breakpoint-s {
     margin: 0 133px;
   }
 
@@ -14,7 +19,7 @@
     cursor: pointer;
     padding-left: $s-md;
 
-    @include breakpoint-m {
+    @include breakpoint-s {
       padding-left: $s-xl;
     }
 
@@ -24,7 +29,7 @@
       max-height: 84px;
       overflow-y: hidden;
 
-      @include breakpoint-m {
+      @include breakpoint-s {
         width: 685px;
       }
 
@@ -34,7 +39,7 @@
         max-height: 84px;
         overflow-y: hidden;
 
-        @include breakpoint-m {
+        @include breakpoint-s {
           width: 404px;
         }
       }
@@ -49,7 +54,7 @@
     justify-content: center;
     margin-right: $s-md;
 
-    @include breakpoint-m {
+    @include breakpoint-s {
       margin-left: -8px;
       margin-right: $s-lg;
     }
@@ -58,16 +63,13 @@
       width: $s-lg;
     }
   }
-  & .availability-label {
-    margin-left: $s-lg;
-  }
 
   &__expand {
     margin-left: auto;
     margin-right: $s-md;
 
-    @include breakpoint-m {
-      margin-right: $s-lg;
+    @include breakpoint-s {
+      margin-right: $s-xl;
     }
 
     &-open {

--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -31,26 +31,26 @@
     @include breakpoint-s {
       padding-left: $s-xl;
     }
+  }
 
-    &__text {
-      width: 201px;
+  &__text {
+    width: 201px;
+    text-overflow: ellipsis;
+    max-height: 84px;
+    overflow-y: hidden;
+
+    @include breakpoint-s {
+      width: 685px;
+    }
+
+    &--shorter {
+      width: 197px;
       text-overflow: ellipsis;
       max-height: 84px;
       overflow-y: hidden;
 
       @include breakpoint-s {
-        width: 685px;
-      }
-
-      &-shorter {
-        width: 197px;
-        text-overflow: ellipsis;
-        max-height: 84px;
-        overflow-y: hidden;
-
-        @include breakpoint-s {
-          width: 404px;
-        }
+        width: 404px;
       }
     }
   }

--- a/src/stories/Library/material-header/MaterialHeader.tsx
+++ b/src/stories/Library/material-header/MaterialHeader.tsx
@@ -8,27 +8,27 @@ import MaterialPeriodicalSelect from "./MaterialPeriodicalSelect";
 
 const listOfAvailabilityLabels = [
   {
-    manifestation: "Bog",
+    manifestationType: "Bog",
     availability: "Hjemme",
     status: "selected",
   } as const,
   {
-    manifestation: "Bog",
+    manifestationType: "Bog",
     availability: "Hjemme",
     status: "available",
   } as const,
   {
-    manifestation: "Bog",
+    manifestationType: "Bog",
     availability: "Hjemme",
     status: "available",
   } as const,
   {
-    manifestation: "Bog",
+    manifestationType: "Bog",
     availability: "Hjemme",
     status: "available",
   } as const,
   {
-    manifestation: "Bog",
+    manifestationType: "Bog",
     availability: "Hjemme",
     status: "available",
   } as const,

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -44,23 +44,23 @@ export const SearchResultItem = ({
       </div>
       <div className="search-result-item__availability">
         <AvailabilityLabel
-          manifestation="Bog"
+          manifestationType="Bog"
           availability="Hjemme"
           status="available"
         />
         <AvailabilityLabel
-          manifestation="Ebog"
+          manifestationType="Ebog"
           availability="Online"
           status="available"
         />
 
         <AvailabilityLabel
-          manifestation="Lydbog (cd-mp3)"
+          manifestationType="Lydbog (cd-mp3)"
           availability="Udlånt"
           status="unavailable"
         />
         <AvailabilityLabel
-          manifestation="Lydbog (net)"
+          manifestationType="Lydbog (net)"
           availability="Online"
           status="available"
         />

--- a/src/stories/availability-label/types.tsx
+++ b/src/stories/availability-label/types.tsx
@@ -1,5 +1,5 @@
 export type AvailabilityLabelPropsType = {
-  manifestation?: "Bog" | "Ebog" | "Lydbog (net)" | "Lydbog (cd-mp3)";
+  manifestationType?: "Bog" | "Ebog" | "Lydbog (net)" | "Lydbog (cd-mp3)";
   availability: "Hjemme" | "Online" | "Udlånt";
   status: "available" | "unavailable" | "selected";
 };

--- a/src/stories/availability-label/types.tsx
+++ b/src/stories/availability-label/types.tsx
@@ -1,5 +1,5 @@
 export type AvailabilityLabelPropsType = {
-  manifestation: "Bog" | "Ebog" | "Lydbog (net)" | "Lydbog (cd-mp3)";
+  manifestation?: "Bog" | "Ebog" | "Lydbog (net)" | "Lydbog (cd-mp3)";
   availability: "Hjemme" | "Online" | "Udlånt";
   status: "available" | "unavailable" | "selected";
 };

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -29,12 +29,24 @@
   position: fixed;
   top: 0;
   right: 0;
-  padding: 34px;
+  padding: 22.5px;
   transition: 0.3s;
   z-index: 2;
 
+  @include breakpoint-s {
+    padding: 34px;
+  }
+
   &:hover {
     transform: rotateZ(90deg);
+  }
+
+  & > img {
+    width: 11.5px;
+
+    @include breakpoint-s {
+      width: 19.5px;
+    }
   }
 }
 

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -25,6 +25,16 @@
   overflow: hidden;
 }
 
+.hide-visually {
+  @include hide-visually;
+
+  &--on-desktop {
+    @include breakpoint-s {
+      @include hide-visually;
+    }
+  }
+}
+
 .modal-btn-close {
   position: fixed;
   top: 0;


### PR DESCRIPTION
#### Ticket
https://reload.atlassian.net/browse/DDFSOEG-227

#### Description
This PR adds the find on shelf modal and as a part of it:
- new disclosure variant - with availability label
- new availability label variant - without manifestation type
- Find on shelf list component, its story and styling
- Find on shelf modal component, its story and styling

#### Screenshots
Disclosure with availability label:
![image](https://user-images.githubusercontent.com/28546954/189109101-94bcb5bd-77db-435e-b629-b2a5f38c17ff.png)
![image](https://user-images.githubusercontent.com/28546954/189109179-9a353dfe-ab25-4710-be5a-63505e2a8a6a.png)

Availability label without manifestation type:
![image](https://user-images.githubusercontent.com/28546954/189109376-83fbc9c8-a211-40e2-b971-7113188c803f.png)

Find on shelf list:
![image](https://user-images.githubusercontent.com/28546954/189109500-85b72e02-9b06-4f71-88ce-b5a744eb4dbe.png)
![image](https://user-images.githubusercontent.com/28546954/189109572-578e7396-f793-4582-bdfd-979f12ac7943.png)

Find on shelf modal:
![image](https://user-images.githubusercontent.com/28546954/189109887-8417e4c2-bed2-48d7-b34c-28fd376d5eb1.png)
![image](https://user-images.githubusercontent.com/28546954/189109743-f8eeb39e-0b76-4c7f-adc3-f62c072bcbd5.png)

#### Additional comments
I disabled the controls for Availability label because all the different controls are covered in the specific stories and it can get  pretty confusing switching between the stories and seeing cached availability labels that don't correspond to the story.