### PR TITLE
Layout units - horizontal and vertical.

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -1,6 +1,7 @@
 @import "./src/styles/scss/reset";
 @import "./src/styles/scss/skeleton";
 @import "./src/styles/scss/tools";
+@import "./src/styles/scss/layout";
 
 // Legacy - utility classes and other stuff that needs to be cleaned later.
 @import "./src/styles/scss/legacy";

--- a/src/styles/scss/lasse-layout.example.scss
+++ b/src/styles/scss/lasse-layout.example.scss
@@ -1,0 +1,109 @@
+// Layout width variables
+// we can move these variables to a separate file if you think this way is bad,
+// sane goes for the mixins.
+// but since its' all to do with the layout specifically i wouldn't mind
+// keeping things that are related to each other in the same file.
+
+$layout__max-width--small: 768px;
+$layout__max-width: 1024px;
+$layout__max-width--large: 1440px;
+
+$layout__max-width--text: 780px;
+$layout__max-width--single-media: 896px;
+$layout__max-width--multiple-medias: 1240px;
+
+// Context-specific spacing variables if something changes down the line.
+$_layout-width: $layout__max-width;
+$_layout-width--small: $layout__max-width--small;
+$_layout-width--large: $layout__max-width--large;
+
+$_layout-padding: $s-md;
+$_layout-padding--small: $s-sm;
+$_layout-padding--large: $s-lg;
+
+$_layout-spacing: $s-lg;
+$_layout-spacing--small: $s-md;
+$_layout-spacing--large: $s-xl;
+
+// Mixin for layout container
+@mixin layout-container(
+  $max-width: $_layout-width,
+  $padding: $_layout-padding
+) {
+  max-width: $max-width;
+  margin: auto;
+  padding-left: $padding;
+  padding-right: $padding;
+  box-sizing: border-box;
+}
+
+// Mixin for vertical spacing
+@mixin vertical-spacing($top: $_layout-spacing, $bottom: $_layout-spacing) {
+  margin-top: $top;
+  margin-bottom: $bottom;
+}
+
+.layout__width {
+  @include layout-container;
+
+  &--small {
+    @include layout-container($max-width: $_layout-width--small);
+  }
+
+  &--large {
+    @include layout-container($max-width: $_layout-width--large);
+  }
+}
+
+.layout__padding {
+  padding-left: $_layout-padding;
+  padding-right: $_layout-padding;
+
+  &--none {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  &--small {
+    padding-left: $_layout-padding--small;
+    padding-right: $_layout-padding--small;
+  }
+
+  &--large {
+    padding-left: $_layout-padding--large;
+    padding-right: $_layout-padding--large;
+  }
+}
+
+// Vertical spacing management using context-specific variables
+.layout__vertical-spacing {
+  @include vertical-spacing;
+
+  &--small {
+    @include vertical-spacing(
+      $top: $_layout-spacing--small,
+      $bottom: $_layout-spacing--small
+    );
+  }
+
+  &--large {
+    @include vertical-spacing(
+      $top: $_layout-spacing--large,
+      $bottom: $_layout-spacing--large
+    );
+  }
+}
+
+// An example of a section/element that requires breakpoint modifications.
+.layout__special-section-or-BEM-name {
+  @include layout-container;
+  @include vertical-spacing;
+
+  @include media-query__small() {
+    @include layout-container($padding: $_layout-padding--large);
+    @include vertical-spacing(
+      $top: $_layout-spacing--large,
+      $bottom: $_layout-spacing--large
+    );
+  }
+}

--- a/src/styles/scss/layout.scss
+++ b/src/styles/scss/layout.scss
@@ -1,0 +1,51 @@
+// A width (horizontal) unit - e.g. setting max-width, centering, and making
+// sure there is padding on mobile.
+// stylelint-disable plugin/stylelint-bem-namics -- Stylelint doesnt understand placeholders in this context.
+%layout__w-unit,
+.layout__w-unit {
+  @include layout-container();
+
+  &--no-padding {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  &--small {
+    @include layout-container($layout__max-width--small);
+  }
+
+  &--large {
+    @include layout-container($layout__max-width--large);
+  }
+}
+
+// A height (vertical) unit - e.g. setting the space that is between elements.
+%layout__h-unit,
+.layout__h-unit {
+  // These units are taken loosely from the figma design, as no specifics
+  // are defined.
+  $_spacing: $s-lg;
+  $_spacing--small: $s-md;
+  $_spacing--large: $s-xl;
+
+  margin-top: $_spacing;
+  margin-bottom: $_spacing;
+
+  &--small {
+    margin-top: $_spacing--small;
+    margin-bottom: $_spacing--small;
+  }
+
+  &--large {
+    margin-top: $_spacing--large;
+    margin-bottom: $_spacing--large;
+  }
+}
+
+// A combination of both height and width (vertical and horizontal) units.
+%layout__unit,
+.layout__unit {
+  @extend %layout__h-unit;
+  @extend %layout__w-unit;
+}
+// stylelint-enable plugin/stylelint-bem-namics


### PR DESCRIPTION
After a discussion today, we agreed to introduce layout unit components. These units are used for centering stuff, and adding padding, and for adding spacing between individual elements.
The idea is that this is done using markup wrappers, but I've also made them so they can be used by individual components using placeholders.
