### PR TITLE
Implement `text-decoration: none` on `header__logo-desktop-link`

### DIFF
--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -28,6 +28,7 @@
 }
 
 .header__logo-desktop-link {
+  text-decoration: none;
   height: 100%;
   width: 100%;
   display: flex;


### PR DESCRIPTION
This commit adds the `text-decoration: none` property to the `header__logo-desktop-link` class in the `header.scss` file. 

This ensures clean fallback text for the logo within the anchor tag.