### PR TITLE
Move logic to show modal into the Modal component

### DIFF
--- a/src/stories/Library/Modals/Modal.tsx
+++ b/src/stories/Library/Modals/Modal.tsx
@@ -9,16 +9,17 @@ interface ModalWrapperProps {
 }
 
 const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
-  const [shoudShowModal, setShouldShowModal] = useState(shownModal);
+  const [shouldShowModal, setShouldShowModal] = useState(shownModal);
 
   useEffect(() => setShouldShowModal(shownModal), [shownModal]);
 
-  const toggleModal = () => setShouldShowModal(!shoudShowModal);
+  const toggleModal = () => setShouldShowModal(!shouldShowModal);
 
-  if (!shoudShowModal) return <ModalFallbackButton toggleModal={toggleModal} />;
+  if (!shouldShowModal)
+    return <ModalFallbackButton toggleModal={toggleModal} />;
 
   return (
-    <div className={clsx("modal", shoudShowModal && "modal-show", classNames)}>
+    <div className={clsx("modal", shouldShowModal && "modal-show", classNames)}>
       <div className="modal__screen-reader-description" id="describemodal">
         Denne modal dækker sidens indhold, og er en demo
       </div>

--- a/src/stories/Library/Modals/Modal.tsx
+++ b/src/stories/Library/Modals/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { clsx } from "clsx";
 import { ModalCloseButton, ModalFallbackButton } from "./ModalShared";
 
 interface ModalWrapperProps {
@@ -17,11 +18,7 @@ const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
   if (!shoudShowModal) return <ModalFallbackButton toggleModal={toggleModal} />;
 
   return (
-    <div
-      className={`modal ${shoudShowModal ? "modal-show" : ""} ${
-        classNames ?? ""
-      }`}
-    >
+    <div className={clsx("modal", shoudShowModal && "modal-show", classNames)}>
       <div className="modal__screen-reader-description" id="describemodal">
         Denne modal dækker sidens indhold, og er en demo
       </div>

--- a/src/stories/Library/Modals/Modal.tsx
+++ b/src/stories/Library/Modals/Modal.tsx
@@ -1,22 +1,26 @@
-import React from "react";
-import { ModalCloseButton } from "./ModalShared";
+import React, { useEffect, useState } from "react";
+import { ModalCloseButton, ModalFallbackButton } from "./ModalShared";
 
 interface ModalWrapperProps {
   shownModal: boolean;
   children?: React.ReactNode;
   classNames?: string;
-  toggleModal?: () => void;
 }
 
-const Modal = ({
-  children,
-  shownModal,
-  classNames,
-  toggleModal,
-}: ModalWrapperProps) => {
+const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
+  const [shoudShowModal, setShouldShowModal] = useState(shownModal);
+
+  useEffect(() => setShouldShowModal(shownModal), [shownModal]);
+
+  const toggleModal = () => setShouldShowModal(!shoudShowModal);
+
+  if (!shoudShowModal) return <ModalFallbackButton toggleModal={toggleModal} />;
+
   return (
     <div
-      className={`modal ${shownModal ? "modal-show" : ""} ${classNames ?? ""}`}
+      className={`modal ${shoudShowModal ? "modal-show" : ""} ${
+        classNames ?? ""
+      }`}
     >
       <div className="modal__screen-reader-description" id="describemodal">
         Denne modal dækker sidens indhold, og er en demo

--- a/src/stories/Library/Modals/modal-cta/ModalCTA.tsx
+++ b/src/stories/Library/Modals/modal-cta/ModalCTA.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-import { ModalFallbackButton } from "../ModalShared";
+import React from "react";
 import { Button } from "../../Buttons/button/Button";
 import { Links } from "../../links/Links";
 import Modal from "../Modal";
@@ -9,63 +8,43 @@ export type ModalCTAProps = {
   showModal: boolean;
 };
 
-export const ModalCTA: React.FC<ModalCTAProps> = ({ title, showModal }) => {
-  const [shownModal, setShownModal] = useState(showModal);
-
-  useEffect(() => {
-    setShownModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShownModal(!showModal);
-  };
-
-  if (!showModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
-  return (
-    <Modal
-      shownModal={shownModal}
-      classNames="modal-cta  modal-padding"
-      toggleModal={toggleModal}
-    >
-      <div className="modal-cta__container">
-        <h2 className="text-header-h2">{title}</h2>
-        <div className="mt-48 color-secondary-gray">
-          <p className="text-body-medium-regular">
-            Fornyer du dine lån, forhøjes dit gebyr.
-          </p>
-          <p className="text-links mt-24">
-            Alle materialer ikke kan fornys og lånet splittes derfor op. Ved
-            overskredne lån modtager du et gebyr pr. lån og derfor forhøjes dit
-            samlede gebyr, hvis du vælger at gå videre med at fornye.{" "}
-            <Links
-              href="/"
-              linkText="Læs mere"
-              classNames="color-secondary-gray ml-8"
-            />
-          </p>
-          <p className="text-links mt-24">Er du sikker på du vil fornye?</p>
-        </div>
-        <div className="modal-cta__buttons mt-48">
-          <Button
-            buttonType="default"
-            size="large"
-            variant="filled"
-            label="Annuller fornyelse"
-            disabled={false}
-            collapsible
+export const ModalCTA: React.FC<ModalCTAProps> = ({ title, showModal }) => (
+  <Modal shownModal={showModal} classNames="modal-cta modal-padding">
+    <div className="modal-cta__container">
+      <h2 className="text-header-h2">{title}</h2>
+      <div className="mt-48 color-secondary-gray">
+        <p className="text-body-medium-regular">
+          Fornyer du dine lån, forhøjes dit gebyr.
+        </p>
+        <p className="text-links mt-24">
+          Alle materialer ikke kan fornys og lånet splittes derfor op. Ved
+          overskredne lån modtager du et gebyr pr. lån og derfor forhøjes dit
+          samlede gebyr, hvis du vælger at gå videre med at fornye.{" "}
+          <Links
+            href="/"
+            linkText="Læs mere"
+            classNames="color-secondary-gray ml-8"
           />
-          <div className="modal-cta__link">
-            <Links
-              href="/"
-              linkText="Ja, forny mulige"
-              classNames="color-secondary-gray ml-8"
-            />
-          </div>
+        </p>
+        <p className="text-links mt-24">Er du sikker på du vil fornye?</p>
+      </div>
+      <div className="modal-cta__buttons mt-48">
+        <Button
+          buttonType="default"
+          size="large"
+          variant="filled"
+          label="Annuller fornyelse"
+          disabled={false}
+          collapsible
+        />
+        <div className="modal-cta__link">
+          <Links
+            href="/"
+            linkText="Ja, forny mulige"
+            classNames="color-secondary-gray ml-8"
+          />
         </div>
       </div>
-    </Modal>
-  );
-};
+    </div>
+  </Modal>
+);

--- a/src/stories/Library/Modals/modal-details/ModalDetails.tsx
+++ b/src/stories/Library/Modals/modal-details/ModalDetails.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react";
-
+import React from "react";
 import { MaterialBanner } from "../../../Blocks/material-banner/MaterialBanner";
 import { MaterialCardProps } from "../../material-card/MaterialCard";
 import { LinkFilter } from "../../link-filters/LinkFilters";
@@ -11,8 +10,6 @@ import { Cover } from "../../cover/Cover";
 import { WarningStatus } from "../../warning-status/WarningStatus";
 import { StatusLabel } from "../../status-label/StatusLabel";
 import { Button } from "../../Buttons/button/Button";
-
-import { ModalFallbackButton } from "../ModalShared";
 import Modal from "../Modal";
 
 const listDetails: Array<ListDetailsProps> = [
@@ -107,77 +104,55 @@ export const ModalDetails: React.FC<ModalDetailsProps> = ({
   type,
   showModal,
   showWarning,
-}) => {
-  const [shoudShowModal, setShouldShowModal] = useState(showModal);
-
-  useEffect(() => {
-    setShouldShowModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShouldShowModal(!showModal);
-  };
-
-  if (!shoudShowModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
-  return (
-    <Modal
-      shownModal={shoudShowModal}
-      classNames="modal-details"
-      toggleModal={toggleModal}
-    >
-      <div className="modal-details__container">
-        <div className="modal-details__header">
-          <div className="modal-details__cover">
-            <Cover size="large" url="images/book_cover_large_1.jpg" animate />
+}) => (
+  <Modal shownModal={showModal} classNames="modal-details">
+    <div className="modal-details__container">
+      <div className="modal-details__header">
+        <div className="modal-details__cover">
+          <Cover size="large" url="images/book_cover_large_1.jpg" animate />
+        </div>
+        <div className="modal-details__material">
+          <div className="modal-details__tags">
+            <StatusLabel label={type} status="outline" />
+            {showWarning && <StatusLabel label="overskredet" status="danger" />}
           </div>
-          <div className="modal-details__material">
-            <div className="modal-details__tags">
-              <StatusLabel label={type} status="outline" />
-              {showWarning && (
-                <StatusLabel label="overskredet" status="danger" />
-              )}
-            </div>
-            <h2 className="modal-details__title text-header-h2">{title}</h2>
-            <p className="text-body-medium-regular">{author}</p>
-          </div>
-        </div>
-        <div className="modal-details__buttons">
-          <Button
-            buttonType="default"
-            label="forny dit lån"
-            size="small"
-            variant="filled"
-            disabled={false}
-            collapsible
-          />
-        </div>
-        <div className="modal-details__warning">
-          {showWarning && (
-            <WarningStatus
-              url="/"
-              description="Afleveringsdatoen for lånet er overskredet, derfor pålægges du et gebyr, når materialet afleveres"
-            />
-          )}
-        </div>
-        <div className="modal-details__list">
-          {listDetails.map((detail, index) => (
-            <ListDetails key={index} {...detail} />
-          ))}
+          <h2 className="modal-details__title text-header-h2">{title}</h2>
+          <p className="text-body-medium-regular">{author}</p>
         </div>
       </div>
-      <div className="modal-details__banner">
-        <MaterialBanner
-          title="Andre materialer"
-          body=""
-          linkFilters={linksFilters}
-          covers={materialCards}
-          showBodyText={false}
-          showLinkfilters
+      <div className="modal-details__buttons">
+        <Button
+          buttonType="default"
+          label="forny dit lån"
+          size="small"
+          variant="filled"
+          disabled={false}
+          collapsible
         />
       </div>
-    </Modal>
-  );
-};
+      <div className="modal-details__warning">
+        {showWarning && (
+          <WarningStatus
+            url="/"
+            description="Afleveringsdatoen for lånet er overskredet, derfor pålægges du et gebyr, når materialet afleveres"
+          />
+        )}
+      </div>
+      <div className="modal-details__list">
+        {listDetails.map((detail, index) => (
+          <ListDetails key={index} {...detail} />
+        ))}
+      </div>
+    </div>
+    <div className="modal-details__banner">
+      <MaterialBanner
+        title="Andre materialer"
+        body=""
+        linkFilters={linksFilters}
+        covers={materialCards}
+        showBodyText={false}
+        showLinkfilters
+      />
+    </div>
+  </Modal>
+);

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from "react";
 import { Disclosure } from "../../disclosure/Disclosure";
 import ListFindOnShelf from "../../Lists/list-find-on-shelf/ListFindOnShelf";
-import { ModalFallbackButton } from "../ModalShared";
 import Modal from "../Modal";
 import { Dropdown } from "../../dropdown/Dropdown";
 
@@ -24,25 +22,11 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
 }) => {
   const branchesArray = new Array(nrOfbranches).fill("item");
   const manifestationArray = new Array(nrOfManifestations).fill("item");
-  const [shoudShowModal, setShouldShowModal] = useState(showModal);
-
-  useEffect(() => {
-    setShouldShowModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShouldShowModal(!shoudShowModal);
-  };
-
-  if (!shoudShowModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
 
   return (
     <Modal
-      shownModal={shoudShowModal}
+      shownModal={showModal}
       classNames="modal-details modal-find-on-shelf"
-      toggleModal={toggleModal}
     >
       <h2 className="text-header-h2 modal-find-on-shelf__headline">
         {workTitle} / {author}

--- a/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
+++ b/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
-import { ModalFallbackButton } from "../ModalShared";
+import { useMemo, useState } from "react";
 import { Button } from "../../Buttons/button/Button";
 import { Checkbox } from "../../Forms/checkbox/Checkbox";
 import { Counter } from "../../counter/Counter";
@@ -135,17 +134,7 @@ export const ModalLoan: React.FC<ModalLoanProps> = ({
   showModal,
   buttonsUpTop,
 }) => {
-  const [shoulShowModal, setShouldShowModal] = useState(showModal);
   const [isAllChecked, setChecked] = useState(false);
-
-  useEffect(() => {
-    setShouldShowModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShouldShowModal(!showModal);
-  };
-
   const isExpired = showExpired;
   const loanList = isExpired ? listExpired : listExpiresSoon;
 
@@ -159,20 +148,12 @@ export const ModalLoan: React.FC<ModalLoanProps> = ({
     return total;
   }, [loanList]);
 
-  if (!shoulShowModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
   const handleToggleAll = () => {
     setChecked(!isAllChecked);
   };
 
   return (
-    <Modal
-      shownModal={shoulShowModal}
-      classNames="modal-loan"
-      toggleModal={toggleModal}
-    >
+    <Modal shownModal={showModal} classNames="modal-loan">
       <div className="modal-loan__container">
         <div className="modal-loan__header">
           {isExpired && (

--- a/src/stories/Library/Modals/modal-login/ModalLogin.tsx
+++ b/src/stories/Library/Modals/modal-login/ModalLogin.tsx
@@ -10,7 +10,7 @@ export type ModalLoginProps = {
 };
 
 export const ModalLogin: React.FC<ModalLoginProps> = ({ showModal }) => {
-  const [shownModal, setShownModal] = useState(showModal);
+  <div className="modal-backdrop">
 
   useEffect(() => {
     setShownModal(showModal);

--- a/src/stories/Library/Modals/modal-login/ModalLogin.tsx
+++ b/src/stories/Library/Modals/modal-login/ModalLogin.tsx
@@ -1,59 +1,33 @@
-import { useEffect, useState } from "react";
-
-import { ModalCloseButton, ModalFallbackButton } from "../ModalShared";
 import { Button } from "../../Buttons/button/Button";
 import { Links } from "../../links/Links";
+import Modal from "../Modal";
 
 export type ModalLoginProps = {
   title: string;
   showModal: boolean;
 };
 
-export const ModalLogin: React.FC<ModalLoginProps> = ({ showModal }) => {
+export const ModalLogin: React.FC<ModalLoginProps> = ({ showModal }) => (
   <div className="modal-backdrop">
-
-  useEffect(() => {
-    setShownModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShownModal(!showModal);
-  };
-
-  if (!showModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
-  return (
-    <div className="modal__backdrop">
-      <div
-        className={`modal modal-login modal-right modal-padding ${
-          shownModal ? "modal-show" : ""
-        }`}
-      >
-        <div className="modal__screen-reader-description" id="describemodal">
-          Denne modal dækker sidens indhold, og er en demo
-        </div>
-        <ModalCloseButton
-          idAriaDescribedBy="describemodal"
-          toggleModal={toggleModal}
+    <Modal
+      shownModal={showModal}
+      classNames="modal-login modal-right modal-padding"
+    >
+      <div className="modal-login__container">
+        <Button
+          buttonType="default"
+          size="large"
+          variant="filled"
+          label="Log ind"
+          disabled={false}
+          collapsible={false}
         />
-        <div className="modal-login__container">
-          <Button
-            buttonType="default"
-            size="large"
-            variant="filled"
-            label="Log ind"
-            disabled={false}
-            collapsible={false}
-          />
-          <Links
-            href="/"
-            linkText="Opret profil"
-            classNames="color-secondary-gray modal-login__btn-create-profile"
-          />
-        </div>
+        <Links
+          href="/"
+          linkText="Opret profil"
+          classNames="color-secondary-gray modal-login__btn-create-profile"
+        />
       </div>
-    </div>
-  );
-};
+    </Modal>
+  </div>
+);

--- a/src/stories/Library/Modals/modal-pause/ModalPause.tsx
+++ b/src/stories/Library/Modals/modal-pause/ModalPause.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
-import { ModalFallbackButton } from "../ModalShared";
 import { Button } from "../../Buttons/button/Button";
 import { Links } from "../../links/Links";
 import Modal from "../Modal";
@@ -19,83 +18,63 @@ export const ModalPause: React.FC<ModalPauseProps> = ({
   subtitle,
   textWithLink,
   linkText,
-}) => {
-  const [shouldShowModal, setShouldShowModal] = useState(showModal);
+}) => (
+  <Modal shownModal={showModal} classNames="modal-padding modal-pause">
+    <div className="modal-pause__container">
+      <h3 className="text-header-h3">{title}</h3>
+      <div className="mt-48 color-secondary-gray">
+        <p className="text-body-medium-regular">{subtitle}</p>
+      </div>
 
-  useEffect(() => {
-    setShouldShowModal(showModal);
-  }, [showModal]);
+      <div className="modal-pause__dropdowns mt-24">
+        <div className="datepickers">
+          <div className="datepicker">
+            <span className="datepicker-toggle">
+              <label htmlFor="startDate" className="text-body-medium-regular">
+                Startdato
+              </label>
+              <input
+                type="date"
+                name="startDate"
+                id="startDate"
+                className="datepicker-input"
+                aria-label="startDate"
+              />
+            </span>
+          </div>
 
-  const toggleModal = () => {
-    setShouldShowModal(!shouldShowModal);
-  };
-
-  if (!shouldShowModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
-  return (
-    <Modal
-      shownModal={shouldShowModal}
-      classNames="modal-padding modal-pause"
-      toggleModal={toggleModal}
-    >
-      <div className="modal-pause__container">
-        <h3 className="text-header-h3">{title}</h3>
-        <div className="mt-48 color-secondary-gray">
-          <p className="text-body-medium-regular">{subtitle}</p>
-        </div>
-
-        <div className="modal-pause__dropdowns mt-24">
-          <div className="datepickers">
-            <div className="datepicker">
-              <span className="datepicker-toggle">
-                <label htmlFor="startDate" className="text-body-medium-regular">
-                  Startdato
-                </label>
-                <input
-                  type="date"
-                  name="startDate"
-                  id="startDate"
-                  className="datepicker-input"
-                  aria-label="startDate"
-                />
-              </span>
-            </div>
-
-            <div className="datepicker">
-              <span className="datepicker-toggle">
-                <label htmlFor="startDate" className="text-body-medium-regular">
-                  Slutdato
-                </label>
-                <input
-                  type="date"
-                  name="endDate"
-                  id="endDate"
-                  className="datepicker-input"
-                  aria-label="endDate"
-                />
-              </span>
-            </div>
+          <div className="datepicker">
+            <span className="datepicker-toggle">
+              <label htmlFor="startDate" className="text-body-medium-regular">
+                Slutdato
+              </label>
+              <input
+                type="date"
+                name="endDate"
+                id="endDate"
+                className="datepicker-input"
+                aria-label="endDate"
+              />
+            </span>
           </div>
         </div>
-
-        <div className="modal-pause__text-link mt-24 color-secondary-gray">
-          <p className="text-body-small-regular">
-            {textWithLink} <Links href="/" linkText={linkText} />
-          </p>
-        </div>
-        <div className="modal-pause__button mt-48">
-          <Button
-            buttonType="default"
-            size="large"
-            variant="filled"
-            label="gem"
-            disabled={false}
-            collapsible
-          />
-        </div>
       </div>
-    </Modal>
-  );
-};
+
+      <div className="modal-pause__text-link mt-24 color-secondary-gray">
+        <p className="text-body-small-regular">
+          {textWithLink} <Links href="/" linkText={linkText} />
+        </p>
+      </div>
+      <div className="modal-pause__button mt-48">
+        <Button
+          buttonType="default"
+          size="large"
+          variant="filled"
+          label="gem"
+          disabled={false}
+          collapsible
+        />
+      </div>
+    </div>
+  </Modal>
+);

--- a/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
+++ b/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useState } from "react";
-
 import { ModalHeader } from "../modal-header/ModalHeader";
-import { ModalCloseButton, ModalFallbackButton } from "../ModalShared";
 import { Button } from "../../Buttons/button/Button";
 import { LinkFilters, LinkFilter } from "../../link-filters/LinkFilters";
 import {
   ListDashboard,
   ListDashboardProps,
 } from "../../Lists/list-dashboard/ListDashboard";
+import Modal from "../Modal";
 
 export type ModalProfileProps = {
   showModal: boolean;
@@ -25,74 +23,46 @@ export const ModalProfile: React.FC<ModalProfileProps> = ({
   headerLinkText,
   notifications,
   profileNavLinks,
-}) => {
+}) => (
   <div className="modal-backdrop">
+    <Modal shownModal={showModal} classNames="modal-profile modal-right">
+      <ModalHeader
+        headerName={headerName}
+        headerLinkHref={headerLinkHref}
+        headerLinkText={headerLinkText}
+      />
 
-  useEffect(() => {
-    setShownModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShownModal(!showModal);
-  };
-
-  if (!showModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
-  return (
-    <div className="modal__backdrop">
-      <div
-        className={`modal modal-profile modal-right ${
-          shownModal ? "modal-show" : ""
-        }`}
-      >
-        <div className="modal__screen-reader-description" id="describemodal">
-          Denne modal dækker sidens indhold, og er en demo
-        </div>
-        <ModalCloseButton
-          idAriaDescribedBy="describemodal"
-          toggleModal={toggleModal}
-        />
-
-        <ModalHeader
-          headerName={headerName}
-          headerLinkHref={headerLinkHref}
-          headerLinkText={headerLinkText}
-        />
-
-        <div className="modal-profile__notifications">
-          {notifications.map((item, index) => (
-            <div key={index} className="modal-profile__notification-item">
-              <ListDashboard
-                title={item.title}
-                number={item.number}
-                label={item.label}
-                showDot={item.showDot}
-                href={item.href}
-              />
-            </div>
-          ))}
-        </div>
-
-        <div className="modal-profile__container">
-          <div className="modal-profile__links">
-            <LinkFilters filters={profileNavLinks} />
-          </div>
-          <div className="modal-profile__btn-logout">
-            <Button
-              buttonType="default"
-              size="medium"
-              variant="filled"
-              label="Log ud"
-              disabled={false}
-              collapsible={false}
+      <div className="modal-profile__notifications">
+        {notifications.map((item, index) => (
+          <div key={index} className="modal-profile__notification-item">
+            <ListDashboard
+              title={item.title}
+              number={item.number}
+              label={item.label}
+              showDot={item.showDot}
+              href={item.href}
             />
           </div>
+        ))}
+      </div>
+
+      <div className="modal-profile__container">
+        <div className="modal-profile__links">
+          <LinkFilters filters={profileNavLinks} />
+        </div>
+        <div className="modal-profile__btn-logout">
+          <Button
+            buttonType="default"
+            size="medium"
+            variant="filled"
+            label="Log ud"
+            disabled={false}
+            collapsible={false}
+          />
         </div>
       </div>
-    </div>
-  );
-};
+    </Modal>
+  </div>
+);
 
 export default ModalProfile;

--- a/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
+++ b/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
@@ -26,7 +26,7 @@ export const ModalProfile: React.FC<ModalProfileProps> = ({
   notifications,
   profileNavLinks,
 }) => {
-  const [shownModal, setShownModal] = useState(showModal);
+  <div className="modal-backdrop">
 
   useEffect(() => {
     setShownModal(showModal);

--- a/src/stories/Library/Modals/modal-search/ModalSearch.tsx
+++ b/src/stories/Library/Modals/modal-search/ModalSearch.tsx
@@ -1,6 +1,3 @@
-import { useEffect, useState } from "react";
-
-import { ModalFallbackButton } from "../ModalShared";
 import { Button } from "../../Buttons/button/Button";
 import Modal from "../Modal";
 
@@ -9,26 +6,8 @@ export type ModalSearchProps = {
 };
 
 export const ModalSearch: React.FC<ModalSearchProps> = ({ showModal }) => {
-  const [shouldShowModal, setShouldShowModal] = useState(showModal);
-
-  useEffect(() => {
-    setShouldShowModal(showModal);
-  }, [showModal]);
-
-  const toggleModal = () => {
-    setShouldShowModal(!shouldShowModal);
-  };
-
-  if (!shouldShowModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
   return (
-    <Modal
-      shownModal={shouldShowModal}
-      classNames="modal-search modal-padding"
-      toggleModal={toggleModal}
-    >
+    <Modal shownModal={showModal} classNames="modal-search modal-padding">
       <div className="modal-search__container">
         <h3 className="text-header-h3">Gem søgning</h3>
         <div className="mt-48 color-secondary-gray">

--- a/src/stories/Library/Modals/modal-text/ModalText.tsx
+++ b/src/stories/Library/Modals/modal-text/ModalText.tsx
@@ -1,6 +1,3 @@
-import { useEffect, useState } from "react";
-
-import { ModalFallbackButton } from "../ModalShared";
 import { Button } from "../../Buttons/button/Button";
 import { Links } from "../../links/Links";
 import Modal from "../Modal";
@@ -19,34 +16,9 @@ export type ModalTextProps = {
 };
 
 export const ModalText = (props: ModalTextProps) => {
-  const {
-    title,
-    subtitle,
-    textContent,
-    linkText,
-    btnLabel,
-    showModal: showModalProp,
-  } = props;
-  const [showModal, setShow] = useState(showModalProp);
-
-  useEffect(() => {
-    setShow(showModalProp);
-  }, [showModalProp]);
-
-  const toggleModal = () => {
-    setShow(!showModal);
-  };
-
-  if (!showModal) {
-    return <ModalFallbackButton toggleModal={toggleModal} />;
-  }
-
+  const { title, subtitle, textContent, linkText, btnLabel, showModal } = props;
   return (
-    <Modal
-      shownModal={showModal}
-      classNames="modal-text modal-padding"
-      toggleModal={toggleModal}
-    >
+    <Modal shownModal={showModal} classNames="modal-text modal-padding">
       <div className="modal-text__container color-secondary-gray">
         <h3 className="text-header-h3">{title}</h3>
 

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -27,16 +27,6 @@
     @include hide-visually;
   }
 
-  &__backdrop {
-    display: block;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-color: hsla(0, 0%, 15%, 1);
-  }
-
   @include breakpoint-m {
     padding: $s-4xl $s-7xl;
   }
@@ -63,4 +53,18 @@
   right: 0;
   max-width: 560px;
   width: 100%;
+}
+
+.modal-backdrop {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: hsla(0, 0%, 15%, 1);
+}
+
+.modal--no-padding {
+  padding: 0;
 }


### PR DESCRIPTION
### Move logic to show modal into the Modal component
All the logic for toggle css class .modal-show is now collected in the component. it means that changes only have to take place in one place and that the various components become more readable

### Rename and move .modal-backdrop to its own css class
Since it is not an element but a block by itself, it must have its own css class
**I have checked in [dpl-react] and it is not used there yet, so this should not cause problems**