### PR TITLE
Material page skeleton screens (Performance optimisations)

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -71,6 +71,7 @@
 @import "./src/stories/Library/horizontal-term-line/horizontal-term-line";
 @import "./src/stories/Library/search-result-page/search-result-info";
 @import "./src/stories/Library/search-result-page/search-result-page";
+@import "./src/stories/Library/search-result-page/search-result-page-skeleton";
 @import "./src/stories/Library/loan-list-page/loan-list-page";
 @import "./src/stories/Library/patron-page/patron-page";
 @import "./src/stories/Library/reservation-list-page/reservation-list-page";

--- a/base.scss
+++ b/base.scss
@@ -61,6 +61,7 @@
 @import "./src/stories/Library/Modals/modal-facet-browser/facet-browser";
 
 @import "./src/stories/Blocks/material-page/material-page";
+@import "./src/stories/Blocks/material-page/material-page-skeleton";
 @import "./src/stories/Library/Buttons/toggle-button/toggle-button";
 @import "./src/stories/Library/pause-reservation/pause-reservation";
 @import "./src/stories/Library/material-header/material-header";

--- a/src/stories/Blocks/material-page/MaterialPage.stories.tsx
+++ b/src/stories/Blocks/material-page/MaterialPage.stories.tsx
@@ -1,6 +1,7 @@
 import { withDesign } from "storybook-addon-designs";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import MaterialPage from "./MaterialPage";
+import MaterialPageSkeleton from "./MaterialPageSkeleton";
 
 export default {
   title: "Blocks / Material Page",
@@ -44,3 +45,7 @@ Item.args = {
   description:
     "Stormandssønnen Arn får hos cisterciensermunkene i Sverige og Danmark den bedste uddannelse, der findes i middelalderens Europa. Men hans lærere aner, at han ikke er bestemt til at være klosterbroder og vil gøre bedre fyldest som Kristi strids... ",
 };
+
+export const SkeletonVersion: ComponentStory<
+  typeof MaterialPageSkeleton
+> = () => <MaterialPageSkeleton />;

--- a/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
+++ b/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
@@ -3,9 +3,7 @@ const MaterialPageSkeleton: React.FC = () => {
     <section className="material-page ssc">
       <header className="material-header">
         <div className="material-header__cover">
-          <div className="cover-container">
-            <div className="ssc-square" />
-          </div>
+          <div className="ssc-square cover--size-xlarge" />
         </div>
         <div className="material-header__content">
           <div>
@@ -35,11 +33,6 @@ const MaterialPageSkeleton: React.FC = () => {
           <div className="ssc-line w-70 mbs" />
           <div className="ssc-line w-70 mbs" />
           <div className="ssc-line w-70 mbs" />
-        </div>
-        <div className="scc-wrapper pt-64">
-          <div className="skeleton-disclosure ssc-head-line mbs" />
-          <div className="skeleton-disclosure ssc-head-line mbs" />
-          <div className="skeleton-disclosure ssc-head-line mbs" />
         </div>
       </section>
     </section>

--- a/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
+++ b/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
@@ -1,0 +1,49 @@
+const MaterialPageSkeleton: React.FC = () => {
+  return (
+    <section className="material-page ssc">
+      <header className="material-header">
+        <div className="material-header__cover">
+          <div className="cover-container">
+            <div className="ssc-square" />
+          </div>
+        </div>
+        <div className="material-header__content">
+          <div>
+            <div className="scc-wrapper">
+              <div className="ssc-square mb-32" />
+              <div className="ssc-head-line mbs" />
+              <div className="ssc-head-line mbs" />
+              <div className="ssc-head-line mb-48" />
+              <div className="ssc-line w-30">&nbsp;</div>
+            </div>
+            <div className="scc-wrapper pt-48">
+              <div className="ssc-head-line w-80 mbs" />
+              <div className="ssc-head-line w-80 mbs" />
+              <div className="ssc-line" />
+            </div>
+          </div>
+        </div>
+      </header>
+      <section className="material-description">
+        <div className="ssc-head-line w-20 mb" />
+        <div className="ssc-line w-60 mbs" />
+        <div className="ssc-line w-60 mbs" />
+        <div className="ssc-line w-60 mbs" />
+        <div className="ssc-line w-60 mb" />
+        <div className="scc-wrapper pt-16">
+          <div className="ssc-head-line w-10 mt mb" />
+          <div className="ssc-line w-70 mbs" />
+          <div className="ssc-line w-70 mbs" />
+          <div className="ssc-line w-70 mbs" />
+        </div>
+        <div className="scc-wrapper pt-64">
+          <div className="skeleton-disclosure ssc-head-line mbs" />
+          <div className="skeleton-disclosure ssc-head-line mbs" />
+          <div className="skeleton-disclosure ssc-head-line mbs" />
+        </div>
+      </section>
+    </section>
+  );
+};
+
+export default MaterialPageSkeleton;

--- a/src/stories/Blocks/material-page/material-page-skeleton.scss
+++ b/src/stories/Blocks/material-page/material-page-skeleton.scss
@@ -1,10 +1,15 @@
 // Since we are using the Skeleton Screen Css classes connected to the existing styling
 // we deliberately not follow the BEM naming convention here.
 /* stylelint-disable plugin/stylelint-bem-namics */
+/* stylelint-disable max-nesting-depth */
 
 .material-page {
   &.ssc {
     .material-header {
+      .ssc-square {
+        height: 30px;
+        width: 30px;
+      }
       &__cover {
         .cover-container {
           .ssc-square {
@@ -16,10 +21,6 @@
       &__content {
         height: 605px;
       }
-      .ssc-square {
-        height: 30px;
-        width: 30px;
-      }
     }
   }
 
@@ -29,3 +30,4 @@
 }
 
 /* stylelint-enable plugin/stylelint-bem-namics */
+/* stylelint-enable max-nesting-depth */

--- a/src/stories/Blocks/material-page/material-page-skeleton.scss
+++ b/src/stories/Blocks/material-page/material-page-skeleton.scss
@@ -1,0 +1,31 @@
+// Since we are using the Skeleton Screen Css classes connected to the existing styling
+// we deliberately not follow the BEM naming convention here.
+/* stylelint-disable plugin/stylelint-bem-namics */
+
+.material-page {
+  &.ssc {
+    .material-header {
+      &__cover {
+        .cover-container {
+          .ssc-square {
+            width: 300px;
+            height: 408px;
+          }
+        }
+      }
+      &__content {
+        height: 605px;
+      }
+      .ssc-square {
+        height: 30px;
+        width: 30px;
+      }
+    }
+  }
+
+  .skeleton-disclosure {
+    height: 100px;
+  }
+}
+
+/* stylelint-enable plugin/stylelint-bem-namics */

--- a/src/stories/Blocks/material-page/material-page-skeleton.scss
+++ b/src/stories/Blocks/material-page/material-page-skeleton.scss
@@ -6,28 +6,19 @@
 .material-page {
   &.ssc {
     .material-header {
-      .ssc-square {
-        height: 30px;
-        width: 30px;
-      }
       &__cover {
-        .cover-container {
-          .ssc-square {
-            width: 300px;
-            height: 408px;
-          }
+        .ssc-square {
+          width: 300px;
         }
       }
       &__content {
         height: 605px;
+        // Favorite icon.
+        .ssc-square {
+          height: 30px;
+          width: 30px;
+        }
       }
     }
   }
-
-  .skeleton-disclosure {
-    height: 100px;
-  }
 }
-
-/* stylelint-enable plugin/stylelint-bem-namics */
-/* stylelint-enable max-nesting-depth */

--- a/src/stories/Library/recommender/Recommender.tsx
+++ b/src/stories/Library/recommender/Recommender.tsx
@@ -1,4 +1,4 @@
-import { Cover } from "../cover/Cover";
+import Cover from "../cover/Cover";
 import { ReactComponent as SvgIcon } from "../Icons/icon-favourite/icon-favourite.svg";
 
 export type RecommenderData = {
@@ -58,7 +58,7 @@ const Recommender: React.FC<RecommenderProps> = ({
             </div>
             <div className="recommender-material__cover-container">
               <Cover
-                url="images/book_cover_3.jpg"
+                src="images/book_cover_3.jpg"
                 size="medium"
                 animate={false}
                 tint="120"

--- a/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
@@ -1,7 +1,7 @@
 export const SearchResultItemSkeleton = () => {
   return (
     <div className="search-result-item arrow arrow__hover--right-small ssc">
-      <div className="ssc-square">&nbsp;</div>
+      <div className="ssc-square cover--size-small">&nbsp;</div>
       <div className="ssc-wrapper">
         <div className="ssc-head-line mb" />
         <div className="ssc-line mbs">&nbsp;</div>

--- a/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItemSkeleton.tsx
@@ -2,10 +2,10 @@ export const SearchResultItemSkeleton = () => {
   return (
     <div className="search-result-item arrow arrow__hover--right-small ssc">
       <div className="ssc-square">&nbsp;</div>
-      <div className="ssc-wrapper w-80">
-        <div className="ssc-head-line w-60 mb" />
-        <div className="ssc-line w-60 mbs">&nbsp;</div>
-        <div className="ssc-line w-60 mbs">&nbsp;</div>
+      <div className="ssc-wrapper">
+        <div className="ssc-head-line mb" />
+        <div className="ssc-line mbs">&nbsp;</div>
+        <div className="ssc-line mbs">&nbsp;</div>
       </div>
     </div>
   );

--- a/src/stories/Library/search-result-item/search-result-item-skeleton.scss
+++ b/src/stories/Library/search-result-item/search-result-item-skeleton.scss
@@ -14,5 +14,11 @@
   .ssc-head-line {
     @extend %mt-16;
   }
+  @include breakpoint-s {
+    .ssc-wrapper {
+      width: 50%;
+    }
+  }
 }
+
 /* stylelint-enable plugin/stylelint-bem-namics */

--- a/src/stories/Library/search-result-item/search-result-item-skeleton.scss
+++ b/src/stories/Library/search-result-item/search-result-item-skeleton.scss
@@ -8,8 +8,8 @@
   }
   .ssc-square {
     @extend %mr-16;
-    width: 100px;
-    height: 140px;
+    width: 72px;
+    height: 104px;
   }
   .ssc-head-line {
     @extend %mt-16;

--- a/src/stories/Library/search-result-item/search-result-item-skeleton.scss
+++ b/src/stories/Library/search-result-item/search-result-item-skeleton.scss
@@ -7,9 +7,7 @@
     grid-template-columns: min-content 1fr;
   }
   .ssc-square {
-    @extend %mr-16;
-    width: 72px;
-    height: 104px;
+    width: 95px;
   }
   .ssc-head-line {
     @extend %mt-16;

--- a/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPage.stories.tsx
@@ -1,6 +1,7 @@
 import { withDesign } from "storybook-addon-designs";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { SearchResultPage } from "./SearchResultPage";
+import { SearchResultPageSkeleton } from "./SearchResultPageSkeleton";
 
 export default {
   title: "Blocks / Search Result Page",
@@ -44,6 +45,11 @@ export default {
 const Template: ComponentStory<typeof SearchResultPage> = (args) => {
   return <SearchResultPage {...args} />;
 };
-
 export const Item = Template.bind({});
-Item.args = {};
+
+const SkeletonTemplate: ComponentStory<typeof SearchResultPageSkeleton> = (
+  args
+) => {
+  return <SearchResultPageSkeleton {...args} />;
+};
+export const SkeletonVersion = SkeletonTemplate.bind({});

--- a/src/stories/Library/search-result-page/SearchResultPageSkeleton.tsx
+++ b/src/stories/Library/search-result-page/SearchResultPageSkeleton.tsx
@@ -1,0 +1,55 @@
+import { SearchResultTitle } from "./SearchResultTitle";
+import { SearchResultItemSkeleton } from "../search-result-item/SearchResultItemSkeleton";
+
+export type SearchResultPageSkeletonProps = {
+  title: string;
+  currentResults: number;
+  totalResults: number;
+  linkName: string;
+  linkTotalResults: string;
+  zeroResult: boolean;
+};
+
+export const SearchResultPageSkeleton = ({
+  title,
+}: SearchResultPageSkeletonProps) => {
+  return (
+    <div className="search-result-page">
+      <SearchResultTitle
+        title={title}
+        totalResults={0}
+        zeroResult={false}
+        isLoading
+      />
+      <div className="search-result-page__skeleton-facet-line--mobile">
+        <div className="ssc mt-48">
+          <div className="ssc-head-line mb" />
+          <div className="ssc-head-line mb" />
+          <div className="ssc-head-line mb" />
+        </div>
+      </div>
+      <div className="search-result-page__skeleton-facet-line--desktop">
+        <div className="ssc mt-48">
+          <div className="ssc-head-line mb" />
+        </div>
+      </div>
+      <ul className="search-result-page__list my-32">
+        <li>
+          <SearchResultItemSkeleton />
+        </li>
+        <li>
+          <SearchResultItemSkeleton />
+        </li>
+        <li>
+          <SearchResultItemSkeleton />
+        </li>
+        <li>
+          <SearchResultItemSkeleton />
+        </li>
+        <li>
+          <SearchResultItemSkeleton />
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/src/stories/Library/search-result-page/search-result-page-skeleton.scss
+++ b/src/stories/Library/search-result-page/search-result-page-skeleton.scss
@@ -1,0 +1,15 @@
+.search-result-page__skeleton-facet-line {
+  &--mobile {
+    display: block;
+    @include breakpoint-s {
+      display: none;
+    }
+  }
+
+  &--desktop {
+    display: none;
+    @include breakpoint-s {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-400

#### Description

Adds skeleton screens to the material page.
And as a bonus improves the lengths of the skeleton lines on search results.

#### Screenshot of the result
##### Mobile

<img width="617" alt="image" src="https://user-images.githubusercontent.com/998889/215259670-3ab4f916-3890-413a-9c35-d2c94d6e9689.png">

##### Desktop
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/998889/215259659-dff806c1-6ec9-47cc-8896-f1b48499a4d0.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

