### PR TITLE
Align label right on mobile

### DIFF
--- a/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
@@ -6,8 +6,16 @@
   padding: 16px;
   text-decoration: none;
 
+  & .status-label {
+    margin-left: auto;
+  }
+
   @include breakpoint-s {
     padding: 16px 24px;
+
+    & .status-label {
+      margin-left: unset;
+    }
 
     &:hover {
       .list-dashboard__arrow {


### PR DESCRIPTION
The current implementation does not align the status labels and gives a bit messy dashboard. On mobile we want to align the labels to the right.

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

