### PR TITLE
5820: remove arrows from number input

### DIFF
--- a/src/stories/Library/Forms/input/input.scss
+++ b/src/stories/Library/Forms/input/input.scss
@@ -30,4 +30,16 @@
     @extend %text-body-small-regular;
     @extend %mt-8;
   }
+
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type="number"] {
+    -moz-appearance: textfield;
+  }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5820

#### Description

Removed "confusing arrows"

#### Screenshot of the result

<img width="1015" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/15377965/0e3fb4b3-a8ce-4391-a439-e6f3b806398c">


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

n/a
