### PR TITLE
Fix/you-owe-alignment

### DIFF
--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -15,7 +15,7 @@
 
 .warning-bar__left {
   display: flex;
-  align-items: start;
+  align-items: center;
 
   @include breakpoint-s {
     align-items: center;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-162

#### Description
This PR fixes alignment issues in the warning bar where text wasn't aligned vertically between the left and the right side.

#### Screenshot of the result
Before:
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/d8369bbd-0c59-4c05-95dd-84081edf3bb4)


After:
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/d227846c-f358-44fe-abf3-96d0edc17dbd)

#### Additional comments or questions
n/a

