### PR TITLE
Refactor pause reservation banner

### DIFF
--- a/src/stories/Library/pause-reservation/PauseReservation.stories.tsx
+++ b/src/stories/Library/pause-reservation/PauseReservation.stories.tsx
@@ -10,9 +10,13 @@ export default {
     isChecked: {
       defaultValue: true,
     },
-    text: {
+    pauseText: {
       control: "text",
       defaultValue: "Sæt fysiske reserveringer på pause",
+    },
+    isPausedtext: {
+      control: "text",
+      defaultValue: "Dine fysiske reserveringer er på pause",
     },
     dates: {
       control: "text",

--- a/src/stories/Library/pause-reservation/PauseReservation.tsx
+++ b/src/stories/Library/pause-reservation/PauseReservation.tsx
@@ -1,14 +1,14 @@
-import ToggleButton from "../Buttons/toggle-button/ToggleButton";
-
 export type PauseReservationProps = {
   isChecked: boolean;
-  text: string;
+  isPausedtext: string;
+  pauseText: string;
   dates: string;
 };
 
 export const PauseReservation = ({
   isChecked,
-  text,
+  pauseText,
+  isPausedtext,
   dates,
 }: PauseReservationProps) => {
   return (
@@ -19,7 +19,7 @@ export const PauseReservation = ({
           <img src="icons/collection/Reservations.svg" alt="" />
         </div>
         <div className="dpl-pause-reservation-component__flex__text">
-          {text}
+          {isChecked ? isPausedtext : pauseText}
         </div>
         {isChecked && (
           <span
@@ -30,7 +30,9 @@ export const PauseReservation = ({
           </span>
         )}
         <div className="dpl-pause-reservation-component__flex__button">
-          <ToggleButton isChecked={isChecked} />
+          <button type="button" className="btn-primary btn-filled btn-small">
+            Indstillinger
+          </button>
         </div>
       </div>
     </div>

--- a/src/stories/Library/pause-reservation/pause-reservation.scss
+++ b/src/stories/Library/pause-reservation/pause-reservation.scss
@@ -17,6 +17,12 @@
     flex-wrap: wrap;
     width: 100%;
     align-items: center;
+    justify-content: center;
+    gap: $s-sm;
+
+    @include breakpoint-xs {
+      justify-content: start;
+    }
 
     &__reservation-icon {
       justify-content: center;
@@ -27,28 +33,22 @@
 
     &__text {
       @extend %text-body-large;
-      @extend %pl-8;
     }
 
     &__badge {
       background-color: $c-global-primary;
-      @extend %pl-8;
-      @extend %pr-8;
-      @extend %pt-4;
-      @extend %pb-4;
+      padding: $s-xs $s-sm;
       @extend %text-body-medium-medium;
-      margin-left: 32px;
-
-      @include breakpoint-s {
-        margin-left: 8px;
-      }
     }
 
     &__button {
       display: flex;
       flex: 1;
-      justify-content: flex-end;
-      @extend %ml-8;
+      justify-content: center;
+
+      @include breakpoint-xs {
+        justify-content: flex-end;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-70

#### Description
The pause reservation banner has been improved and storybook will now reflect that.
The previous styling did not handle small screens very well. This both takes care for smaller devices and cleans up some CSS.

#### Screenshot of the result
Before:
<img width="237" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/d255b691-2623-425b-b99c-ee56d24a4862">

After:
<img width="233" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/be04d49e-6bc5-4cd2-9c78-79ba798003fb">


