### PR TITLE
Adding text-loading class

### DIFF
--- a/src/stories/Library/search-result-page/ResultPager.tsx
+++ b/src/stories/Library/search-result-page/ResultPager.tsx
@@ -1,15 +1,16 @@
 import { Button } from "../Buttons/button/Button";
 
 interface ResultPagerProps {
-  currentResults: string;
-  totalResults: string;
+  currentResults: number;
+  totalResults: number;
 }
 
 const ResultPager = ({ currentResults, totalResults }: ResultPagerProps) => {
+  const total = totalResults.toLocaleString("da-Dk");
   return (
     <div className="result-pager">
       <p className="text-small-caption result-pager__title">
-        {`Viser ${currentResults} ud af ${totalResults} resultater`}
+        {`Viser ${currentResults} ud af ${total} resultater`}
       </p>
       <Button
         label="VIS FLERE"

--- a/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
@@ -18,8 +18,8 @@ export default {
       defaultValue: "harry potter",
     },
     totalResults: {
-      control: { type: "text" },
-      defaultValue: "3.576",
+      control: { type: "number" },
+      defaultValue: 3576,
     },
     linkName: {
       control: { type: "text" },
@@ -30,8 +30,8 @@ export default {
       defaultValue: "8",
     },
     currentResults: {
-      control: { type: "text" },
-      defaultValue: "10",
+      control: { type: "number" },
+      defaultValue: 10,
     },
 
     zeroResult: {

--- a/src/stories/Library/search-result-page/SearchResultPage.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPage.tsx
@@ -9,8 +9,8 @@ import data from "./SearchResultPageData";
 
 export type SearchResultPageProps = {
   title: string;
-  currentResults: string;
-  totalResults: string;
+  currentResults: number;
+  totalResults: number;
   linkName: string;
   linkTotalResults: string;
   zeroResult: boolean;
@@ -32,7 +32,7 @@ export const SearchResultPage = ({
     <div className="search-result-page">
       <SearchResultTitle
         title={title}
-        totalResults={zeroResult ? "0" : totalResults}
+        totalResults={zeroResult ? 0 : totalResults}
         zeroResult={zeroResult}
       />
       {zeroResult ? (

--- a/src/stories/Library/search-result-page/SearchResultTitle.stories.tsx
+++ b/src/stories/Library/search-result-page/SearchResultTitle.stories.tsx
@@ -1,0 +1,36 @@
+import { withDesign } from "storybook-addon-designs";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { SearchResultTitle } from "./SearchResultTitle";
+
+export default {
+  title: "Blocks / Search Result Header Title",
+  component: SearchResultTitle,
+  decorators: [withDesign],
+  argTypes: {
+    title: {
+      control: { type: "text" },
+      defaultValue: "harry potter",
+    },
+    totalResults: {
+      control: { type: "number" },
+      defaultValue: 100,
+    },
+    zeroResult: {
+      description: "Do we have zero results?",
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    isLoading: {
+      description: "Are we in a loading state?",
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+  },
+} as ComponentMeta<typeof SearchResultTitle>;
+
+const Template: ComponentStory<typeof SearchResultTitle> = (args) => {
+  return <SearchResultTitle {...args} />;
+};
+
+export const Item = Template.bind({});
+Item.args = {};

--- a/src/stories/Library/search-result-page/SearchResultTitle.stories.tsx
+++ b/src/stories/Library/search-result-page/SearchResultTitle.stories.tsx
@@ -34,3 +34,13 @@ const Template: ComponentStory<typeof SearchResultTitle> = (args) => {
 
 export const Item = Template.bind({});
 Item.args = {};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  isLoading: true,
+};
+
+export const ZeroResults = Template.bind({});
+ZeroResults.args = {
+  zeroResult: true,
+};

--- a/src/stories/Library/search-result-page/SearchResultTitle.tsx
+++ b/src/stories/Library/search-result-page/SearchResultTitle.tsx
@@ -16,6 +16,7 @@ export const SearchResultTitle = ({
   const classes = clsx(["text-header-h2", "mb-16", "search-result-title"], {
     "text-loading": isLoading,
   });
+  const total = totalResults.toLocaleString("da-Dk");
 
   if (zeroResult) {
     return <h1 className={classes}>Din søgning gav 0 resultater</h1>;
@@ -24,7 +25,7 @@ export const SearchResultTitle = ({
   return (
     <h1 className={classes}>
       {isLoading && `Viser resultater for “${title}”`}
-      {!isLoading && `Viser resultater for “${title}” (${totalResults})`}
+      {!isLoading && `Viser resultater for “${title}” (${total})`}
     </h1>
   );
 };

--- a/src/stories/Library/search-result-page/SearchResultTitle.tsx
+++ b/src/stories/Library/search-result-page/SearchResultTitle.tsx
@@ -1,25 +1,30 @@
+import clsx from "clsx";
+
 export type SearchResultTitleProps = {
   title: string;
-  totalResults: string;
+  totalResults: number;
   zeroResult: boolean;
+  isLoading?: boolean;
 };
 
 export const SearchResultTitle = ({
   title,
   totalResults,
   zeroResult,
+  isLoading = false,
 }: SearchResultTitleProps) => {
+  const classes = clsx(["text-header-h2", "mb-16", "search-result-title"], {
+    "text-loading": isLoading,
+  });
+
   if (zeroResult) {
-    return (
-      <h1 className="text-header-h2 mb-16 search-result-title">
-        Din søgning gav 0 resultater
-      </h1>
-    );
+    return <h1 className={classes}>Din søgning gav 0 resultater</h1>;
   }
 
   return (
-    <h1 className="text-header-h2 mb-16 search-result-title">
-      {`Viser resultater for “${title}” (${totalResults})`}
+    <h1 className={classes}>
+      {isLoading && `Viser resultater for “${title}”`}
+      {!isLoading && `Viser resultater for “${title}” (${totalResults})`}
     </h1>
   );
 };

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -113,15 +113,3 @@
     width: 1.25em;
   }
 }
-
-@-webkit-keyframes ellipsis {
-  to {
-    width: 1.25em;
-  }
-}
-
-@-moz-keyframes ellipsis {
-  to {
-    width: 1.25em;
-  }
-}

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -95,3 +95,33 @@
 .cursor-pointer {
   cursor: pointer;
 }
+
+// When class is used on a block element it will show a loading ellipsis animation.
+.text-loading:after {
+  overflow: hidden;
+  display: inline-block;
+  vertical-align: bottom;
+  animation: ellipsis 1.7s infinite;
+  -webkit-animation: ellipsis 1.7s infinite;
+  -moz-animation: ellipsis 1.7s infinite;
+  content: "\2026"; /* ascii code for the ellipsis character */
+  width: 0px;
+}
+
+@keyframes ellipsis {
+  to {
+    width: 1.25em;
+  }
+}
+
+@-webkit-keyframes ellipsis {
+  to {
+    width: 1.25em;
+  }
+}
+
+@-moz-keyframes ellipsis {
+  to {
+    width: 1.25em;
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-371

#### Description

To be used for show loading state in a text.
Adds animated ellipsis to the end of a text.
Used by the search header title in the first place.

#### Screenshot of the result

![loading](https://user-images.githubusercontent.com/998889/211199999-a94cb0d9-fb27-439f-a7de-37252f4580d0.gif)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

