### PR TITLE
Remove default spacing in article + Add spacing in infomedia + Change padding for the search result page

### DIFF
--- a/src/stories/Library/Modals/modal-infomedia/Infomedia.tsx
+++ b/src/stories/Library/Modals/modal-infomedia/Infomedia.tsx
@@ -10,7 +10,7 @@ export const Infomedia = (props: InfomediaProps) => {
   const { title, text, showModal } = props;
   return (
     <Modal shownModal={showModal} classNames="">
-      <article>
+      <article className="infomedia-article">
         <img
           className="infomedia-logo"
           src="icons/logo/infomedia-logo.svg"

--- a/src/stories/Library/Modals/modal-infomedia/infomedia.scss
+++ b/src/stories/Library/Modals/modal-infomedia/infomedia.scss
@@ -4,3 +4,7 @@
   object-fit: contain;
   height: $s-lg;
 }
+
+.infomedia-article > * + * {
+  margin-top: 1em;
+}

--- a/src/stories/Library/search-result-item/SearchResultItem.tsx
+++ b/src/stories/Library/search-result-item/SearchResultItem.tsx
@@ -49,7 +49,7 @@ export const SearchResultItem = ({
           )}
         </div>
 
-        <h2 className="search-result-item__title text-header-h4">
+        <h2 className="search-result-item__title text-header-h4 mb-4">
           <a href="">{title}</a>
         </h2>
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>

--- a/src/stories/Library/search-result-page/search-result-page.scss
+++ b/src/stories/Library/search-result-page/search-result-page.scss
@@ -3,7 +3,7 @@
   padding: 16px;
 
   @include breakpoint-m {
-    padding: 157px;
+    padding: $s-4xl 157px $s-2xl;
   }
 
   &__list {

--- a/src/styles/scss/reset.scss
+++ b/src/styles/scss/reset.scss
@@ -53,11 +53,6 @@ img {
   display: block;
 }
 
-/* Natural flow and rhythm in articles by default */
-article > * + * {
-  margin-top: 1em;
-}
-
 /* Inherit fonts for inputs and buttons */
 input,
 button,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-408
https://reload.atlassian.net/browse/DDFSOEG-409 

#### This PR is remove default styling from all article elements.
it is not desired because we want to use the article for semantic reasons, not for styling. 

**The only place in the design system where this has a consequence is in Infomedia**
Therefore, I have added a new CSS class to keep the desired styling of infomedia articles

**This PR also fix padding for the search result page**

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
This was discovered because we have used article element for semantic reasons in search-result-item in dpl-react