### PR TITLE
adding class to prevent background from scrolling

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -86,7 +86,7 @@
 @import "./src/stories/Library/promo-bar/promo-bar";
 @import "./src/stories/Library/Lists/list-intermediates/list-intermediates";
 @import "./src/stories/Library/instant-loan/instant-loan";
-@import "./src/stories/Library/scroll-lock-background/";
+@import "./src/stories/Library/scroll-lock-background/scroll-lock-background";
 
 // Blocks
 @import "./src/stories/Blocks/footer/footer";

--- a/base.scss
+++ b/base.scss
@@ -86,6 +86,7 @@
 @import "./src/stories/Library/promo-bar/promo-bar";
 @import "./src/stories/Library/Lists/list-intermediates/list-intermediates";
 @import "./src/stories/Library/instant-loan/instant-loan";
+@import "./src/stories/Library/scroll-lock-background/";
 
 // Blocks
 @import "./src/stories/Blocks/footer/footer";

--- a/src/stories/Library/scroll-lock-background/scroll-lock-background.scss
+++ b/src/stories/Library/scroll-lock-background/scroll-lock-background.scss
@@ -1,0 +1,4 @@
+.scroll-lock-background {
+  overflow: "hidden";
+  height: "100vh";
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5533

PR which uses this class:
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/311

#### Description

A class for toggling a scroll-lock. Applied to elements behind an open modal to prevent scrolling.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

