### PR TITLE
Update `MaterialPageSkeleton` to reflect the new cover size on mobile

### DIFF
--- a/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
+++ b/src/stories/Blocks/material-page/MaterialPageSkeleton.tsx
@@ -3,7 +3,7 @@ const MaterialPageSkeleton: React.FC = () => {
     <section className="material-page ssc">
       <header className="material-header">
         <div className="material-header__cover">
-          <div className="ssc-square cover--size-xlarge" />
+          <div className="ssc-square cover cover--size-xlarge cover--aspect-xlarge" />
         </div>
         <div className="material-header__content">
           <div>

--- a/src/stories/Blocks/material-page/material-page-skeleton.scss
+++ b/src/stories/Blocks/material-page/material-page-skeleton.scss
@@ -6,11 +6,6 @@
 .material-page {
   &.ssc {
     .material-header {
-      &__cover {
-        .ssc-square {
-          width: 300px;
-        }
-      }
       &__content {
         height: 605px;
         // Favorite icon.


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-522


#### Description
This PR is changing the `MaterialPageSkeleton` to reflect the new cover size on mobile.

#### Screenshot of the result
https://www.chromatic.com/build?appId=616ffdab9acbf5003ad5fd2b&number=866

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/438
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/312