### PR TITLE
5548: margin zero on deskop

### DIFF
--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -97,6 +97,7 @@ $list-reservation-space-desktop: 24px;
     margin-top: 0;
     p {
       font-size: 12px;
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5548

#### Description

Margin zero on desktop, so the author and serie title does not have space between them 

#### Screenshot of the result

<img width="709" alt="image" src="https://user-images.githubusercontent.com/15377965/208847497-c01ebf42-f1ac-48eb-8dc6-1e005ce894a0.png">



