### PR TITLE
Add min-height to 'material-header'

### DIFF
--- a/src/stories/Library/material-header/material-header.scss
+++ b/src/stories/Library/material-header/material-header.scss
@@ -2,9 +2,14 @@
   border-bottom: 1px solid $c-global-tertiary-1;
   padding-bottom: 56px;
   @include breakpoint-m {
+    min-height: 800px;
     display: grid;
     grid-template-columns: 1fr 1fr;
     padding-bottom: 0;
+  }
+
+  @include breakpoint-l {
+    min-height: 650px;
   }
 
   .button-favourite {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-418

#### Implement minimum height for the 'material-header' component to prevent the cover from jumping / the middle of the container from shifting.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
This change will keep the cover in place and ensure that the center of the container remains unchanged."
