### PR TITLE
5606: filter none on hover on stacked items

### DIFF
--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -184,4 +184,8 @@ $list-reservation-space-desktop: 24px;
     transform: translateY(16px) scale(0.9);
     z-index: -2;
   }
+
+  &:hover {
+    filter: none;
+  }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5606

#### Description

The filter disturbs the stacked effect on hover, so its removed for stacked items

#### Screenshot of the result

<img width="813" alt="image" src="https://user-images.githubusercontent.com/15377965/214275048-b32fb33a-042d-4d05-8cb5-c024354da3c4.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

