### PR TITLE
Focus outline on dropdowns

### DIFF
--- a/src/stories/Library/Buttons/icon-button/icon-button.scss
+++ b/src/stories/Library/Buttons/icon-button/icon-button.scss
@@ -6,7 +6,5 @@
     fill: $color__global-tertiary-2;
   }
 
-  &.dpl-icon-button:focus {
-    outline: $color__text-primary-black 5px auto;
-  }
+  @extend %default-focus-visible;
 }

--- a/src/stories/Library/accordion/accordion.scss
+++ b/src/stories/Library/accordion/accordion.scss
@@ -38,8 +38,8 @@
 .accordion__header {
   height: $s-3xl;
 
-  button:focus {
-    outline: -webkit-focus-ring-color auto 5px;
+  button {
+    @extend %default-focus-visible;
   }
 }
 

--- a/src/stories/Library/dropdown/dropdown.scss
+++ b/src/stories/Library/dropdown/dropdown.scss
@@ -34,10 +34,8 @@
 
   @include typography($typo__button);
 
-  &:focus {
-    outline: none;
-    border-color: $color__text-primary-black;
-  }
+  // Chromeium based browsers will trigger focus when opening the dropdown
+  @extend %default-focus-visible;
 }
 
 .dropdown__option {

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -67,4 +67,10 @@
   }
 }
 
+%default-focus-visible {
+  &:focus-visible {
+    outline: 2px solid $color__text-primary-black;
+  }
+}
+
 // stylelint-enable plugin/stylelint-bem-namics


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-216

#### Description
To comply with the laws of WCAG, we need a distinctive style for focused dropdown/select boxes.
This needs to be an outline with at least 2px wideness, and a clear difference in contrast

#### Pictures
Dropdown default
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/1c4344f9-d894-498d-bebc-2548a9316bb3)

Dropdown focused
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/f117e791-33a9-4b93-8b3a-29abf250cffc)

Accordion default
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/cb15a774-8dfc-4233-bca2-7dde5ad6ac5c)

Accordion focused
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/14014012/eed430fa-f2d2-4347-8224-06b5f09ed1ef)
