### PR TITLE
Added hover state for buttons

### DIFF
--- a/src/stories/Library/Buttons/button/buttons.scss
+++ b/src/stories/Library/Buttons/button/buttons.scss
@@ -19,6 +19,8 @@ $c-btn-border-disabled: $c-global-tertiary-2;
   border: 1px solid $c-btn-border-active;
   cursor: pointer;
   white-space: nowrap;
+  transition: background-color 0.4s ease-in-out, color 0.2s ease-in-out,
+    opacity 0.4s ease-in-out;
 
   @extend %text-button-placeholder;
 
@@ -32,6 +34,7 @@ $c-btn-border-disabled: $c-global-tertiary-2;
     border: 1px solid $c-btn-border-disabled;
     color: $c-btn-border-disabled;
     fill: $c-btn-border-disabled;
+    cursor: not-allowed;
 
     .arrow__body {
       stroke: $c-btn-border-disabled;
@@ -68,12 +71,21 @@ $c-btn-border-disabled: $c-global-tertiary-2;
   padding: 0 24px;
 }
 
-.btn-filled {
+.btn-filled:not([disabled]) {
   background-color: $c-text-primary-black;
   color: $c-text-primary-white;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }
 
 .btn-outline {
   background-color: transparent;
   color: $c-text-primary-black;
+
+  &:not([disabled]):hover {
+    background-color: $c-text-primary-black;
+    color: $c-text-primary-white;
+  }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-77

#### Description
Buttons have a very "dead" interaction, and we need to show the user when they hover it. This adds some opacity to filled hovered buttons, and fill to outlined hovered buttons. It also aligns the filled disabled state with the figma design

#### Screenshot of the result
![FilledStateHoverArrow](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/355a8133-3199-48d6-9b40-7ffc3368bb34)
![FilledStateHover](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/d1ea0242-2d6b-4e82-8313-bf675fdae99f)
![DisabledStateHover](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/cabf34df-6b58-4253-91bf-b87affcc8352)
![ArrowStateHover](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/a928d124-c5f2-4996-bbf4-113ade06ab3d)
![DefaultStateHover](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/0f077642-d6ea-4121-aaf7-b05d8d99007a)


