### PR TITLE
Fix/pay-button

### DIFF
--- a/src/stories/Library/Buttons/button/LinkButton.tsx
+++ b/src/stories/Library/Buttons/button/LinkButton.tsx
@@ -31,7 +31,6 @@ export const LinkButton = ({
         getVariant(variant),
         getSize(size),
         "arrow__hover--right-small",
-        "hide-linkstyle",
         classNames
       )}
     >

--- a/src/stories/Library/Buttons/button/buttons.scss
+++ b/src/stories/Library/Buttons/button/buttons.scss
@@ -21,6 +21,7 @@ $c-btn-border-disabled: $c-global-tertiary-2;
   white-space: nowrap;
   transition: background-color 0.4s ease-in-out, color 0.2s ease-in-out,
     opacity 0.4s ease-in-out;
+  text-decoration: none;
 
   @extend %text-button-placeholder;
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-334

#### Description

This PR makes sure that any text inside a button is never with text decorations, even if there is an <a> tag inside it. We never want an underline, and instead of using the utility class "hide-linkstyle" I am moving this responsibility to the main button class.

#### Screenshot of the result
n/a

#### Additional comments or questions
Sibling to [this PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/754).
