### PR TITLE
fix old non responsive stories

### DIFF
--- a/src/stories/Library/Modals/modal-cta/ModalCTA.tsx
+++ b/src/stories/Library/Modals/modal-cta/ModalCTA.tsx
@@ -36,6 +36,7 @@ export const ModalCTA: React.FC<ModalCTAProps> = ({ title, showModal }) => (
           label="Annuller fornyelse"
           disabled={false}
           collapsible
+          classNames="modal-cta__button"
         />
         <div className="modal-cta__link">
           <Links

--- a/src/stories/Library/Modals/modal-cta/modal-cta.scss
+++ b/src/stories/Library/Modals/modal-cta/modal-cta.scss
@@ -9,12 +9,22 @@
 }
 
 .modal-cta__buttons {
-  display: grid;
-  justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .modal-cta__link {
   display: flex;
   justify-content: center;
   margin-top: $s-md;
+}
+
+.modal-cta__button {
+  padding: 0;
+  width: 100%;
+  @include media-query__medium {
+    padding: 0 86px;
+    width: auto;
+  }
 }


### PR DESCRIPTION
- Updated mobile responsiveness for modalCTA item component.

#### Link to issue

I found this as a part of going through UI tests as part of changing the fonts. 

#### Description

Found a component that was not responsive. Made it responsive. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/13272656/30665c47-8c9f-4d0d-aeb3-34321d2a54fc)

#### Additional comments or questions

See the UI test that must be accepted in order to see the change. 
