### PR TITLE
Improved expand icon animation in 'horizontal-term-line' and 'disclosure'

### DIFF
--- a/src/stories/Library/disclosure/disclosure.scss
+++ b/src/stories/Library/disclosure/disclosure.scss
@@ -85,8 +85,15 @@
       margin-right: $s-xl;
     }
 
-    &-open {
+    // This is for DisclosureControllable because it's not a details element. and can't use the [open] attribute.
+    &--expanded {
+      transition: transform 0.3s ease-in-out;
       transform: scaleY(-1);
     }
   }
+}
+
+.disclosure[open] .disclosure__expand {
+  transition: transform 0.3s ease-in-out;
+  transform: scaleY(-1);
 }

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,3 +1,6 @@
+import clsx from "clsx";
+import { useState } from "react";
+
 export interface HorizontalTermLineList {
   url: string;
   text: string;
@@ -19,19 +22,43 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   subTitle,
   linkList,
 }) => {
+  const numberOfItemsToShow = 2;
+  const [showMore, setShowMore] = useState(false);
+  const itemsToShow = showMore
+    ? linkList
+    : linkList.slice(0, numberOfItemsToShow);
+  const showMoreButton = linkList.length > numberOfItemsToShow;
+
   return (
     <div className="text-small-caption horizontal-term-line">
       <p className="text-label-bold">
         {`${title}`}{" "}
         {subTitle && <span className="text-small-caption">{subTitle} </span>}
       </p>
-      {linkList.map((link, index) => (
+
+      {itemsToShow.map((link, index) => (
         <span key={generateId(index)}>
           <a href="/" className="link-tag" key={index}>
             {link.text}
           </a>
         </span>
       ))}
+
+      {showMoreButton && (
+        <button
+          type="button"
+          onClick={() => setShowMore(!showMore)}
+          aria-label="Expand More"
+        >
+          <img
+            className={clsx("horizontal-term-line__expand", {
+              "horizontal-term-line__expand--expanded": showMore,
+            })}
+            src="icons/collection/ExpandMore.svg"
+            alt=""
+          />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
+++ b/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
@@ -15,4 +15,13 @@
     flex-wrap: wrap;
     gap: $s-sm;
   }
+
+  &__expand {
+    cursor: pointer;
+    transition: transform 0.3s ease-in-out;
+
+    &--expanded {
+      transform: scaleY(-1);
+    }
+  }
 }

--- a/src/stories/Library/recommender/recommender.scss
+++ b/src/stories/Library/recommender/recommender.scss
@@ -33,6 +33,7 @@
     display: flex;
     justify-content: end;
     margin-bottom: $s-md;
+    gap: $s-md;
   }
 
   &__grid {

--- a/src/styles/scss/reset.scss
+++ b/src/styles/scss/reset.scss
@@ -66,6 +66,7 @@ button,
 input[type="button"],
 input[type="submit"],
 input[type="reset"] {
+  padding: 0;
   border: inherit;
   background-color: inherit;
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-37

#### This pull request enhances the HorizontalTermLine component with the following new features:

- Limits the number of terms displayed to the value set in numberOfItemsToShow, which is set to 2.

- a toggle button has been added, allowing users to switch between displaying only the limited number of terms and all of them. The button features a toggle icon that changes according to the component's state.

**Other Changes**

- A new CSS class for the icon and a modifier to flip the arrow direction have been introduced in horizontal-term-line.

- The modifier used in DisclosureControllable has been renamed and a transition has been added.
- CSS for the default Disclosure component that uses 'details' has been added

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/49920322/217814158-ca700214-a4d8-4c00-ae61-e11fcef6194b.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.