### PR TITLE
CMN-293: add  screen-reader-description

### DIFF
--- a/src/stories/Library/list-buttons/ListButtons.tsx
+++ b/src/stories/Library/list-buttons/ListButtons.tsx
@@ -15,6 +15,14 @@ export const ListButton: React.FC<ListButtonProps> = ({
 }) => {
   return (
     <div className="dpl-list-buttons">
+      <div
+        className="dpl-list-buttons__screen-reader-description"
+        id="renew-multiple-modal"
+      >
+        This button opens a modal that covers the entire page and contains loans
+        with different due dates, if some of the loans in the modal are
+        renewable you can renew them
+      </div>
       <h2 className="dpl-list-buttons__header">
         {header}
         <div className="dpl-list-buttons__power">{number}</div>
@@ -32,7 +40,10 @@ export const ListButton: React.FC<ListButtonProps> = ({
             src="icons/collection/Various.svg"
           />
         </div>
-        <div className="dpl-list-buttons__buttons__button">
+        <div
+          className="dpl-list-buttons__buttons__button"
+          aria-describedby="renew-multiple-modal"
+        >
           <Button
             label={buttonLabel}
             buttonType="none"

--- a/src/stories/Library/list-buttons/list-buttons.scss
+++ b/src/stories/Library/list-buttons/list-buttons.scss
@@ -39,3 +39,15 @@
     display: flex;
   }
 }
+
+.dpl-list-buttons__screen-reader-description {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  // Should include "hide-visually", but it doesn't work, I suspect due to import order
+  // @include hide-visually;
+}


### PR DESCRIPTION
#### Link to issue

Link til låneliste ? -> https://platform.dandigbib.org/issues/5387

#### Description

Hidden explanation for screen readers

#### Screenshot of the result

<img width="379" alt="image" src="https://user-images.githubusercontent.com/15377965/204289395-5484cf01-4cc0-4b98-a750-a7fbcfb9d5c9.png">

:)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

