### PR TITLE
Fix/autosuggest structure

### DIFF
--- a/src/stories/Library/autosuggest-material/AutosuggestMaterial.tsx
+++ b/src/stories/Library/autosuggest-material/AutosuggestMaterial.tsx
@@ -14,33 +14,28 @@ export const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
 }) => {
   return (
     <ul className="autosuggest pb-16">
-      <li>
-        <ul>
-          <li className="autosuggest__text text-body-medium-regular px-24">
-            I am a contextual text item
-          </li>
-        </ul>
+      {/* The contextual item needs to be up to date with AutosuggestText.tsx as it imitates it. */}
+      <li className="autosuggest__text-item text-body-medium-regular px-24">
+        <p className="autosuggest__text text-body-medium-regular">
+          I am a contextual item
+        </p>
       </li>
       <li className="autosuggest__divider" />
-      <li>
-        <ul className="autosuggest__materials">
-          {items.map((item) => {
-            return (
-              <li className="autosuggest__material">
-                <div className="autosuggest__material__content">
-                  <Cover size="xsmall" animate src={item.cover} shadow />
-                  <div className="autosuggest__info">
-                    <div className="text-body-medium-medium autosuggest__title">
-                      {item.title}
-                    </div>
-                    <div className="text-body-small-regular autosuggest__author">{`${item.author} (${item.year})`}</div>
-                  </div>
+      {items.map((item) => {
+        return (
+          <li className="autosuggest__material-item">
+            <div className="autosuggest__material-card">
+              <Cover size="xsmall" animate src={item.cover} shadow />
+              <div className="autosuggest__info">
+                <div className="text-body-medium-medium autosuggest__title">
+                  {item.title}
                 </div>
-              </li>
-            );
-          })}
-        </ul>
-      </li>
+                <div className="text-body-small-regular autosuggest__author">{`${item.author} (${item.year})`}</div>
+              </div>
+            </div>
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/src/stories/Library/autosuggest-material/autosuggest-material.scss
+++ b/src/stories/Library/autosuggest-material/autosuggest-material.scss
@@ -5,32 +5,21 @@
     height: 1px;
     border: 0;
     border-top: 1px solid $c-global-tertiary-1;
-    margin: 20px 0;
+    margin: $s-md 0;
     padding: 0;
   }
 
-  &__materials {
-    display: flex;
-    flex-direction: column;
-    margin: 0 15px;
-
-    @include breakpoint-m {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      justify-content: center;
-    }
-  }
-
-  &__material {
+  &__material-item {
     width: 100%;
-    overflow: hidden;
-    padding: 7px 0;
+    overflow: visible;
+    padding: $s-sm $s-md;
 
     &:last-child {
       margin-bottom: 0;
     }
 
     @include breakpoint-m {
+      width: calc(100% / 3);
       // Because the main autosuggest is a prominent feature we don't want the hover
       // effect to take effect on phones, as iPhones have a known bug that requires
       // users to double click in order to get past hover to register a click.
@@ -43,13 +32,13 @@
     &--highlight {
       background-color: $c-global-secondary;
     }
+  }
 
-    &__content {
-      display: flex;
-      flex-flow: row nowrap;
-      gap: 15px;
-      width: 95%;
-    }
+  &__material-card {
+    display: flex;
+    flex-flow: row nowrap;
+    gap: 15px;
+    width: 95%;
   }
 
   &__info {

--- a/src/stories/Library/autosuggest-text/AutosuggestText.tsx
+++ b/src/stories/Library/autosuggest-text/AutosuggestText.tsx
@@ -7,22 +7,18 @@ export const AutosuggestText = (props: AutosuggestTextProps) => {
   const { items, categoryText } = props;
   return (
     <ul className="autosuggest pb-16">
-      <li>
-        <ul>
-          {items.map((item) => {
-            return (
-              <li className="autosuggest__text text-body-medium-regular px-24">
-                {item}
-                {categoryText && (
-                  <div className="boxed-text text-tags noselect ml-8">
-                    {categoryText}
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      </li>
+      {items.map((item) => {
+        return (
+          <li className="autosuggest__text-item text-body-medium-regular px-24">
+            <p className="autosuggest__text text-body-medium-regular">{item}</p>
+            {categoryText && (
+              <div className="boxed-text text-tags noselect ml-8">
+                {categoryText}
+              </div>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/src/stories/Library/autosuggest-text/autosuggest-text.scss
+++ b/src/stories/Library/autosuggest-text/autosuggest-text.scss
@@ -6,15 +6,16 @@
   right: 0;
   top: calc(100% + 1px);
   z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding-top: $s-md;
 
-  @include breakpoint-m {
-    padding-top: $s-md;
-  }
-
-  &__text {
+  &__text-item {
+    min-height: 40px;
+    width: 100%;
     display: flex;
     align-items: center;
-    min-height: 40px;
 
     @include breakpoint-m {
       // Because the main autosuggest is a prominent feature we don't want the hover
@@ -30,10 +31,17 @@
 
     @include breakpoint-l {
       height: 40px;
+      padding-right: $s-lg;
     }
 
     &--highlight {
       background-color: $c-global-secondary;
     }
+  }
+
+  &__text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-433
https://reload.atlassian.net/browse/DDFSOEG-432
https://reload.atlassian.net/browse/DDFSOEG-431

#### Description
According to https://www.w3.org/TR/wai-aria-1.1/#option & https://www.w3.org/TR/wai-aria-1.1/#listbox our autosuggest wasn't living up to accessibility criteria, where unordered lists of role "listbox" needs to have direct list items that are of role "option" OR own them. Plus an unordered list without a role needs to be a parent to list items.
This PR fixes these problems, plus some minor scss corrections according to the BEM structure.

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a