### PR TITLE
Fix availability label accessibility

### DIFF
--- a/src/stories/Library/availability-label/AvailabilityLabel.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.tsx
@@ -19,7 +19,7 @@ const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
       />
       {manifestationType && (
         <>
-          <p className="text-label-semibold ml-24">
+          <p className="availability-label__text text-label-semibold ml-24">
             {manifestationType.toUpperCase()}
           </p>
           <div className="availability-label--divider ml-4" />
@@ -27,12 +27,16 @@ const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
         </>
       )}
       {!manifestationType && (
-        <p className="text-label-normal ml-24 mr-8">{availability}</p>
+        <p className="availability-label__text text-label-normal ml-24 mr-8">
+          {availability}
+        </p>
       )}
       {quantity && (
         <>
           <div className="availability-label--divider ml-4" />
-          <p className="text-label-normal mx-8">{quantity} stk</p>
+          <p className="availability-label__text text-label-normal mx-8">
+            {quantity} stk
+          </p>
         </>
       )}
     </AvailabilityPagefold>

--- a/src/stories/Library/availability-label/AvailabilityLabel.tsx
+++ b/src/stories/Library/availability-label/AvailabilityLabel.tsx
@@ -13,7 +13,7 @@ const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
   return (
     <AvailabilityPagefold status={status}>
       <img
-        className={`availability-label--check ${status}`}
+        className={`availability-label__check ${status}`}
         src="icons/collection/Check.svg"
         alt="check-icon"
       />
@@ -22,7 +22,7 @@ const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
           <p className="availability-label__text text-label-semibold ml-24">
             {manifestationType.toUpperCase()}
           </p>
-          <div className="availability-label--divider ml-4" />
+          <div className="availability-label__divider ml-4" />
           <p className="text-label-normal ml-4 mr-8">{availability}</p>
         </>
       )}
@@ -33,7 +33,7 @@ const AvailabilityLabel: React.FC<AvailabilityLabelPropsType> = ({
       )}
       {quantity && (
         <>
-          <div className="availability-label--divider ml-4" />
+          <div className="availability-label__divider ml-4" />
           <p className="availability-label__text text-label-normal mx-8">
             {quantity} stk
           </p>

--- a/src/stories/Library/availability-label/availability-label.scss
+++ b/src/stories/Library/availability-label/availability-label.scss
@@ -32,4 +32,11 @@
       display: inline-block;
     }
   }
+
+  & p {
+    // We need to make sure that accessibility tools don't add a bottom margin to
+    // this text, as it would then be unreadable, hidden. We can do this as there
+    // is no paragraph of text following this text inside availability labels.
+    margin-bottom: 0px !important;
+  }
 }

--- a/src/stories/Library/availability-label/availability-label.scss
+++ b/src/stories/Library/availability-label/availability-label.scss
@@ -33,7 +33,7 @@
     }
   }
 
-  & p {
+  &__text {
     // We need to make sure that accessibility tools don't add a bottom margin to
     // this text, as it would then be unreadable, hidden. We can do this as there
     // is no paragraph of text following this text inside availability labels.

--- a/src/stories/Library/availability-label/availability-label.scss
+++ b/src/stories/Library/availability-label/availability-label.scss
@@ -16,13 +16,13 @@
     border: 1px solid $c-global-tertiary-1;
   }
 
-  &--divider {
+  &__divider {
     height: 14px;
     width: 1px;
     background-color: $c-global-tertiary-1;
   }
 
-  &--check {
+  &__check {
     width: 14px;
     position: absolute;
     left: 5px;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-430

#### Description
This PR makes sure text inside availability labels can't have a bottom margin.
We need to make sure that accessibility tools don't add a it to this text, as it would then be unreadable - hidden. We can afford to do this as there is no paragraph of text following the text inside availability labels.

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Connected PR taking these changes to dpl-react repository: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/372