### PR TITLE
Make all full-screen modals smaller as default styling

### DIFF
--- a/src/stories/Blocks/material-banner/material-banner.scss
+++ b/src/stories/Blocks/material-banner/material-banner.scss
@@ -69,7 +69,7 @@
   }
 
   @include breakpoint-s {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 
   @include breakpoint-l {

--- a/src/stories/Library/Modals/Modal.tsx
+++ b/src/stories/Library/Modals/Modal.tsx
@@ -6,9 +6,15 @@ interface ModalWrapperProps {
   shownModal: boolean;
   children?: React.ReactNode;
   classNames?: string;
+  orientation?: "right";
 }
 
-const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
+const Modal = ({
+  children,
+  shownModal,
+  classNames,
+  orientation,
+}: ModalWrapperProps) => {
   const [shouldShowModal, setShouldShowModal] = useState(shownModal);
 
   useEffect(() => setShouldShowModal(shownModal), [shownModal]);
@@ -29,7 +35,7 @@ const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
         <ModalCloseButton
           idAriaDescribedBy="describemodal"
           toggleModal={toggleModal}
-          classNames={classNames}
+          orientation={orientation}
         />
         {children}
       </div>

--- a/src/stories/Library/Modals/Modal.tsx
+++ b/src/stories/Library/Modals/Modal.tsx
@@ -19,15 +19,20 @@ const Modal = ({ children, shownModal, classNames }: ModalWrapperProps) => {
     return <ModalFallbackButton toggleModal={toggleModal} />;
 
   return (
-    <div className={clsx("modal", shouldShowModal && "modal-show", classNames)}>
-      <div className="modal__screen-reader-description" id="describemodal">
-        Denne modal dækker sidens indhold, og er en demo
+    <div className="modal-backdrop">
+      <div
+        className={clsx("modal", shouldShowModal && "modal-show", classNames)}
+      >
+        <div className="modal__screen-reader-description" id="describemodal">
+          Denne modal dækker sidens indhold, og er en demo
+        </div>
+        <ModalCloseButton
+          idAriaDescribedBy="describemodal"
+          toggleModal={toggleModal}
+          classNames={classNames}
+        />
+        {children}
       </div>
-      <ModalCloseButton
-        idAriaDescribedBy="describemodal"
-        toggleModal={toggleModal}
-      />
-      {children}
     </div>
   );
 };

--- a/src/stories/Library/Modals/ModalShared.tsx
+++ b/src/stories/Library/Modals/ModalShared.tsx
@@ -28,18 +28,19 @@ export function ModalFallbackButton({
 export function ModalCloseButton({
   toggleModal,
   idAriaDescribedBy,
-  classNames,
+  orientation,
 }: {
   toggleModal: void | (() => void);
   idAriaDescribedBy: string;
-  classNames?: string;
+  orientation?: "right";
 }) {
-  const isOffset = !(classNames && classNames.includes("modal-right"));
   return (
     <ButtonUI
       describe={idAriaDescribedBy}
       onClick={toggleModal || (() => {})}
-      classes={`modal-btn-close ${isOffset ? "modal-btn-close--offset" : ""}`}
+      classes={`modal-btn-close ${
+        !orientation ? "modal-btn-close--offset" : ""
+      }`}
       ariaLabel="close modal"
       content={{
         kind: "ICON",

--- a/src/stories/Library/Modals/ModalShared.tsx
+++ b/src/stories/Library/Modals/ModalShared.tsx
@@ -28,15 +28,18 @@ export function ModalFallbackButton({
 export function ModalCloseButton({
   toggleModal,
   idAriaDescribedBy,
+  classNames,
 }: {
   toggleModal: void | (() => void);
   idAriaDescribedBy: string;
+  classNames?: string;
 }) {
+  const isOffset = !(classNames && classNames.includes("modal-right"));
   return (
     <ButtonUI
       describe={idAriaDescribedBy}
       onClick={toggleModal || (() => {})}
-      classes="modal-btn-close"
+      classes={`modal-btn-close ${isOffset ? "modal-btn-close--offset" : ""}`}
       ariaLabel="close modal"
       content={{
         kind: "ICON",

--- a/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
+++ b/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
@@ -19,48 +19,46 @@ const FacetBrowser: React.FC<FacetBrowserProps> = ({
   showMore,
   showResults,
 }) => (
-  <div className="modal-backdrop">
-    <Modal shownModal={showModal} classNames="modal-right modal--no-padding">
-      <section className="facet-browser">
-        <header className="facet-browser__header">
-          <h3 className="text-header-h3">{title}</h3>
-          {clearAll && (
-            <button className="link-tag cursor-pointer facet-browser__clear-btn">
-              {clearAll}
-            </button>
-          )}
-        </header>
+  <Modal shownModal={showModal} classNames="modal-right modal--no-padding">
+    <section className="facet-browser">
+      <header className="facet-browser__header">
+        <h3 className="text-header-h3">{title}</h3>
+        {clearAll && (
+          <button className="link-tag cursor-pointer facet-browser__clear-btn">
+            {clearAll}
+          </button>
+        )}
+      </header>
 
-        {facetBrowserDummyData.map((facet) => (
-          <Disclosure
-            fullWidth
-            removeHeadlinePadding
-            key={facet.title}
-            headline={facet.title}
-          >
-            <div className="facet-browser__facet-group">
-              {facet.tags.map((tag) => (
-                <Tag key={tag}>{tag}</Tag>
-              ))}
-            </div>
-            <button className="link-tag cursor-pointer facet-browser__more-btn">
-              {showMore}
-            </button>
-          </Disclosure>
-        ))}
+      {facetBrowserDummyData.map((facet) => (
+        <Disclosure
+          fullWidth
+          removeHeadlinePadding
+          key={facet.title}
+          headline={facet.title}
+        >
+          <div className="facet-browser__facet-group">
+            {facet.tags.map((tag) => (
+              <Tag key={tag}>{tag}</Tag>
+            ))}
+          </div>
+          <button className="link-tag cursor-pointer facet-browser__more-btn">
+            {showMore}
+          </button>
+        </Disclosure>
+      ))}
 
-        <Button
-          classNames="facet-browser__results-btn"
-          label={showResults}
-          disabled={false}
-          collapsible
-          size="medium"
-          buttonType="none"
-          variant="filled"
-        />
-      </section>
-    </Modal>
-  </div>
+      <Button
+        classNames="facet-browser__results-btn"
+        label={showResults}
+        disabled={false}
+        collapsible
+        size="medium"
+        buttonType="none"
+        variant="filled"
+      />
+    </section>
+  </Modal>
 );
 
 export default FacetBrowser;

--- a/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
+++ b/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
@@ -19,7 +19,11 @@ const FacetBrowser: React.FC<FacetBrowserProps> = ({
   showMore,
   showResults,
 }) => (
-  <Modal shownModal={showModal} classNames="modal-right modal--no-padding">
+  <Modal
+    shownModal={showModal}
+    classNames="modal-right modal--no-padding"
+    orientation="right"
+  >
     <section className="facet-browser">
       <header className="facet-browser__header">
         <h3 className="text-header-h3">{title}</h3>

--- a/src/stories/Library/Modals/modal-loan/modal-loan.scss
+++ b/src/stories/Library/Modals/modal-loan/modal-loan.scss
@@ -48,12 +48,14 @@ $MODAL_LOAN_CONTAINER_WIDTH: 1000px;
   position: fixed;
   left: 0;
   bottom: 0;
-  right: 0;
+  width: 100vw;
   background-color: $c-global-primary;
   padding: $s-md;
-  min-width: 100%;
 
   @include breakpoint-m {
     padding: $s-sm $s-7xl;
+    bottom: 100px;
+    left: 100px;
+    width: calc(100vw - 200px);
   }
 }

--- a/src/stories/Library/Modals/modal-login/ModalLogin.tsx
+++ b/src/stories/Library/Modals/modal-login/ModalLogin.tsx
@@ -12,6 +12,7 @@ export const ModalLogin: React.FC<ModalLoginProps> = ({ showModal }) => (
     <Modal
       shownModal={showModal}
       classNames="modal-login modal-right modal-padding"
+      orientation="right"
     >
       <div className="modal-login__container">
         <Button

--- a/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
+++ b/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
@@ -24,45 +24,43 @@ export const ModalProfile: React.FC<ModalProfileProps> = ({
   notifications,
   profileNavLinks,
 }) => (
-  <div className="modal-backdrop">
-    <Modal shownModal={showModal} classNames="modal-profile modal-right">
-      <ModalHeader
-        headerName={headerName}
-        headerLinkHref={headerLinkHref}
-        headerLinkText={headerLinkText}
-      />
+  <Modal shownModal={showModal} classNames="modal-profile modal-right">
+    <ModalHeader
+      headerName={headerName}
+      headerLinkHref={headerLinkHref}
+      headerLinkText={headerLinkText}
+    />
 
-      <div className="modal-profile__notifications">
-        {notifications.map((item, index) => (
-          <div key={index} className="modal-profile__notification-item">
-            <ListDashboard
-              title={item.title}
-              number={item.number}
-              label={item.label}
-              showDot={item.showDot}
-              href={item.href}
-            />
-          </div>
-        ))}
-      </div>
-
-      <div className="modal-profile__container">
-        <div className="modal-profile__links">
-          <LinkFilters filters={profileNavLinks} />
-        </div>
-        <div className="modal-profile__btn-logout">
-          <Button
-            buttonType="default"
-            size="medium"
-            variant="filled"
-            label="Log ud"
-            disabled={false}
-            collapsible={false}
+    <div className="modal-profile__notifications">
+      {notifications.map((item, index) => (
+        <div key={index} className="modal-profile__notification-item">
+          <ListDashboard
+            title={item.title}
+            number={item.number}
+            label={item.label}
+            showDot={item.showDot}
+            href={item.href}
           />
         </div>
+      ))}
+    </div>
+
+    <div className="modal-profile__container">
+      <div className="modal-profile__links">
+        <LinkFilters filters={profileNavLinks} />
       </div>
-    </Modal>
-  </div>
+      <div className="modal-profile__btn-logout">
+        <Button
+          buttonType="default"
+          size="medium"
+          variant="filled"
+          label="Log ud"
+          disabled={false}
+          collapsible={false}
+        />
+      </div>
+    </div>
+  </Modal>
 );
 
 export default ModalProfile;

--- a/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
+++ b/src/stories/Library/Modals/modal-profile/ModalProfile.tsx
@@ -24,7 +24,11 @@ export const ModalProfile: React.FC<ModalProfileProps> = ({
   notifications,
   profileNavLinks,
 }) => (
-  <Modal shownModal={showModal} classNames="modal-profile modal-right">
+  <Modal
+    shownModal={showModal}
+    classNames="modal-profile modal-right"
+    orientation="right"
+  >
     <ModalHeader
       headerName={headerName}
       headerLinkHref={headerLinkHref}

--- a/src/stories/Library/Modals/modal-text/modal-text.scss
+++ b/src/stories/Library/Modals/modal-text/modal-text.scss
@@ -32,6 +32,11 @@ $MODAL_TEXT_CONTAINER_WIDTH: 550px;
   width: 100%;
   background-color: $c-global-primary;
   filter: drop-shadow(4px 0 20px rgb(72 72 72 / 10%));
+
+  @include breakpoint-s {
+    bottom: 100px;
+    width: calc(100vw - 200px);
+  }
 }
 
 .modal-text__buttons-inner {

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -19,12 +19,17 @@
   opacity: 0;
   display: none;
   transition: opacity 0.3s;
-  min-height: 100vh;
-  height: 100%;
+  height: 100vh;
   overflow: scroll;
 
   &__screen-reader-description {
     @include hide-visually;
+  }
+
+  @include breakpoint-s {
+    height: calc(100vh - 200px);
+    width: calc(100vw - 200px);
+    margin: 100px 0 0 100px;
   }
 
   @include breakpoint-m {
@@ -57,6 +62,8 @@
   right: 0;
   max-width: 560px;
   width: 100%;
+  height: 100vh;
+  margin: 0;
 }
 
 .modal-backdrop {

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -80,3 +80,41 @@
 .modal--no-padding {
   padding: 0;
 }
+
+.modal-btn-close {
+  position: fixed;
+  top: 0;
+  right: 0;
+  padding: 22.5px;
+  transition: 0.3s;
+  z-index: 2;
+
+  &.modal-btn-close--offset {
+    @include breakpoint-s {
+      top: 100px;
+      right: 100px;
+    }
+  }
+
+  @include breakpoint-s {
+    padding: 34px;
+  }
+
+  &:hover {
+    transform: rotateZ(90deg);
+  }
+
+  & > img {
+    width: 11.5px;
+
+    @include breakpoint-s {
+      width: 19.5px;
+    }
+  }
+}
+
+.modal-btn-fallback {
+  display: flex;
+  justify-content: flex-end;
+  padding: 20px;
+}

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -43,6 +43,13 @@
   transition: 0.3s;
   z-index: 2;
 
+  &.modal-btn-close--offset {
+    @include breakpoint-s {
+      top: 100px;
+      right: 100px;
+    }
+  }
+
   @include breakpoint-s {
     padding: 34px;
   }

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -35,50 +35,12 @@
   }
 }
 
-.modal-btn-close {
-  position: fixed;
-  top: 0;
-  right: 0;
-  padding: 22.5px;
-  transition: 0.3s;
-  z-index: 2;
-
-  &.modal-btn-close--offset {
-    @include breakpoint-s {
-      top: 100px;
-      right: 100px;
-    }
-  }
-
-  @include breakpoint-s {
-    padding: 34px;
-  }
-
-  &:hover {
-    transform: rotateZ(90deg);
-  }
-
-  & > img {
-    width: 11.5px;
-
-    @include breakpoint-s {
-      width: 19.5px;
-    }
-  }
-}
-
 :root {
   --parent-bg-color: #fff;
 }
 
 .uppercase {
   text-transform: uppercase;
-}
-
-.modal-btn-fallback {
-  display: flex;
-  justify-content: flex-end;
-  padding: 20px;
 }
 
 .noselect {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-27

#### Description
This PR adjusts the modal styling component to by default not fill the entire screen. This change affected other stories and uses of the modal component and its content. The biggest change that I introduced is to Material Banner - because the modal is smaller, the chromatic snapshot showed it looking quite broken. I adjusted the number of items that fit in a single row for tablets/smaller screen laptops (from 4 to 3).
#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/217011207-1195fc8b-0361-47c2-a878-ce645371095f.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a

