### PR TITLE
Modify `.material-header__button` CSS to target direct child elements

### DIFF
--- a/src/stories/Library/material-header/material-header.scss
+++ b/src/stories/Library/material-header/material-header.scss
@@ -59,7 +59,7 @@
   }
 
   // set all buttons to the full width
-  &__button button {
+  &__button > * {
     width: 100%;
     @include breakpoint-m {
       width: 346px;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-507

#### Description
This Pull Request addresses the problems that arose when the material's CTA button could be either an 'a' tag or a 'button'. The changes implemented ensure suitable styling for both types of elements.

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions