### PR TITLE
Add skeleton screen css for loading state style

### DIFF
--- a/architecture/adr-001-skeleton-screens.md
+++ b/architecture/adr-001-skeleton-screens.md
@@ -1,0 +1,36 @@
+# Architecture Decision Record: Skeleton Screens
+
+## Context
+
+In the work of trying to improve the performance of the search results
+we needed a way to fill the viewport with a simulated interface in order to:
+
+* Show some content immediately to the user
+* Prevent layout shifting between loading state and ready state
+
+## Decision
+
+We decided to implement skeleton screens when loading data. The skeleton screens
+are rendered in pure css.
+The css classes are coming from the library: skeleton-screen-css
+
+## Alternatives considered
+
+The library is very small and based on simple css rules, so we could have
+considered replicating it in our own design system or make something similar.
+But by using the open source library we are ensured, to a certain extent,
+that the code is being maintained, corrected and evolves as time goes by.
+
+We could also have chosen to use images or GIF's to render the screens.
+But by using the simple toolbox of skeleton-screen-css we should be able
+to make screens for all the different use cases in the different apps.
+
+## Consequences
+
+It is now possible, with a limited amount of work, to construct skeleton screens
+in the loading state of the various user interfaces.
+
+Because we use library where skeletons are implemented purely in CSS
+we also provide a solution which can be consumed in any technology
+already using the design system without any additional dependencies,
+client side or server side.

--- a/architecture/adr-001-skeleton-screens.md
+++ b/architecture/adr-001-skeleton-screens.md
@@ -34,3 +34,10 @@ Because we use library where skeletons are implemented purely in CSS
 we also provide a solution which can be consumed in any technology
 already using the design system without any additional dependencies,
 client side or server side.
+
+### BEM rules when using Skeleton Screen Classes in dpl-design-system
+
+Because we want to use existing styling setup in conjunction
+with the Skeleton Screen Classes we sometimes need to ignore the existing
+BEM rules that we normally comply to.
+See eg. the [search result styling](../src/stories/Library/search-result-item/search-result-item-skeleton.scss).

--- a/base.scss
+++ b/base.scss
@@ -1,5 +1,6 @@
 @import "./src/styles/scss/reset";
 @import "./src/stories/Library/colors/color-variables";
+@import "./src/styles/scss/skeleton";
 
 // The imports below are not advised to be moved around, because
 // they cross-reference various defined variables between each other.
@@ -38,6 +39,7 @@
 @import "./src/stories/Library/autosuggest-material/autosuggest-material";
 @import "./src/stories/Library/material-card/material-card";
 @import "./src/stories/Library/search-result-item/search-result-item";
+@import "./src/stories/Library/search-result-item/search-result-item-skeleton";
 @import "./src/stories/Library/Lists/list-reservation/list-reservation";
 @import "./src/stories/Library/Lists/list-dashboard/list-dashboard";
 @import "./src/stories/Library/Lists/list-description/list-description";

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
     "sass": "^1.53.0",
+    "skeleton-screen-css": "^1.1.0",
     "storybook-addon-designs": "^6.2.1",
     "stylelint": "^14.10.0",
     "stylelint-config-prettier": "^9.0.3",

--- a/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.stories.tsx
@@ -2,6 +2,7 @@ import { withDesign } from "storybook-addon-designs";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SearchResultItem } from "./SearchResultItem";
+import { SearchResultItemSkeleton } from "./SearchResultItemSkeleton";
 
 export default {
   title: "Library / Search Result Item",
@@ -51,17 +52,20 @@ export default {
   },
 } as ComponentMeta<typeof SearchResultItem>;
 
-const Template: ComponentStory<typeof SearchResultItem> = (args) => {
+export const Item: ComponentStory<typeof SearchResultItem> = (args) => {
   return <SearchResultItem {...args} />;
 };
 
-export const Item = Template.bind({});
-Item.args = {};
-
-export const ContentOverload = Template.bind({});
+export const ContentOverload = Item.bind({});
 ContentOverload.args = {
   title:
     "En roman om Jon og hans breve til sin gravide kone, da han opholdt sig i en grotte hen over vinteren og forberedte hendes ankomst og de nye tider (dansk)",
   author: "Sánchez Vegara, Amaia Arrazola, Sánchez Vegara, et al.",
   availabilityLabels: 25,
+};
+
+export const SkeletonItem: ComponentStory<
+  typeof SearchResultItemSkeleton
+> = () => {
+  return <SearchResultItemSkeleton />;
 };

--- a/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
@@ -1,0 +1,14 @@
+export const SearchResultItemSkeleton = () => {
+  return (
+    <div className="search-result-item arrow arrow__hover--right-small ssc">
+      <div className="ssc-square">&nbsp;</div>
+      <div className="ssc-wrapper w-80">
+        <div className="ssc-head-line w-60 mb" />
+        <div className="ssc-line w-60 mbs">&nbsp;</div>
+        <div className="ssc-line w-60 mbs">&nbsp;</div>
+      </div>
+    </div>
+  );
+};
+
+export default {};

--- a/src/stories/Library/search-result-item/search-result-item-skeleton.scss
+++ b/src/stories/Library/search-result-item/search-result-item-skeleton.scss
@@ -1,3 +1,7 @@
+// Since we are using the Skeleton Screen Css classes connected to the existing styling
+// we deliberately not follow the BEM naming convention here.
+/* stylelint-disable plugin/stylelint-bem-namics */
+
 .search-result-item {
   &.ssc {
     grid-template-columns: min-content 1fr;
@@ -11,3 +15,4 @@
     @extend %mt-16;
   }
 }
+/* stylelint-enable plugin/stylelint-bem-namics */

--- a/src/stories/Library/search-result-item/search-result-item-skeleton.scss
+++ b/src/stories/Library/search-result-item/search-result-item-skeleton.scss
@@ -1,0 +1,13 @@
+.search-result-item {
+  &.ssc {
+    grid-template-columns: min-content 1fr;
+  }
+  .ssc-square {
+    @extend %mr-16;
+    width: 100px;
+    height: 140px;
+  }
+  .ssc-head-line {
+    @extend %mt-16;
+  }
+}

--- a/src/styles/scss/skeleton.scss
+++ b/src/styles/scss/skeleton.scss
@@ -1,0 +1,3 @@
+$skeleton-line-border-radius: 3px;
+
+@import "../../../node_modules/skeleton-screen-css/dist/index";

--- a/yarn.lock
+++ b/yarn.lock
@@ -13910,6 +13910,11 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+skeleton-screen-css@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/skeleton-screen-css/-/skeleton-screen-css-1.1.0.tgz#27f7566164a0229a6f51427bc9f15dba3e2166a0"
+  integrity sha512-lk5fHivmKKvK1g+VbvPgW5vro2aNwAIzTiF3RTKhv35e/p8MscVlkcziDY5kqCNWrFGF3fUL8f0djg6mMRtGDQ==
+
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-374

#### Description

Add skeleton screen css for loading state style and implement it on a search result

#### Screenshot of the result

<img width="738" alt="image" src="https://user-images.githubusercontent.com/998889/211085304-596170d1-c0a7-45c6-8bd1-7846de0d469a.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

