### PR TITLE
Don't set overflow-y auto on modal-loan__container

### DIFF
--- a/src/stories/Library/Modals/modal-loan/modal-loan.scss
+++ b/src/stories/Library/Modals/modal-loan/modal-loan.scss
@@ -6,7 +6,6 @@
 
 .modal-loan__container {
   width: 100%;
-  overflow-y: auto;
 }
 
 .modal-loan__header {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-295

#### Description
The scrollbar should appear on the side of the modal, not on elements inside the modal.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/7e11030a-f84f-411e-a518-7c79977e793d)

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
n/a
