### PR TITLE
Fix rich text + Re-factor layout max width as a mixin

### DIFF
--- a/src/stories/Library/event-description/event-description.scss
+++ b/src/stories/Library/event-description/event-description.scss
@@ -1,4 +1,5 @@
 .event-description {
+  // @todo use @include layout-container instead here.
   padding: $s-md;
   max-width: $layout__max-width;
   margin: 0 auto;

--- a/src/stories/Library/event-header/event-header.scss
+++ b/src/stories/Library/event-header/event-header.scss
@@ -1,4 +1,5 @@
 .event-header {
+  // @todo use @include layout-container instead here.
   max-width: $layout__max-width;
   margin: 0 auto;
 

--- a/src/stories/Library/link-with-icon/link-with-icon.scss
+++ b/src/stories/Library/link-with-icon/link-with-icon.scss
@@ -1,9 +1,11 @@
 .link-with-icon {
   @include typography($typo__body-placeholder);
   @include show-svg-on-hover();
+  @include layout-container;
 
   background-color: $color__global-primary;
-  padding: $s-md $s-lg;
+  padding-top: $s-md;
+  padding-bottom: $s-md;
   display: grid;
   grid-template-columns: 40px auto max-content;
   align-items: center;
@@ -11,9 +13,6 @@
   text-decoration: none;
   border: 1px solid $color__global-tertiary-1;
   width: 100%;
-  max-width: $layout__max-width;
-  margin-left: auto;
-  margin-right: auto;
 
   &:first-child {
     margin-top: 0;

--- a/src/stories/Library/medias/medias.scss
+++ b/src/stories/Library/medias/medias.scss
@@ -13,12 +13,7 @@ $_medias-breakpoint: 550px;
 }
 
 .medias--single {
-  max-width: $layout__max-width--single-media;
-  margin: auto;
-
-  .medias__item {
-    padding: 0 $s-md;
-  }
+  @include layout-container($layout__max-width--single-media, 0);
 }
 
 @include media-query($_medias-breakpoint) {
@@ -55,9 +50,7 @@ $_medias-breakpoint: 550px;
 }
 
 .medias--multiple {
-  max-width: $layout__max-width--multiple-medias;
-  //max-width: 900px;
-  margin: auto;
+  @include layout-container($layout__max-width--multiple-medias, 0);
 
   .medias__item--last {
     img {

--- a/src/stories/Library/rich-text/rich-text.scss
+++ b/src/stories/Library/rich-text/rich-text.scss
@@ -5,10 +5,7 @@
   @include typography($typo__rich-text-body);
 
   // Setting a max-width to increase readability for sentences.
-  max-width: $layout__max-width--text;
-  margin: auto;
-  padding-left: $layout__page-padding;
-  padding-right: $layout__page-padding;
+  @include layout-container($layout__max-width--text);
 
   a {
     @extend %text-inline-link;

--- a/src/stories/Library/rich-text/rich-text.scss
+++ b/src/stories/Library/rich-text/rich-text.scss
@@ -6,6 +6,9 @@
 
   // Setting a max-width to increase readability for sentences.
   max-width: $layout__max-width--text;
+  margin: auto;
+  padding-left: $layout__page-padding;
+  padding-right: $layout__page-padding;
 
   a {
     @extend %text-inline-link;

--- a/src/styles/scss/tools.scss
+++ b/src/styles/scss/tools.scss
@@ -1,7 +1,7 @@
 @import "tools/variables.fonts";
 @import "tools/variables.z-indexes";
-@import "tools/variables.layout";
 @import "tools/variables.spacings";
+@import "tools/variables.layout";
 @import "tools/variables.colors";
 @import "tools/variables.breakpoints";
 @import "tools/variables.typography";

--- a/src/styles/scss/tools/mixins.misc.scss
+++ b/src/styles/scss/tools/mixins.misc.scss
@@ -46,3 +46,14 @@
     opacity: 1;
   }
 }
+
+@mixin layout-container(
+  $max-width: $layout__max-width,
+  $padding: $layout__page-padding
+) {
+  max-width: $max-width;
+  margin: auto;
+  padding-left: $padding;
+  padding-right: $padding;
+  box-sizing: border-box;
+}

--- a/src/styles/scss/tools/variables.layout.scss
+++ b/src/styles/scss/tools/variables.layout.scss
@@ -5,3 +5,7 @@ $layout__max-width--large: 1440px;
 $layout__max-width--text: 780px;
 $layout__max-width--single-media: 896px;
 $layout__max-width--multiple-medias: 1240px;
+
+// Some elements should not go out to the edge of the screen on small screens.
+// This is the padding that is always shown on the left and right.
+$layout__page-padding: $s-xl;


### PR DESCRIPTION
[Make sure that rich-text has spacing and margin. DDFFORM-5](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/390/commits/dd485fb3e1a484e554a62a8195b8f4affa8e5f40) 

It worked in Storybook, but not in Drupal.
That is because Storybook adds its own wrapper, which made it appear
correct.

----

Add a layout-container mixin, and replace any existing max-widths.