### PR TITLE
Fix/autosuggest dividers

### DIFF
--- a/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
+++ b/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
+import clsx from "clsx";
 import { Autosuggest, AutosuggestProps } from "./Autosuggest";
 import AutosuggestMaterialStories from "../../Library/autosuggest-material/AutosuggestMaterial.stories";
 import AutosuggestTextStories from "../../Library/autosuggest-text/AutosuggestText.stories";
@@ -68,9 +69,10 @@ const getStoryArguments = (suggestions: number) => {
     },
     classes: {
       ...{ ...AutosuggestMaterialStories.argTypes?.classes },
-      defaultValue: `autosuggest__material-item--${
-        suggestions === 2 ? "two" : ""
-      }${suggestions === 1 ? "one" : ""}`,
+      defaultValue: clsx({
+        "autosuggest__material-item--two": suggestions === 2,
+        "autosuggest__material-item--one": suggestions === 1,
+      }),
     },
   };
 };

--- a/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
+++ b/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
@@ -1,10 +1,9 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import { Autosuggest, AutosuggestProps } from "./Autosuggest";
-import AutosuggestMaterialStories, {
-  autosuggestMaterialSuggestions,
-} from "../../Library/autosuggest-material/AutosuggestMaterial.stories";
+import AutosuggestMaterialStories from "../../Library/autosuggest-material/AutosuggestMaterial.stories";
 import AutosuggestTextStories from "../../Library/autosuggest-text/AutosuggestText.stories";
+import { autosuggestMaterialSuggestions } from "../../Library/autosuggest-material/helper";
 
 export default {
   title: "Blocks / Autosuggest",

--- a/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
+++ b/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
@@ -1,7 +1,9 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import { Autosuggest, AutosuggestProps } from "./Autosuggest";
-import AutosuggestMaterialStories from "../../Library/autosuggest-material/AutosuggestMaterial.stories";
+import AutosuggestMaterialStories, {
+  autosuggestMaterialSuggestions,
+} from "../../Library/autosuggest-material/AutosuggestMaterial.stories";
 import AutosuggestTextStories from "../../Library/autosuggest-text/AutosuggestText.stories";
 
 export default {
@@ -57,3 +59,25 @@ const Template: ComponentStory<typeof Autosuggest> = (
 );
 
 export const Default = Template.bind({});
+
+const getStoryArguments = (suggestions: number) => {
+  return {
+    ...AutosuggestTextStories.argTypes,
+    materialSuggestions: {
+      ...{ ...AutosuggestMaterialStories.argTypes?.materialSuggestions },
+      defaultValue: autosuggestMaterialSuggestions.slice(0, suggestions),
+    },
+    classes: {
+      ...{ ...AutosuggestMaterialStories.argTypes?.classes },
+      defaultValue: `autosuggest__material-item--${
+        suggestions === 2 ? "two" : ""
+      }${suggestions === 1 ? "one" : ""}`,
+    },
+  };
+};
+
+export const TwoMaterials = Template.bind({});
+TwoMaterials.argTypes = getStoryArguments(2);
+
+export const OneMaterial = Template.bind({});
+OneMaterial.argTypes = getStoryArguments(1);

--- a/src/stories/Blocks/autosuggest/Autosuggest.tsx
+++ b/src/stories/Blocks/autosuggest/Autosuggest.tsx
@@ -13,11 +13,15 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
   textSuggestions,
   categoryText,
   materialSuggestions,
+  classes,
 }) => {
   return (
     <ul className="autosuggest pb-16">
       <AutosuggestText textSuggestions={textSuggestions} />
-      <AutosuggestMaterial materialSuggestions={materialSuggestions} />
+      <AutosuggestMaterial
+        materialSuggestions={materialSuggestions}
+        classes={classes}
+      />
       <AutosuggestText
         textSuggestions={textSuggestions}
         categoryText={categoryText}

--- a/src/stories/Library/autosuggest-material/AutosuggestMaterial.stories.tsx
+++ b/src/stories/Library/autosuggest-material/AutosuggestMaterial.stories.tsx
@@ -4,27 +4,7 @@ import {
   AutosuggestMaterial,
   AutosuggestMaterialProps,
 } from "./AutosuggestMaterial";
-
-export const autosuggestMaterialSuggestions = [
-  {
-    cover: "images/book_cover_1.jpg",
-    title: "De uadskillelige",
-    author: "Simone De Beauvoir",
-    year: "1954",
-  },
-  {
-    cover: "images/book_cover_2.jpg",
-    title: "Den lille bog om dansk design",
-    author: "Marie Hugsted",
-    year: "2018",
-  },
-  {
-    cover: "images/book_cover_3.jpg",
-    title: "Audrey Hepburn",
-    author: "Maria Isabel Sanchez Vegara",
-    year: "2018",
-  },
-];
+import { autosuggestMaterialSuggestions } from "./helper";
 
 export default {
   title: "Library / Autosuggest - Material",

--- a/src/stories/Library/autosuggest-material/AutosuggestMaterial.stories.tsx
+++ b/src/stories/Library/autosuggest-material/AutosuggestMaterial.stories.tsx
@@ -5,7 +5,7 @@ import {
   AutosuggestMaterialProps,
 } from "./AutosuggestMaterial";
 
-const autosuggestMaterialSuggestions = [
+export const autosuggestMaterialSuggestions = [
   {
     cover: "images/book_cover_1.jpg",
     title: "De uadskillelige",
@@ -35,6 +35,11 @@ export default {
       name: "Material suggestions",
       defaultValue: autosuggestMaterialSuggestions,
       control: { type: "array" },
+    },
+    classes: {
+      name: "Classes",
+      defaultValue: undefined,
+      control: { type: "text" },
     },
   },
   parameters: {

--- a/src/stories/Library/autosuggest-material/AutosuggestMaterial.tsx
+++ b/src/stories/Library/autosuggest-material/AutosuggestMaterial.tsx
@@ -7,16 +7,18 @@ export type AutosuggestMaterialProps = {
     author: string;
     year: string;
   }[];
+  classes?: string;
 };
 
 export const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
   materialSuggestions,
+  classes,
 }) => {
   return (
     <>
       {materialSuggestions.map((item) => {
         return (
-          <li className="autosuggest__material-item">
+          <li className={`autosuggest__material-item ${classes || ""}`}>
             <div className="autosuggest__material-card">
               <Cover size="xsmall" animate src={item.cover} shadow />
               <div className="autosuggest__info">

--- a/src/stories/Library/autosuggest-material/autosuggest-material.scss
+++ b/src/stories/Library/autosuggest-material/autosuggest-material.scss
@@ -18,6 +18,18 @@
       }
     }
 
+    &.autosuggest__material-item--two {
+      @include breakpoint-m {
+        width: calc(100% / 2);
+      }
+    }
+
+    &.autosuggest__material-item--one {
+      @include breakpoint-m {
+        width: 100%;
+      }
+    }
+
     &--highlight {
       background-color: $c-global-secondary;
     }

--- a/src/stories/Library/autosuggest-material/helper.ts
+++ b/src/stories/Library/autosuggest-material/helper.ts
@@ -1,0 +1,22 @@
+export const autosuggestMaterialSuggestions = [
+  {
+    cover: "images/book_cover_1.jpg",
+    title: "De uadskillelige",
+    author: "Simone De Beauvoir",
+    year: "1954",
+  },
+  {
+    cover: "images/book_cover_2.jpg",
+    title: "Den lille bog om dansk design",
+    author: "Marie Hugsted",
+    year: "2018",
+  },
+  {
+    cover: "images/book_cover_3.jpg",
+    title: "Audrey Hepburn",
+    author: "Maria Isabel Sanchez Vegara",
+    year: "2018",
+  },
+];
+
+export default {};


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-520

#### Description
This PR fixes a bug for autosuggest - material suggestions where if we got less than three items the dividers between sections would not span the full width as seen on the picture:
![image](https://user-images.githubusercontent.com/28546954/235455587-fcd17716-68c2-41d2-b8cc-1f0a8403fce8.png)

#### Screenshot of the result
Two items desktop:
![image](https://user-images.githubusercontent.com/28546954/235455692-3978703e-2958-4555-b57b-ee8530605e69.png)

Two items mobile:
![image](https://user-images.githubusercontent.com/28546954/235455781-bbdb16eb-c151-4616-87c2-ebc3136a1843.png)

One item desktop:
![image](https://user-images.githubusercontent.com/28546954/235455845-a9103909-e88a-4059-b4c8-95f1b8efec24.png)

One item mobile:
![image](https://user-images.githubusercontent.com/28546954/235455873-28b71b9d-649c-40e2-82cb-b1843700c781.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
