### PR TITLE
5581: add padding to mobile details modal

### DIFF
--- a/src/stories/Library/Modals/modal-details/modal-details.scss
+++ b/src/stories/Library/Modals/modal-details/modal-details.scss
@@ -15,9 +15,11 @@ $MODAL_DETAILS_CONTAINER_WIDTH: 1000px;
   overflow: scroll;
   margin: 0 24px;
   max-width: $MODAL_DETAILS_CONTAINER_WIDTH;
+  padding-bottom: $s-2xl;
 
   @include breakpoint-s {
     margin: 0 45px;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5581

#### Description

add padding-bottom to mobile details modal

#### Screenshot of the result

<img width="356" alt="image" src="https://user-images.githubusercontent.com/15377965/214798085-ec258b8b-4ef1-43de-98d8-ec1fbcaf641a.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

