### PR TITLE
Fix overflow on x-axis

### DIFF
--- a/src/stories/Blocks/footer/footer.scss
+++ b/src/stories/Blocks/footer/footer.scss
@@ -32,7 +32,7 @@
   // Pagefold tweaks
   .pagefold-parent--small,
   .pagefold-parent--medium {
-    width: 100vw;
+    width: 100%;
     height: auto;
   }
 

--- a/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard.scss
@@ -50,7 +50,8 @@
   margin-left: auto;
   width: 90px; // Avoids extending beyond the edge of the box.
 
-  @include breakpoint-s {
+  // Arrow takes too much space on small screens
+  @include breakpoint-l {
     display: block;
   }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-183

#### Description
This fixes an issue where the footer will take up too much space on the x-axis and overflow the main content. When using window sizing like vw or vh, scrollbars are counted in, and this will add additional unneeded space.
