### PR TITLE
5548: move margin

### DIFF
--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -90,13 +90,13 @@ $list-reservation-space-desktop: 24px;
   p {
     margin-top: 2px;
     font-size: 14px;
-    margin-bottom: $s-md;
   }
 
   @include breakpoint-s {
     margin-top: 0;
     p {
       font-size: 12px;
+      margin-bottom: $s-md;
     }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5546

#### Description

Fix error from previous pr, margin was supposed to be on mobile

#### Screenshot of the result

<img width="362" alt="image" src="https://user-images.githubusercontent.com/15377965/208846088-389b7894-cc40-498e-a31d-187f3e0494bf.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

