### PR TITLE
Add bold caption styling

### DIFF
--- a/src/stories/Library/review/review.scss
+++ b/src/stories/Library/review/review.scss
@@ -24,6 +24,7 @@
 
   &__headline {
     color: $c-text-secondary-gray;
+    @extend %text-small-caption-bold;
   }
 
   &__body {

--- a/src/stories/Library/typography/Typography.tsx
+++ b/src/stories/Library/typography/Typography.tsx
@@ -52,6 +52,10 @@ const typographyClasses = [
     title: "Small Text / Caption",
   },
   {
+    className: "text-small-caption-bold",
+    title: "Small Text / Caption Bold",
+  },
+  {
     className: "text-label",
     title: "Desktop / Label",
   },

--- a/src/stories/Library/typography/typography.scss
+++ b/src/stories/Library/typography/typography.scss
@@ -377,6 +377,31 @@
   }
 }
 
+//styleName: Desktop/Small Text - Caption Bold;
+%text-small-caption-bold,
+.text-small-caption-bold {
+  font-family: "Noto Sans JP", sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 10px;
+  line-height: 16px;
+  text-align: left;
+
+  @include breakpoint-s {
+    line-height: 160%;
+  }
+
+  @include breakpoint-m {
+    font-size: 12px;
+    line-height: 120%;
+  }
+
+  @include breakpoint-xl {
+    font-size: 14px;
+    line-height: 130%;
+  }
+}
+
 //styleName: Desktop/Label;
 %text-label,
 .text-label {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-417

#### Description
This PR introduces a new typography class - text small caption bold. This is then used for review headlines.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/217524884-5034a6f7-333e-481c-a590-a082caddb374.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
