### PR TITLE
Refactor Cover identity tint

### DIFF
--- a/src/stories/Blocks/material-banner/MaterialBanner.stories.tsx
+++ b/src/stories/Blocks/material-banner/MaterialBanner.stories.tsx
@@ -49,7 +49,7 @@ Item.args = {
         url: "images/book_cover_3.jpg",
         animate: true,
         size: "medium",
-        tint: "60",
+        tint: "100",
       },
     },
     {
@@ -104,7 +104,7 @@ Item.args = {
         url: "images/book_cover_2.jpg",
         animate: true,
         size: "medium",
-        tint: "60",
+        tint: "100",
       },
     },
   ],

--- a/src/stories/Library/Modals/modal-details/ModalDetails.tsx
+++ b/src/stories/Library/Modals/modal-details/ModalDetails.tsx
@@ -61,7 +61,7 @@ const materialCards: MaterialCardProps[] = [
       url: "images/book_cover_3.jpg",
       animate: true,
       size: "medium",
-      tint: "60",
+      tint: "100",
     },
   },
   {

--- a/src/stories/Library/colors/color-classes.scss
+++ b/src/stories/Library/colors/color-classes.scss
@@ -83,14 +83,14 @@
   background-color: var(--tint-color-40);
 }
 
-%bg-identity-tint-60,
-.bg-identity-tint-60 {
-  background-color: var(--tint-color-60);
-}
-
 %bg-identity-tint-80,
 .bg-identity-tint-80 {
   background-color: var(--tint-color-80);
+}
+
+%bg-identity-tint-100,
+.bg-identity-tint-100 {
+  background-color: var(--tint-color-100);
 }
 
 %bg-identity-tint-120,

--- a/src/stories/Library/colors/color-variables.scss
+++ b/src/stories/Library/colors/color-variables.scss
@@ -28,8 +28,8 @@ $c-signal-alert: #d5364a;
     var(--identity-color-l);
   --tint-color-20: hsl(var(--identity-color), 0.2);
   --tint-color-40: hsl(var(--identity-color), 0.4);
-  --tint-color-60: hsl(var(--identity-color), 0.6);
   --tint-color-80: hsl(var(--identity-color), 0.8);
+  --tint-color-100: hsl(var(--identity-color), 1);
   --tint-color-120: hsl(
     var(--identity-color-h),
     calc(var(--identity-color-s) - 1%),

--- a/src/stories/Library/colors/identity-color/IdentityColor.tsx
+++ b/src/stories/Library/colors/identity-color/IdentityColor.tsx
@@ -73,10 +73,10 @@ const colorClasses: ColorClasses = [
         className: "bg-identity-tint-120",
       },
       {
-        className: "bg-identity-tint-80",
+        className: "bg-identity-tint-100",
       },
       {
-        className: "bg-identity-tint-60",
+        className: "bg-identity-tint-80",
       },
       {
         className: "bg-identity-tint-40",

--- a/src/stories/Library/cover/Cover.stories.tsx
+++ b/src/stories/Library/cover/Cover.stories.tsx
@@ -52,7 +52,7 @@ CoverVisible.args = {};
 export const CoverNotVisible = Template.bind({});
 CoverNotVisible.args = {
   url: "",
-  tint: "60",
+  tint: "100",
   coverUrl: "",
 };
 

--- a/src/stories/Library/cover/Cover.tsx
+++ b/src/stories/Library/cover/Cover.tsx
@@ -4,7 +4,7 @@ export type CoverProps = {
   url: string;
   animate: boolean;
   size: "xsmall" | "small" | "medium" | "large" | "xlarge";
-  tint?: "20" | "40" | "60" | "80" | "120";
+  tint?: "20" | "40" | "80" | "100" | "120";
   coverUrl?: string;
   coverDescription?: string;
 };
@@ -18,8 +18,8 @@ export const Cover = (props: CoverProps) => {
   const tintClasses: TintClassesType = {
     default: "bg-identity-tint-120",
     "120": "bg-identity-tint-120",
+    "100": "bg-identity-tint-100",
     "80": "bg-identity-tint-80",
-    "60": "bg-identity-tint-60",
     "40": "bg-identity-tint-40",
     "20": "bg-identity-tint-20",
   };


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-389
**Figma:**
https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=4517%3A17645&t=prvkjmQxLeKEuX9U-4

#### This PR adds the background color of the Cover Identity Tint of 100% according to the Figma design. The previous color of 60% was not present in the Figma design and has therefore been removed.

#### Screenshot of the result

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.