### PR TITLE
Only show scrollbar when content is overflowing

### DIFF
--- a/src/stories/Library/Modals/modal-loan/modal-loan.scss
+++ b/src/stories/Library/Modals/modal-loan/modal-loan.scss
@@ -6,7 +6,7 @@
 
 .modal-loan__container {
   width: 100%;
-  overflow: scroll;
+  overflow-y: auto;
 }
 
 .modal-loan__header {


### PR DESCRIPTION
overflow: scroll, will always show a scrollbar, which is very ugly

