### PR TITLE
Use min-width: 100% for an "image only" campaign to handle small images

### DIFF
--- a/src/stories/Library/campaign/campaign.scss
+++ b/src/stories/Library/campaign/campaign.scss
@@ -20,6 +20,7 @@
     &.campaign__image--full-width {
       @include breakpoint-s {
         max-width: 100%;
+        min-width: 100%;
       }
     }
   }


### PR DESCRIPTION
If the image is small, we need to use min-width together with breakpoint max-width to overwrite regular campaign's image breakpoint (where the max-width is set to 30%).