### PR TITLE
Added flatpickr

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -27,7 +27,8 @@
 @import "./src/stories/Library/Forms/checkbox/checkbox";
 @import "./src/stories/Library/cover/cover";
 @import "./src/stories/Library/Forms/input/input";
-@import "./src/stories/Library/Forms/date-picker/datepicker.scss";
+@import "./src/stories/Library/Forms/date-picker/date-picker.scss";
+@import "./src/stories/Library/date-calendar/date-calendar.scss";
 @import "./src/stories/Library/list-buttons/list-buttons";
 @import "./src/stories/Library/progress-bar/progress-bar";
 @import "./src/stories/Library/missing-story/missing-story";

--- a/base.scss
+++ b/base.scss
@@ -27,6 +27,7 @@
 @import "./src/stories/Library/Forms/checkbox/checkbox";
 @import "./src/stories/Library/cover/cover";
 @import "./src/stories/Library/Forms/input/input";
+@import "./src/stories/Library/Forms/date-picker/datepicker.scss";
 @import "./src/stories/Library/list-buttons/list-buttons";
 @import "./src/stories/Library/progress-bar/progress-bar";
 @import "./src/stories/Library/missing-story/missing-story";

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-webpack-plugin": "^4.0.1",
+    "flatpickr": "^4.6.13",
     "json": "^11.0.0",
     "markdownlint-cli2": "^0.4.0",
     "postcss": "^8.4.32",

--- a/src/stories/Library/Forms/date-picker/DatePicker.stories.tsx
+++ b/src/stories/Library/Forms/date-picker/DatePicker.stories.tsx
@@ -6,7 +6,12 @@ export default {
   title: "Library / Forms / DatePicker",
   component: DatePicker,
   decorators: [withDesign],
-  argTypes: {},
+  argTypes: {
+    locale: {
+      options: ["en", "da"],
+      defaultValue: "en",
+    },
+  },
   parameters: {
     design: {
       type: "figma",
@@ -16,6 +21,8 @@ export default {
   },
 } as ComponentMeta<typeof DatePicker>;
 
-const Template: ComponentStory<typeof DatePicker> = () => <DatePicker />;
+const Template: ComponentStory<typeof DatePicker> = (args) => (
+  <DatePicker {...args} />
+);
 
 export const Default = Template.bind({});

--- a/src/stories/Library/Forms/date-picker/DatePicker.stories.tsx
+++ b/src/stories/Library/Forms/date-picker/DatePicker.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import DatePicker from "./DatePicker";
+
+export default {
+  title: "Library / Forms / DatePicker",
+  component: DatePicker,
+  decorators: [withDesign],
+  argTypes: {},
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=7605%3A54868&mode=design&t=MoXpQuI4TAXRxRDe-1",
+    },
+    layout: "fullscreen",
+  },
+} as ComponentMeta<typeof DatePicker>;
+
+const Template: ComponentStory<typeof DatePicker> = () => <DatePicker />;
+
+export const Default = Template.bind({});

--- a/src/stories/Library/Forms/date-picker/DatePicker.tsx
+++ b/src/stories/Library/Forms/date-picker/DatePicker.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 // Import default styling
 import "flatpickr/dist/flatpickr.css";
 

--- a/src/stories/Library/Forms/date-picker/DatePicker.tsx
+++ b/src/stories/Library/Forms/date-picker/DatePicker.tsx
@@ -1,0 +1,59 @@
+// Import default styling
+import "flatpickr/dist/flatpickr.css";
+
+import flatpickr from "flatpickr";
+import { english } from "flatpickr/dist/l10n/default";
+import { Danish } from "flatpickr/dist/l10n/da";
+import { Instance } from "flatpickr/dist/types/instance";
+import { MutableRefObject, useCallback, useRef } from "react";
+import { BaseOptions } from "flatpickr/dist/types/options";
+
+export type DatePickerProps = {
+  locale?: "en" | "da";
+};
+
+const DatePicker = (props: DatePickerProps) => {
+  const { locale = "en" } = props;
+  const picker = useRef() as MutableRefObject<Instance>;
+
+  const pickerRef = useCallback(
+    (node: Node | null) => {
+      const options: Partial<BaseOptions> = {
+        wrap: true,
+        static: true,
+        locale: locale === "en" ? english : Danish,
+      };
+
+      if (node !== null) {
+        picker.current = flatpickr(node, options);
+      }
+    },
+    [locale]
+  );
+
+  return (
+    <div className="datepicker">
+      <div className="datepicker__wrapper" ref={pickerRef}>
+        <input
+          type="text"
+          placeholder="Date"
+          className="datepicker__input"
+          data-input
+        />
+        <button
+          name="Toggle datepicker"
+          className="datepicker__opener"
+          data-toggle
+        >
+          <img
+            className="datepicker__icon"
+            src="icons/collection/ExpandMore.svg"
+            alt="Expand more icon"
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DatePicker;

--- a/src/stories/Library/Forms/date-picker/date-picker.scss
+++ b/src/stories/Library/Forms/date-picker/date-picker.scss
@@ -10,10 +10,6 @@
     border: 1px solid $c-global-tertiary-1;
   }
 
-  & .flatpickr-calendar * {
-    font-family: "Noto Sans JP", sans-serif;
-  }
-
   &__input {
     @extend %text-button-placeholder;
     width: 100%;

--- a/src/stories/Library/Forms/date-picker/datepicker.scss
+++ b/src/stories/Library/Forms/date-picker/datepicker.scss
@@ -1,0 +1,42 @@
+.datepicker {
+  &__wrapper {
+    position: relative;
+    width: 100%;
+    height: 48px;
+    background-color: transparent;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    border: 1px solid $c-global-tertiary-1;
+  }
+
+  & .flatpickr-calendar * {
+    font-family: "Noto Sans JP", sans-serif;
+  }
+
+  &__input {
+    @extend %text-button-placeholder;
+    width: 100%;
+    height: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 $s-md;
+    border: none;
+    cursor: pointer;
+  }
+
+  &__opener {
+    width: 44px;
+    min-width: 44px;
+    height: 48px;
+    border-left: 1px solid $c-global-tertiary-1;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  &__icon {
+    margin: auto;
+  }
+}

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -15,6 +15,7 @@ const DateCalendar = () => {
       inline: true,
       animate: false,
       mode: "range",
+      defaultDate: ["2024-01-01", "2024-01-10"],
     };
 
     if (node !== null) {

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -23,7 +23,14 @@ const DateCalendar = () => {
   }, []);
 
   // An input is required for flatpickr to work, but we don't want to show it in the story
-  return <input ref={calendar} type="text" className="hide-visually" />;
+  return (
+    <input
+      ref={calendar}
+      title="Hidden field"
+      type="text"
+      className="hide-visually"
+    />
+  );
 };
 
 export default DateCalendar;

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable import/no-extraneous-dependencies */
+// Import default styling
+import "flatpickr/dist/flatpickr.css";
+
+import flatpickr from "flatpickr";
+import { Instance } from "flatpickr/dist/types/instance";
+import { MutableRefObject, useCallback, useRef } from "react";
+import { BaseOptions } from "flatpickr/dist/types/options";
+
+const DateCalendar = () => {
+  const picker = useRef() as MutableRefObject<Instance>;
+
+  const calendar = useCallback((node: Node | null) => {
+    const options: Partial<BaseOptions> = {
+      inline: true,
+      animate: false,
+    };
+
+    if (node !== null) {
+      picker.current = flatpickr(node, options);
+    }
+  }, []);
+
+  return <input type="text" ref={calendar} />;
+};
+
+export default DateCalendar;

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -14,6 +14,7 @@ const DateCalendar = () => {
     const options: Partial<BaseOptions> = {
       inline: true,
       animate: false,
+      mode: "range",
     };
 
     if (node !== null) {

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -27,6 +27,7 @@ const DateCalendar = () => {
     <input
       ref={calendar}
       title="Hidden field"
+      aria-label="Hidden field"
       type="text"
       className="hide-visually"
     />

--- a/src/stories/Library/date-calendar/DateCalendar.tsx
+++ b/src/stories/Library/date-calendar/DateCalendar.tsx
@@ -22,7 +22,8 @@ const DateCalendar = () => {
     }
   }, []);
 
-  return <input type="text" ref={calendar} />;
+  // An input is required for flatpickr to work, but we don't want to show it in the story
+  return <input ref={calendar} type="text" className="hide-visually" />;
 };
 
 export default DateCalendar;

--- a/src/stories/Library/date-calendar/DatePicker.stories.tsx
+++ b/src/stories/Library/date-calendar/DatePicker.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import DateCalendar from "./DateCalendar";
+
+export default {
+  title: "Library / Forms / DateCalendar",
+  component: DateCalendar,
+  decorators: [withDesign],
+  argTypes: {},
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=7605%3A54868&mode=design&t=MoXpQuI4TAXRxRDe-1",
+    },
+    layout: "fullscreen",
+  },
+} as ComponentMeta<typeof DateCalendar>;
+
+const Template: ComponentStory<typeof DateCalendar> = () => <DateCalendar />;
+
+export const Default = Template.bind({});

--- a/src/stories/Library/date-calendar/DatePicker.stories.tsx
+++ b/src/stories/Library/date-calendar/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import { withDesign } from "storybook-addon-designs";
 import DateCalendar from "./DateCalendar";
 
 export default {
-  title: "Library / Forms / DateCalendar",
+  title: "Library / DateCalendar",
   component: DateCalendar,
   decorators: [withDesign],
   argTypes: {},

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -1,0 +1,78 @@
+.flatpickr-calendar {
+  font-family: "Noto Sans JP";
+  font-style: normal;
+  font-weight: 500;
+  color: $c-text-primary-black;
+  padding: $s-md !important;
+  width: fit-content !important;
+
+  & * {
+    font-weight: 500 !important;
+  }
+
+  & .flatpickr-months {
+    & .flatpickr-month {
+      order: -1;
+      display: flex;
+      padding-left: 5px;
+
+      & .flatpickr-current-month {
+        display: flex;
+        align-items: center;
+        position: relative;
+        padding: 0;
+        left: 0;
+        width: auto;
+        font-size: 14px;
+        line-height: 100%;
+        color: $c-text-primary-black;
+
+        & select {
+          appearance: none;
+          height: 30px;
+          line-height: 30px;
+          padding: 0 $s-xs;
+        }
+
+        & .numInputWrapper {
+          width: 7ch;
+          display: flex;
+          height: 30px;
+        }
+      }
+    }
+
+    & .flatpickr-prev-month,
+    & .flatpickr-next-month {
+      position: relative;
+      height: auto;
+      line-height: 100%;
+      display: flex;
+      align-items: center;
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.05);
+      }
+
+      & svg {
+        stroke: $c-text-primary-black;
+      }
+    }
+  }
+
+  & .flatpickr-innerContainer {
+    & .flatpickr-weekdays {
+      height: auto;
+      padding: 20px 0;
+    }
+  }
+  & .flatpickr-days {
+    & .flatpickr-day {
+      &.prevMonthDay,
+      &.nextMonthDay {
+        color: rgba(57, 57, 57, 0.7);
+        font-weight: 400 !important;
+      }
+    }
+  }
+}

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -1,3 +1,6 @@
+// flatpickr does not use BEM naming convention, so we have to disable stylelint for this file
+/* stylelint-disable */
+
 .flatpickr-calendar {
   font-family: "Noto Sans JP";
   font-style: normal;

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -6,6 +6,11 @@
   padding: $s-md !important;
   width: fit-content !important;
 
+  &.inline {
+    box-shadow: none;
+    border-radius: 0;
+  }
+
   & * {
     font-weight: 500 !important;
   }
@@ -51,6 +56,7 @@
       align-items: center;
 
       &:hover {
+        // inherited by flatpickr
         background: rgba(0, 0, 0, 0.05);
       }
 
@@ -68,6 +74,9 @@
   }
   & .flatpickr-days {
     & .flatpickr-day {
+      display: flex;
+      align-items: center;
+
       &.prevMonthDay,
       &.nextMonthDay {
         color: rgba(57, 57, 57, 0.7);

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -1,6 +1,11 @@
 // flatpickr does not use BEM naming convention, so we have to disable stylelint for this file
 /* stylelint-disable */
 
+//// Color variables
+$primary-gray: rgba(57, 57, 57, 0.7);
+// inherited by flatpickr
+$hover-background: rgba(0, 0, 0, 0.05);
+
 .flatpickr-calendar {
   font-family: "Noto Sans JP";
   font-style: normal;
@@ -59,8 +64,7 @@
       align-items: center;
 
       &:hover {
-        // inherited by flatpickr
-        background: rgba(0, 0, 0, 0.05);
+        background: $hover-background;
       }
 
       & svg {
@@ -82,7 +86,7 @@
 
       &.prevMonthDay,
       &.nextMonthDay {
-        color: rgba(57, 57, 57, 0.7);
+        color: $primary-gray;
         font-weight: 400 !important;
       }
     }

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -5,6 +5,8 @@
 $primary-gray: rgba(57, 57, 57, 0.7);
 // inherited by flatpickr
 $hover-background: rgba(0, 0, 0, 0.05);
+// we do not currently have a good color for this in the design system
+$selected-date-background: rgb(0, 105, 255);
 
 .flatpickr-calendar {
   font-family: "Noto Sans JP";
@@ -84,8 +86,19 @@ $hover-background: rgba(0, 0, 0, 0.05);
       display: flex;
       align-items: center;
 
-      &.prevMonthDay,
-      &.nextMonthDay {
+      &.selected {
+        background-color: $selected-date-background;
+        border-color: $selected-date-background;
+      }
+
+      &.selected.startRange + .endRange:not(:nth-child(7n + 1)),
+      &.startRange.startRange + .endRange:not(:nth-child(7n + 1)),
+      &.endRange.startRange + .endRange:not(:nth-child(7n + 1)) {
+        box-shadow: -10px 0 0 $selected-date-background;
+      }
+
+      &.prevMonthDay:not(.endRange):not(.startRange),
+      &.nextMonthDay:not(.endRange):not(.startRange) {
         color: $primary-gray;
         font-weight: 400 !important;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7755,6 +7755,11 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
+flatpickr@^4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.13.tgz#8a029548187fd6e0d670908471e43abe9ad18d94"
+  integrity sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==
+
 flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-351

#### Description
We needed to find a find to share a datepicker across React and Drupal with the same styling applied both places.
This PR introduces flatpickr JS as the foundation for our new datepicker. The design system makes sure that flatpickr is styled the same way whereever it is used, and it is up to the respective app to implement flatpickr how it sees fit. The React app could for example use the Flatpickr React package and Drupal the native JS package. It does really not matte, because the flatpickr is the same. 

#### Screenshot of the result
The bare bone date calendar
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/f68ae027-091b-4ed8-872d-bf15058ecd85)

The date calendar implemented as a datepicker
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/55b7001d-1dec-475f-bd73-7460e10d184d)

