### PR TITLE
Skip deploy workflow for Dependabot

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,6 +1,10 @@
 name: Deployment
 
-on: push
+on:
+  push:
+    branches-ignore:
+      # Dependabot does not have permissions to create releases
+      - 'dependabot/**'
 
 jobs:
   deploy_release:


### PR DESCRIPTION
#### Description

Dependabot does not have permissions to create deployments. This causes  the workflow to fail.

According to GitHub having Dependabot run with read-only scopes is  intentional and the recommended approach is to skip running such  workflows based on branch naming:
https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/resource-not-accessible-by-integration

This is a sister PR to danskernesdigitalebibliotek/dpl-react#546