### PR TITLE
Added explicit focus  styles for buttons

### DIFF
--- a/src/stories/Library/Buttons/button/buttons.scss
+++ b/src/stories/Library/Buttons/button/buttons.scss
@@ -34,8 +34,8 @@ $color__btn-filled-hover: $color__text-secondary-gray;
   }
 
   &:focus-visible {
-    outline: 2px solid black;
-    box-shadow: inset 0 0 0 3px white;
+    outline: 2px solid $color__btn-border-active;
+    box-shadow: inset 0 0 0 3px $color__text-primary-white;
   }
 
   &[disabled] {

--- a/src/stories/Library/Buttons/button/buttons.scss
+++ b/src/stories/Library/Buttons/button/buttons.scss
@@ -1,5 +1,6 @@
 $color__btn-border-active: $color__text-primary-black;
 $color__btn-border-disabled: $color__global-tertiary-2;
+$color__btn-filled-hover: $color__text-secondary-gray;
 
 .btn-icon {
   margin-left: $s-md;
@@ -25,10 +26,16 @@ $color__btn-border-disabled: $color__global-tertiary-2;
 
   @include typography($typo__button);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     .btn-collapsible {
       display: block;
     }
+  }
+
+  &:focus-visible {
+    outline: 2px solid black;
+    box-shadow: inset 0 0 0 3px white;
   }
 
   &[disabled] {
@@ -76,8 +83,10 @@ $color__btn-border-disabled: $color__global-tertiary-2;
   background-color: $color__text-primary-black;
   color: $color__text-primary-white;
 
-  &:hover {
-    opacity: 0.7;
+  &:hover,
+  &:focus-visible {
+    background-color: $color__btn-filled-hover;
+    border-color: $color__btn-filled-hover;
   }
 }
 
@@ -85,7 +94,8 @@ $color__btn-border-disabled: $color__global-tertiary-2;
   background-color: transparent;
   color: $color__text-primary-black;
 
-  &:not([disabled]):hover {
+  &:not([disabled]):hover,
+  &:not([disabled]):focus-visible {
     background-color: $color__text-primary-black;
     color: $color__text-primary-white;
   }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-55

#### Description
To comply with the laws of WCAG, we need a distinctive style for focused buttons.
This needs to be an outline with at least 2px wideness, and a clear difference in contrast

#### Screenshot of the result
![button focus](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/9d8c2783-fcb2-4a36-979a-68fa490c89c1)
