### PR TITLE
Align label right on mobile

### DIFF
--- a/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
@@ -6,8 +6,16 @@
   padding: 16px;
   text-decoration: none;
 
+  & .status-label {
+    margin-left: auto;
+  }
+
   @include breakpoint-s {
     padding: 16px 24px;
+
+    & .status-label {
+      margin-left: unset;
+    }
 
     &:hover {
       .list-dashboard__arrow {


### PR DESCRIPTION
#### Link to issue
This is a follow-up on below issue
https://reload.atlassian.net/browse/DDFLSBP-207

#### Description
The current implementation does not align the status labels and gives a bit messy dashboard. On mobile we want to align the labels to the right.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/aa43e74c-db51-4825-b2c5-081d610fd5c8)