### PR TITLE
Fix / Add bottom padding to material page

### DIFF
--- a/src/stories/Blocks/material-page/material-page.scss
+++ b/src/stories/Blocks/material-page/material-page.scss
@@ -1,3 +1,6 @@
 .material-page {
-  // source can not be empty
+  padding-bottom: $s-2xl;
+  @include breakpoint-s {
+    padding-bottom: $s-6xl;
+  }
 }


### PR DESCRIPTION
#### Description
This PR fixes spacing on the material page based on feedback from DDF by adding bottom padding. (marked purple on the picture below)

#### Screenshots of the result
![image](https://user-images.githubusercontent.com/28546954/191277215-e90e90b9-8444-49c8-a829-5184cbd9fa43.png)

Mobile:
![image](https://user-images.githubusercontent.com/28546954/191277726-b862cb3a-edd5-4f99-883b-7580f82e76db.png)

