### PR TITLE
Fix markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -11,6 +11,7 @@ config:
       # https://gist.github.com/scmx/eca72d44afee0113ceb0349dd54a84a2
       - summary
       - details
-  # Allow duplicate headings. These do not cause problems for GitHub, which is
-  # our default renderer
-  MD024: false
+  # Allow duplicate headings for non-siblings.
+  # Duplications do not cause problems for GitHub, which is our default renderer.
+  MD024:
+    siblings_only: true


### PR DESCRIPTION
The current approach to disabling the linting rule does not work.

We allow duplications except for siblings as this does not make sense structurally.