### PR TITLE
Unify the search result cards

### DIFF
--- a/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
@@ -44,6 +44,7 @@ export default {
       },
     },
     availabilityLabels: {
+      // The control is disabled because we use stories to explore different availability label counts.
       control: { type: "null" },
       defaultValue: 3,
     },

--- a/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
@@ -61,7 +61,7 @@ Item.args = {};
 export const ContentOverload = Template.bind({});
 ContentOverload.args = {
   title:
-    "Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn",
+    "En roman om Jon og hans breve til sin gravide kone, da han opholdt sig i en grotte hen over vinteren og forberedte hendes ankomst og de nye tider (dansk)",
   author: "Sánchez Vegara, Amaia Arrazola, Sánchez Vegara, et al.",
   availabilityLabels: 25,
 };

--- a/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
@@ -30,7 +30,6 @@ export default {
       control: { type: "text" },
       defaultValue: "2018",
     },
-
     horizontalTermLineData: {
       control: { type: "object" },
       defaultValue: {
@@ -44,6 +43,10 @@ export default {
         ],
       },
     },
+    availabilityLabels: {
+      control: { type: "null" },
+      defaultValue: 3,
+    },
   },
 } as ComponentMeta<typeof SearchResultItem>;
 
@@ -53,3 +56,11 @@ const Template: ComponentStory<typeof SearchResultItem> = (args) => {
 
 export const Item = Template.bind({});
 Item.args = {};
+
+export const ContentOverload = Template.bind({});
+ContentOverload.args = {
+  title:
+    "Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn Audrey Hepburn",
+  author: "Sánchez Vegara, Amaia Arrazola, Sánchez Vegara, et al.",
+  availabilityLabels: 25,
+};

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -1,4 +1,5 @@
 import { AvailabilityLabel } from "../availability-label/AvailabilityLabel";
+import { AvailabilityLabelPropsType } from "../../availability-label/types";
 import { Cover } from "../cover/Cover";
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
 import { ButtonFavourite } from "../Buttons/button-favourite/ButtonFavourite";
@@ -23,6 +24,13 @@ export const SearchResultItem = ({
   horizontalTermLineData,
   availabilityLabels,
 }: SearchResultItemProps) => {
+  const materialTypes: AvailabilityLabelPropsType["manifestationType"][] = [
+    "Bog",
+    "Ebog",
+    "Lydbog (net)",
+    "Lydbog (cd-mp3)",
+  ];
+
   return (
     <a href="/" className="search-result-item arrow arrow__hover--right-small">
       <div className="search-result-item__cover">
@@ -47,12 +55,14 @@ export const SearchResultItem = ({
       <div className="search-result-item__availability">
         {Array(availabilityLabels)
           .fill(0)
-          .map(() => {
+          .map((_value, index) => {
             return (
               <AvailabilityLabel
-                manifestationType="Lydbog (cd-mp3)"
+                manifestationType={
+                  index < 4 ? materialTypes[index] : materialTypes[index % 4]
+                }
                 availability="Hjemme"
-                status="available"
+                status={index % 2 === 0 ? "available" : "unavailable"}
               />
             );
           })}

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -12,6 +12,7 @@ export type SearchResultItemProps = {
   author: string;
   year: string;
   horizontalTermLineData?: HorizontalTermLineProps;
+  availabilityLabels: number;
 };
 
 export const SearchResultItem = ({
@@ -20,6 +21,7 @@ export const SearchResultItem = ({
   author,
   year,
   horizontalTermLineData,
+  availabilityLabels,
 }: SearchResultItemProps) => {
   return (
     <a href="/" className="search-result-item arrow arrow__hover--right-small">
@@ -43,27 +45,17 @@ export const SearchResultItem = ({
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>
       </div>
       <div className="search-result-item__availability">
-        <AvailabilityLabel
-          manifestationType="Bog"
-          availability="Hjemme"
-          status="available"
-        />
-        <AvailabilityLabel
-          manifestationType="Ebog"
-          availability="Online"
-          status="available"
-        />
-
-        <AvailabilityLabel
-          manifestationType="Lydbog (cd-mp3)"
-          availability="Udlånt"
-          status="unavailable"
-        />
-        <AvailabilityLabel
-          manifestationType="Lydbog (net)"
-          availability="Online"
-          status="available"
-        />
+        {Array(availabilityLabels)
+          .fill(0)
+          .map(() => {
+            return (
+              <AvailabilityLabel
+                manifestationType="Lydbog (cd-mp3)"
+                availability="Hjemme"
+                status="available"
+              />
+            );
+          })}
       </div>
 
       <ArrowSmallRight />

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -53,10 +53,13 @@ export const SearchResultItem = ({
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>
       </div>
       <div className="search-result-item__availability">
+        {/* We render the amount of availability labels defined by the story. */}
         {Array(availabilityLabels)
           .fill(0)
           .map((_value, index) => {
             return (
+              // To emulate a more realistic view, we render a mix of available & unavailable
+              // labels and cycle through different material types.
               <AvailabilityLabel
                 manifestationType={
                   index < 4 ? materialTypes[index] : materialTypes[index % 4]

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -71,7 +71,6 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     margin-top: 16px;
-    max-width: 407px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -67,6 +67,12 @@
   margin-top: 10px;
 
   @include breakpoint-s {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     margin-top: 16px;
+    max-width: 407px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -8,7 +8,7 @@
   text-decoration: none;
 
   @include breakpoint-s {
-    height: 184px;
+    min-height: 184px;
     gap: 0;
     padding: 24px;
     grid-template-columns: min-content minmax(min-content, 407px) 1fr max-content;

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -9,7 +9,6 @@
   min-height: 184px;
 
   @include breakpoint-s {
-    min-height: 184px;
     gap: 0;
     padding: 24px;
     grid-template-columns: min-content minmax(min-content, 407px) 1fr max-content;

--- a/src/stories/Library/search-result-page/SearchResultPageData.ts
+++ b/src/stories/Library/search-result-page/SearchResultPageData.ts
@@ -9,6 +9,7 @@ const searchResult = [
     year: "2018",
     seriesNumber: "3",
     series: "Små mennesker, store drømme",
+    availabilityLabels: 1,
   },
   {
     coverUrl: "images/book_cover_2.jpg",
@@ -16,6 +17,7 @@ const searchResult = [
     title: "De uadskillelige",
     author: "Simone de Beauvoir",
     year: "2020",
+    availabilityLabels: 3,
   },
   {
     coverUrl: "images/book_cover_3.jpg",
@@ -23,6 +25,7 @@ const searchResult = [
     title: "Døgnkioskmennesket",
     author: "Sayaka Murata",
     year: "2019",
+    availabilityLabels: 4,
   },
   {
     coverUrl: "images/book_cover_4.jpg",
@@ -30,6 +33,7 @@ const searchResult = [
     title: "Testamente",
     author: "Nina Wähä (f. 1979)",
     year: "2019",
+    availabilityLabels: 3,
   },
   {
     coverUrl: "images/book_cover_5.jpg",
@@ -37,6 +41,7 @@ const searchResult = [
     title: "Sønnen (Norsk)",
     author: "Jo Nesbø",
     year: "2014",
+    availabilityLabels: 2,
   },
   {
     coverUrl: "images/book_cover_6.jpg",
@@ -44,6 +49,7 @@ const searchResult = [
     title: "Den bæredygtige stat",
     author: "Rasmus Willig, Anders Blok",
     year: "2020",
+    availabilityLabels: 2,
   },
   {
     coverUrl: "images/book_cover_7.jpg",
@@ -51,6 +57,7 @@ const searchResult = [
     title: "Den lille bog om dansk design - for børn og barnlige sjæle",
     author: "Marie Hugsted",
     year: "2018",
+    availabilityLabels: 2,
   },
   {
     coverUrl: "images/book_cover_8.jpg",
@@ -58,6 +65,7 @@ const searchResult = [
     title: "Den lille prins (Ved Henrik Ægidius)",
     author: "Antoine de Saint-Exupéry",
     year: "2016",
+    availabilityLabels: 2,
   },
   {
     coverUrl: "images/book_cover_9.jpg",
@@ -65,6 +73,7 @@ const searchResult = [
     title: "Yayoi Kusama",
     author: "",
     year: "2014",
+    availabilityLabels: 2,
   },
   {
     coverUrl: "images/book_cover_10.jpg",
@@ -72,6 +81,7 @@ const searchResult = [
     title: "Kvinde kend din historie - spejl dig i fortiden",
     author: "Gry Jexen",
     year: "2021",
+    availabilityLabels: 2,
   },
 ];
 
@@ -103,4 +113,8 @@ const selectedTerms = [
   { title: "Spil", facet: "workTypes", type: "term", score: 21 },
 ] as FacetLineItem<"term">[];
 
-export default { searchResult, facetLineItems, selectedTerms };
+export default {
+  searchResult,
+  facetLineItems,
+  selectedTerms,
+};


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-8

#### Description
The search result cards had fixed height, which didn't account for content overload. This resulted in the excess content to bleed out of the cards - in some cases even overlaying other elements on the page. 
Now we make sure that on desktop long titles get cut off after two lines, and suffixed with three dots. If there are too many availability labels present, the whole card expands in height. 
Mobile implementation stays the same - cards expand and titles are always shown in their full length. 

#### Screenshot of the result
mobile: 
![image](https://user-images.githubusercontent.com/28546954/209943192-b47fa211-35bd-4446-9826-f5a600df2888.png)

desktop:
![image](https://user-images.githubusercontent.com/28546954/209943235-d883f094-8e85-4688-801e-a5e603903d49.png)

![image](https://user-images.githubusercontent.com/28546954/211551233-d086c0e5-08ea-4612-9aec-a4a3bac17556.png)



#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
