### PR TITLE
Fix 'g' letters being cut at the bottom.

### DIFF
--- a/src/stories/Library/card-list-item/card-list-item.scss
+++ b/src/stories/Library/card-list-item/card-list-item.scss
@@ -65,5 +65,6 @@
     margin-top: 16px;
     overflow: hidden;
     text-overflow: ellipsis;
+    min-height: 30px;
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-514

#### Description

This pull request addresses the issue where letters like 'g' are cut off at the bottom.

To fix this, I added a `min-height` property to the `.search-result-item__title` class. This prevents letters like "g" from getting cut off due to the use of `text-overflow: ellipsis;` and `overflow: hidden;`. With the inclusion of `min-height: 30px;`, the display is now correct.

#### Screenshot of the result
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/49920322/234280044-b04d3982-7b03-4237-9c40-2763eb645b8d.png">
Screenshot is from dpl-react

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Remember to update the dpl-design-system in dpl-react