### PR TITLE
Implementing hover-based underlining for searchResultItem title

### DIFF
--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -39,7 +39,9 @@ export const SearchResultItem = ({
           )}
         </div>
 
-        <h2 className="search-result-item__title text-header-h4">{title}</h2>
+        <h2 className="search-result-item__title text-header-h4">
+          <a href="">{title}</a>
+        </h2>
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>
       </div>
       <div className="search-result-item__availability">

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -66,6 +66,14 @@
 .search-result-item__title {
   margin-top: 10px;
 
+  & > a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   @include breakpoint-s {
     margin-top: 16px;
   }


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-357

#### This pull request adds hover-based underlining to the search result item titles.

Previously, the titles were always displayed with an underline (if there is an a tag around the title). By implementing hover-based underlining, the underlines will only be displayed when the user hovers their cursor over the title. This improves the visual appeal and user experience of the search results page.

#### Screenshot of the result
The first element is shown with a hover
![Skærmbillede 2022-12-20 kl  15 59 56 (3)](https://user-images.githubusercontent.com/49920322/208697335-cbb7fdc0-8a06-4f30-8bf8-580e3a13e955.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

* The underline could not be seen in the design system, but it could be seen in dpl-react, because we have used a link tag around the title.
