### PR TITLE
Improved space for status label in list dashboard

### DIFF
--- a/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
@@ -12,6 +12,7 @@
     &:hover {
       .list-dashboard__arrow {
         visibility: visible;
+        display: block;
       }
     }
   }
@@ -37,6 +38,7 @@
 }
 
 .list-dashboard__arrow {
+  display: none;
   visibility: hidden;
   margin-left: auto;
   width: 90px; // Avoids extending beyond the edge of the box.

--- a/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
@@ -12,7 +12,6 @@
     &:hover {
       .list-dashboard__arrow {
         visibility: visible;
-        display: block;
       }
     }
   }
@@ -42,4 +41,8 @@
   visibility: hidden;
   margin-left: auto;
   width: 90px; // Avoids extending beyond the edge of the box.
+
+  @include breakpoint-s {
+    display: block;
+  }
 }

--- a/src/stories/Library/status-label/status-label.scss
+++ b/src/stories/Library/status-label/status-label.scss
@@ -5,6 +5,7 @@
   justify-content: center;
   align-items: center;
   font-size: 10px;
+  line-height: 11px; //keep text inside when it is wrapped
 
   @include breakpoint-s {
     padding: 0 16px;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-207

#### Description

The current implementation does not hide the dashboard arrow on mobile devices which gives limited space for the status label.
I allowed more space by hiding the arrow on mobile and added less line hight for the status label.

#### Screenshot of the result
Normal size mobile
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/2a30a878-79a1-4d91-a7f4-ad2a1ff5dde7)
Small size mobile
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/9c5d52a5-941d-4249-a188-59a554cfc50c)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
