### PR TITLE
Event prices

### DIFF
--- a/src/stories/Blocks/event-page/EventPage.stories.tsx
+++ b/src/stories/Blocks/event-page/EventPage.stories.tsx
@@ -76,8 +76,11 @@ export default {
     listDescriptionData: {
       defaultValue: {
         Tid: { value: ["19:30 — 21:00"], type: "standard" },
-        Standard: { value: ["65 kr."], type: "standard" },
-        Børn: { value: ["Gratis"], type: "standard" },
+        Pris: {
+          value: ["Standard: 65 kr.", "Børn: Gratis"],
+          type: "standard",
+          layout: "column",
+        },
         Sted: {
           value: [
             "Hovedbibliotek",

--- a/src/stories/Library/Lists/list-description/ListDescription.tsx
+++ b/src/stories/Library/Lists/list-description/ListDescription.tsx
@@ -1,8 +1,13 @@
+import clsx from "clsx";
 import { Fragment } from "react";
 import { generateId } from "../../horizontal-term-line/HorizontalTermLine";
 
 export type ListData = {
-  [k: string]: { value: string[]; type: "standard" | "link" };
+  [k: string]: {
+    value: string[];
+    type: "standard" | "link";
+    layout?: "default" | "column";
+  };
 };
 
 const ListDescription: React.FC<{ data: ListData; className?: string }> = ({
@@ -12,11 +17,16 @@ const ListDescription: React.FC<{ data: ListData; className?: string }> = ({
   return (
     <dl className={`list-description ${className ?? ""}`}>
       {Object.keys(data).map((key, index) => {
-        const { value, type } = data[key as keyof ListData];
+        const { value, type, layout = "default" } = data[key as keyof ListData];
         return (
           <div className="list-description__item" key={generateId(index)}>
             <dt className="list-description__key">{key}:</dt>
-            <dd className="list-description__value">
+            <dd
+              className={clsx(
+                "list-description__value",
+                layout === "column" && "list-description__value--column"
+              )}
+            >
               {value.map((val) => (
                 <Fragment key={val}>
                   {type === "standard" && <span>{val}</span>}

--- a/src/stories/Library/Lists/list-description/ListDescriptionFakeData.tsx
+++ b/src/stories/Library/Lists/list-description/ListDescriptionFakeData.tsx
@@ -10,6 +10,11 @@ const fakeData: ListData = {
   Omfang: { value: ["795 sider"], type: "standard" },
   Forlag: { value: ["Rosinante"], type: "standard" },
   Målgruppe: { value: ["Voksenmateriale"], type: "standard" },
+  Pris: {
+    value: ["Standard: 65 kr.", "Børn: Gratis"],
+    type: "standard",
+    layout: "column",
+  },
 };
 
 export default fakeData;

--- a/src/stories/Library/Lists/list-description/list-description.scss
+++ b/src/stories/Library/Lists/list-description/list-description.scss
@@ -21,6 +21,11 @@ dl.list-description {
       gap: $s-sm;
     }
   }
+
+  .list-description__value--column {
+    flex-direction: column;
+  }
+
   .link-tag {
     @extend %text-small-caption;
     color: $c-text-primary-black;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-57

#### Description

This PR adds support for displaying prices for events. Prices are shown next to descriptions.

An important part of the handling is the support of multiple categories and prices. Instead of adding each category as a separate entry they now get a single price entry containing each of the categories. This makes sense - especially when you look at the mobile view.

To prevent categories from wrapping a new modifier is added to the `list-description` block.

#### Screenshot of the result

<img width="1840" alt=" Event page - Default ⋅ Storybook 2023-12-10 21-33-55" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/73966/73ec4601-fa12-4c94-baa8-85299741c63e">

