### PR TITLE
Remove default padding from profile modal

### DIFF
--- a/src/stories/Library/Modals/modal-profile/modal-profile.scss
+++ b/src/stories/Library/Modals/modal-profile/modal-profile.scss
@@ -1,4 +1,5 @@
 .modal-profile {
+  padding: 0; // reset padding from default .modal class
   flex-direction: column;
 
   &__notifications {


### PR DESCRIPTION
### Remove default padding from profile modal
This must be a mistake that was not detected when we added padding to all modals

Please check chromatic 
https://www.chromatic.com/test?appId=616ffdab9acbf5003ad5fd2b&id=633c13831c3e24f30298fa25