### PR TITLE
Fix lower part of letters being cut off in `CardListItem` titles

### DIFF
--- a/src/stories/Library/card-list-item/CardListItem.tsx
+++ b/src/stories/Library/card-list-item/CardListItem.tsx
@@ -52,7 +52,7 @@ export const CardListItem = ({
           )}
         </div>
 
-        <h2 className="card-list-item__title text-header-h4 mb-4">
+        <h2 className="card-list-item__title text-header-h4">
           <a href="">{title}</a>
         </h2>
         <p className="text-small-caption">{`Af ${author} (${year})`}</p>

--- a/src/stories/Library/card-list-item/card-list-item.scss
+++ b/src/stories/Library/card-list-item/card-list-item.scss
@@ -65,6 +65,6 @@
     margin-top: 16px;
     overflow: hidden;
     text-overflow: ellipsis;
-    min-height: 30px;
+    min-height: 35px;
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-514

#### Description

This pull request addresses an issue where the lower part of letters was being cut off in `CardListItem` titles due to the usage of the `ellipsis` property. 

To resolve this, the following changes have been implemented:

- Added a min-height of 35px to ensure there is enough space for the text.
- Removed the unnecessary margin-bottom property.

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions