### PR TITLE
Ensure baseline alignment for `HorizontalTermLine` + Separate `ButtonExpand` component

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -32,6 +32,7 @@
 @import "./src/stories/Library/Icons/icon-favourite/icon-favourite";
 @import "./src/stories/Library/Buttons/button-favourite/button-favourite";
 @import "./src/stories/Library/Buttons/icon-button/icon-button";
+@import "./src/stories/Library/Buttons/button/button-expand/button-expand";
 @import "./src/stories/Library/warning-status/warning-status";
 @import "./src/stories/Library/availability-label/availability-label";
 @import "./src/stories/Library/avatar/avatar";

--- a/src/stories/Library/Buttons/button/button-expand/ButtonExpand.tsx
+++ b/src/stories/Library/Buttons/button/button-expand/ButtonExpand.tsx
@@ -1,0 +1,28 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+export type ButtonExpandProps = {
+  showMore: boolean;
+  setShowMore: (showMore: boolean) => void;
+};
+
+const ButtonExpand: FC<ButtonExpandProps> = ({ showMore, setShowMore }) => {
+  return (
+    <button
+      className="button-expand"
+      type="button"
+      onClick={() => setShowMore(!showMore)}
+      aria-label="Expand More"
+    >
+      <img
+        className={clsx("button-expand__image", {
+          "button-expand__image--expanded": showMore,
+        })}
+        src="icons/collection/ExpandMore.svg"
+        alt=""
+      />
+    </button>
+  );
+};
+
+export default ButtonExpand;

--- a/src/stories/Library/Buttons/button/button-expand/button-expand.scss
+++ b/src/stories/Library/Buttons/button/button-expand/button-expand.scss
@@ -1,0 +1,12 @@
+.button-expand {
+  cursor: pointer;
+  align-self: center;
+
+  &__image {
+    transition: transform 0.3s ease-in-out;
+
+    &.button-expand__image--expanded {
+      transform: scaleY(-1);
+    }
+  }
+}

--- a/src/stories/Library/Buttons/button/button-expand/button-expand.stories.tsx
+++ b/src/stories/Library/Buttons/button/button-expand/button-expand.stories.tsx
@@ -1,0 +1,34 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import ButtonExpand, { ButtonExpandProps } from "./ButtonExpand";
+
+export default {
+  title: "Library / Buttons / Button Expand",
+  component: ButtonExpand,
+  parameters: {},
+  argTypes: {
+    showMore: {
+      control: {
+        type: "boolean",
+      },
+      title: {
+        control: {
+          type: "text",
+        },
+      },
+    },
+  },
+} as ComponentMeta<typeof ButtonExpand>;
+
+const Template: ComponentStory<typeof ButtonExpand> = (
+  args: ButtonExpandProps
+) => <ButtonExpand {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  showMore: false,
+};
+
+export const Expand = Template.bind({});
+Expand.args = {
+  showMore: true,
+};

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,5 +1,5 @@
-import clsx from "clsx";
 import { useState } from "react";
+import ButtonExpand from "../Buttons/button/button-expand/ButtonExpand";
 
 export interface HorizontalTermLineList {
   url: string;
@@ -45,19 +45,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
       ))}
 
       {showMoreButton && (
-        <button
-          type="button"
-          onClick={() => setShowMore(!showMore)}
-          aria-label="Expand More"
-        >
-          <img
-            className={clsx("horizontal-term-line__expand", {
-              "horizontal-term-line__expand--expanded": showMore,
-            })}
-            src="icons/collection/ExpandMore.svg"
-            alt=""
-          />
-        </button>
+        <ButtonExpand showMore={showMore} setShowMore={setShowMore} />
       )}
     </div>
   );

--- a/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
+++ b/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
@@ -1,6 +1,6 @@
 .horizontal-term-line {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   flex-wrap: wrap;
   white-space: nowrap;
   gap: $s-sm;
@@ -8,20 +8,5 @@
   // Set all text to the same font size even if other text classes have been used.
   * {
     font-size: 12px;
-  }
-
-  &__list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $s-sm;
-  }
-
-  &__expand {
-    cursor: pointer;
-    transition: transform 0.3s ease-in-out;
-
-    &--expanded {
-      transform: scaleY(-1);
-    }
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-488

#### Description

This pull request addresses alignment issues in the horizontal-term-line component and improves reusability by extracting the ButtonExpand functionality into a separate component.

#### Screenshot of the result
See https://www.chromatic.com/test?appId=616ffdab9acbf5003ad5fd2b&id=643e7cc368aa7db42330a82e


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Here are the reflecting changes in dpl-react
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/421