### PR TITLE
Set min height on search result items

### DIFF
--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -9,6 +9,7 @@
   min-height: 184px;
 
   @include breakpoint-s {
+    height: 184px;
     gap: 0;
     padding: 24px;
     grid-template-columns: min-content minmax(min-content, 407px) 1fr max-content;

--- a/src/stories/Library/search-result-item/search-result-item.scss
+++ b/src/stories/Library/search-result-item/search-result-item.scss
@@ -6,9 +6,9 @@
   gap: 22px 16px;
   cursor: pointer;
   text-decoration: none;
+  min-height: 184px;
 
   @include breakpoint-s {
-    height: 184px;
     gap: 0;
     padding: 24px;
     grid-template-columns: min-content minmax(min-content, 407px) 1fr max-content;


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-356

#### Description

Sets min height on search result items In order to reduce cumulative layout shift.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

