### PR TITLE
Refactor headings tree structure for `Material Page`

### DIFF
--- a/src/stories/Blocks/material-manifestation-item/MaterialMainfestationItem.tsx
+++ b/src/stories/Blocks/material-manifestation-item/MaterialMainfestationItem.tsx
@@ -38,9 +38,9 @@ export const MaterialMainfestationItem = ({
         />
       </div>
       <div className="material-manifestation-item__text">
-        <h2 className="material-manifestation-item__title text-header-h4">
+        <h3 className="material-manifestation-item__title text-header-h4">
           {title}
-        </h2>
+        </h3>
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>
         <div
           className={`material-manifestation-item__details ${

--- a/src/stories/Blocks/material-page/MaterialPage.tsx
+++ b/src/stories/Blocks/material-page/MaterialPage.tsx
@@ -34,7 +34,7 @@ const MaterialPage: React.FC<MaterialPageProps> = ({
         ctaText={ctaText}
       />
       <MaterialDescription description={description} />
-      <Disclosure headline="Udgaver (2)" icon="Various">
+      <Disclosure headline="Udgaver (2)" icon="Various" headingLevel="h2">
         {amountOfRenders.map((item) => {
           return (
             <MaterialMainfestationItem
@@ -47,10 +47,10 @@ const MaterialPage: React.FC<MaterialPageProps> = ({
           );
         })}
       </Disclosure>
-      <Disclosure headline="Detaljer" icon="Receipt">
+      <Disclosure headline="Detaljer" icon="Receipt" headingLevel="h2">
         <ListDescription data={fakeData as ListData} className="pl-80 pb-48" />
       </Disclosure>
-      <Disclosure headline="Anmeldelser" icon="Create">
+      <Disclosure headline="Anmeldelser" icon="Create" headingLevel="h2">
         <Review
           numberOfReviews={1}
           meta="Meta headline"

--- a/src/stories/Blocks/material-page/MaterialPage.tsx
+++ b/src/stories/Blocks/material-page/MaterialPage.tsx
@@ -1,4 +1,4 @@
-import { Disclosure } from "../../Library/disclosure/Disclosure";
+import Disclosure from "../../Library/disclosure/Disclosure";
 import { generateId } from "../../Library/horizontal-term-line/HorizontalTermLine";
 import ListDescription, {
   ListData,

--- a/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
+++ b/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
@@ -1,4 +1,4 @@
-import { Disclosure } from "../../disclosure/Disclosure";
+import Disclosure from "../../disclosure/Disclosure";
 import { Button } from "../../Buttons/button/Button";
 import Modal from "../Modal";
 import facetBrowserDummyData from "./facet-browser-dummy-data";

--- a/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
+++ b/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
@@ -26,7 +26,7 @@ const FacetBrowser: React.FC<FacetBrowserProps> = ({
   >
     <section className="facet-browser">
       <header className="facet-browser__header">
-        <h3 className="text-header-h3">{title}</h3>
+        <h2 className="text-header-h3">{title}</h2>
         {clearAll && (
           <button className="link-tag cursor-pointer facet-browser__clear-btn">
             {clearAll}
@@ -40,6 +40,7 @@ const FacetBrowser: React.FC<FacetBrowserProps> = ({
           removeHeadlinePadding
           key={facet.title}
           headline={facet.title}
+          headingLevel="h3"
         >
           <div className="facet-browser__facet-group">
             {facet.tags.map((tag) => (

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -63,6 +63,7 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
       {branchesArray.map((branchKey) => {
         return (
           <Disclosure
+            headingLevel="h2"
             withAvailability
             fullWidth
             headline="Bibliotek fliale navn"

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -1,4 +1,4 @@
-import { Disclosure } from "../../disclosure/Disclosure";
+import Disclosure from "../../disclosure/Disclosure";
 import ListFindOnShelf from "../../Lists/list-find-on-shelf/ListFindOnShelf";
 import Modal from "../Modal";
 import { Dropdown } from "../../dropdown/Dropdown";

--- a/src/stories/Library/disclosure/Disclosure.stories.tsx
+++ b/src/stories/Library/disclosure/Disclosure.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
-import { Disclosure, DisclosureProps } from "./Disclosure";
+import Disclosure, { DisclosureProps } from "./Disclosure";
 
 export default {
   title: "Library / Disclosure",

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -13,7 +13,7 @@ export type DisclosureProps = {
   headingLevel: HeadingLevelType;
 };
 
-export const Disclosure: React.FC<DisclosureProps> = ({
+const Disclosure: React.FC<DisclosureProps> = ({
   headline,
   children,
   icon,

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { clsx } from "clsx";
 import AvailabilityLabel from "../availability-label/AvailabilityLabel";
+import Heading, { HeadingLevelType } from "../heading/Heading";
 
 export type DisclosureProps = {
   headline: string;
@@ -9,6 +10,7 @@ export type DisclosureProps = {
   withAvailability?: boolean;
   fullWidth?: boolean;
   removeHeadlinePadding?: boolean;
+  headingLevel?: HeadingLevelType;
 };
 
 export const Disclosure: React.FC<DisclosureProps> = ({
@@ -18,6 +20,7 @@ export const Disclosure: React.FC<DisclosureProps> = ({
   withAvailability,
   fullWidth = false,
   removeHeadlinePadding,
+  headingLevel,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
@@ -45,13 +48,14 @@ export const Disclosure: React.FC<DisclosureProps> = ({
             />
           </div>
         )}
-        <h2
+        <Heading
+          level={headingLevel || "h2"}
           className={`text-body-large disclosure__text ${
             withAvailability ? "disclosure__text--shorter" : ""
           }`}
         >
           {headline}
-        </h2>
+        </Heading>
         {withAvailability && (
           <AvailabilityLabel availability="Hjemme" status="available" />
         )}

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -45,13 +45,13 @@ export const Disclosure: React.FC<DisclosureProps> = ({
             />
           </div>
         )}
-        <span
-          className={`disclosure__text ${
+        <h2
+          className={`text-body-large disclosure__text ${
             withAvailability ? "disclosure__text--shorter" : ""
           }`}
         >
           {headline}
-        </span>
+        </h2>
         {withAvailability && (
           <AvailabilityLabel availability="Hjemme" status="available" />
         )}

--- a/src/stories/Library/disclosure/Disclosure.tsx
+++ b/src/stories/Library/disclosure/Disclosure.tsx
@@ -10,7 +10,7 @@ export type DisclosureProps = {
   withAvailability?: boolean;
   fullWidth?: boolean;
   removeHeadlinePadding?: boolean;
-  headingLevel?: HeadingLevelType;
+  headingLevel: HeadingLevelType;
 };
 
 export const Disclosure: React.FC<DisclosureProps> = ({
@@ -49,7 +49,7 @@ export const Disclosure: React.FC<DisclosureProps> = ({
           </div>
         )}
         <Heading
-          level={headingLevel || "h2"}
+          level={headingLevel}
           className={`text-body-large disclosure__text ${
             withAvailability ? "disclosure__text--shorter" : ""
           }`}

--- a/src/stories/Library/heading/Heading.stories.tsx
+++ b/src/stories/Library/heading/Heading.stories.tsx
@@ -11,7 +11,7 @@ export default {
       options: ["h2", "h3", "h4", "h5"],
     },
     className: {
-      name: "Heading classNames",
+      name: "Heading class names",
       control: "text",
     },
     children: {

--- a/src/stories/Library/heading/Heading.stories.tsx
+++ b/src/stories/Library/heading/Heading.stories.tsx
@@ -1,0 +1,59 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Heading from "./Heading";
+
+export default {
+  title: "Library / Heading",
+  component: Heading,
+  argTypes: {
+    level: {
+      name: "Heading level",
+      control: "radio",
+      options: ["h2", "h3", "h4", "h5"],
+    },
+    className: {
+      name: "Heading classNames",
+      control: "text",
+    },
+    children: {
+      name: "Heading text",
+      control: "text",
+    },
+  },
+
+  parameters: {},
+} as ComponentMeta<typeof Heading>;
+
+const Template: ComponentStory<typeof Heading> = (args) => (
+  <Heading {...args} />
+);
+
+export const H2 = Template.bind({});
+H2.args = {
+  level: "h2",
+  children: "Heading 2",
+};
+
+export const H3 = Template.bind({});
+H3.args = {
+  level: "h3",
+  children: "Heading 3",
+};
+
+export const H4 = Template.bind({});
+H4.args = {
+  level: "h4",
+  children: "Heading 4",
+};
+
+export const H5 = Template.bind({});
+H5.args = {
+  level: "h5",
+  children: "Heading 5",
+};
+
+export const H5WithClassNames = Template.bind({});
+H5WithClassNames.args = {
+  level: "h5",
+  className: "text-header-h2",
+  children: "Heading With ClassNames",
+};

--- a/src/stories/Library/heading/Heading.tsx
+++ b/src/stories/Library/heading/Heading.tsx
@@ -10,7 +10,7 @@ type HeadingProps = {
 
 const Heading: React.FunctionComponent<HeadingProps> = ({
   children,
-  level,
+  level = "h2",
   className,
 }) => {
   const HeadingTag = level as keyof JSX.IntrinsicElements;

--- a/src/stories/Library/heading/Heading.tsx
+++ b/src/stories/Library/heading/Heading.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export type HeadingLevelType = "h2" | "h3" | "h4" | "h5";
+
+type HeadingProps = {
+  children: React.ReactNode;
+  level: HeadingLevelType;
+  className?: string;
+};
+
+const Heading: React.FunctionComponent<HeadingProps> = ({
+  children,
+  level,
+  className,
+}) => {
+  const HeadingTag = level as keyof JSX.IntrinsicElements;
+
+  return <HeadingTag className={className}>{children}</HeadingTag>;
+};
+
+export default Heading;

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -31,10 +31,10 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
 
   return (
     <div className="text-small-caption horizontal-term-line">
-      <p className="text-label-bold">
+      <h3 className="text-label-bold">
         {`${title}`}{" "}
         {subTitle && <span className="text-small-caption">{subTitle} </span>}
-      </p>
+      </h3>
 
       {itemsToShow.map((link, index) => (
         <span key={generateId(index)}>

--- a/src/stories/Library/review/Review.tsx
+++ b/src/stories/Library/review/Review.tsx
@@ -54,7 +54,7 @@ export const Review: React.FC<ReviewProps> = ({
                 );
               })}
             </div>
-            <div className="review__headline mb-8">{headline}</div>
+            <h3 className="review__headline mb-8">{headline}</h3>
             {body && <p className="review__body mb-8">{body}</p>}
             {linkText && (
               <a href={linkLink} className="link-tag text-small-caption mb-8">


### PR DESCRIPTION
# DPL-REACT:  https://github.com/danskernesdigitalebibliotek/dpl-react/pull/387
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-452
https://reload.atlassian.net/browse/DDFSOEG-422
https://reload.atlassian.net/browse/DDFSOEG-423

#### This PR is refactoring the headings tree structure for the `Material Page`
To improve user navigation and content comprehension

#### it also adds a new `Heading` component to the codebase. 
The component allows for dynamic generation of the HTML tag based on the level prop provided, which can be one of four options (h2, h3, h4, or h5).



#### Screenshot of the result
<img width="166" alt="Skærmbillede 2023-03-09 kl  16 02 57" src="https://user-images.githubusercontent.com/49920322/224068035-92d67d71-863b-4d09-b0a8-df003f758576.png">

![image](https://user-images.githubusercontent.com/49920322/224969765-e4ee0a44-d522-4b2f-af0c-3c810199f50f.png)



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.