### PR TITLE
Adding 'Identity' CSS for missing `event` image

### DIFF
--- a/src/stories/Blocks/event-page/EventPage.stories.tsx
+++ b/src/stories/Blocks/event-page/EventPage.stories.tsx
@@ -109,3 +109,7 @@ export default {
 const Template: ComponentStory<typeof Event> = (args) => <Event {...args} />;
 
 export const Default = Template.bind({});
+export const withOutImage = Template.bind({});
+withOutImage.args = {
+  image: "",
+};

--- a/src/stories/Library/image-credited/ImageCredited.stories.tsx
+++ b/src/stories/Library/image-credited/ImageCredited.stories.tsx
@@ -38,3 +38,7 @@ const Template: ComponentStory<typeof ImageCredited> = (args) => (
 );
 
 export const Default = Template.bind({});
+export const withOutImage = Template.bind({});
+withOutImage.args = {
+  src: "",
+};

--- a/src/stories/Library/image-credited/ImageCredited.tsx
+++ b/src/stories/Library/image-credited/ImageCredited.tsx
@@ -18,11 +18,17 @@ const ImageCredited: FC<ImageCreditedProps> = ({
 }) => {
   return (
     <figure className={clsx("image-credited", className)}>
-      <img src={src} className="image-credited__img" alt={alt} />
-      <div className="image-credited__info">
-        <span>{description}</span>
-        <span>{year}</span>
-      </div>
+      {src ? (
+        <>
+          <img src={src} className="image-credited__img" alt={alt} />
+          <figcaption className="image-credited__info">
+            <span>{description}</span>
+            <span>{year}</span>
+          </figcaption>
+        </>
+      ) : (
+        <div className="image-credited__no-image" />
+      )}
     </figure>
   );
 };

--- a/src/stories/Library/image-credited/image-credited.scss
+++ b/src/stories/Library/image-credited/image-credited.scss
@@ -8,3 +8,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+.image-credited__no-image {
+  aspect-ratio: 16 / 9;
+  @extend %identity-placeholder;
+}

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -47,4 +47,9 @@
   @include typography($typo__body-small);
 }
 
+%identity-placeholder {
+  background-color: var(--tint-color-120);
+  border: $s-2xl solid $color__identity-primary;
+}
+
 // stylelint-enable plugin/stylelint-bem-namics


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-93

#### Description

This pull request introduces the "identity" CSS class to manage scenarios involving missing images. 
- Implementation of the `%identity-placeholder` class, which sets the background color and adds a bold border.
- Introduction of the `image-credited__no-image class`, an extension of `%identity-placeholder`.
- Addition of the `height: auto` property to img elements, ensuring the aspect ratio of images is maintained.

#### Screenshot of the result
<img width="983" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/49920322/1d2ddf88-0172-4ecd-a7e5-e2018628550c">
