### PR TITLE
Group Dependabot updates for Storybook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
       timezone: Europe/Copenhagen
     labels:
       - dependencies
+    groups:
+      storybook:
+        patterns:
+          - "@storybook/*"


### PR DESCRIPTION
#### Description

We use many packages from Storybook. These are often updated in parallel  and may have dependencies between them. Thus is makes sense to group  updates of these packages in Dependabot to ensure that we get an update  to e.g. Storybook 7 in the same pull request.