### PR TITLE
Card slider, and placeholder/pagefold refactor. DDFFORM-86

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,12 +1,7 @@
 {
   "extends": ["stylelint-config-recommended-scss", "stylelint-prettier/recommended"],
-  "plugins": ["@namics/stylelint-bem"],
   "rules": {
     "max-nesting-depth": 3,
-    "plugin/stylelint-bem-namics": {
-      "patternPrefixes": [],
-      "helperPrefixes": []
-    },
     "selector-class-pattern": "^[a-z][a-z0-9_-]*$",
     "selector-max-id": null,
     "selector-no-qualifying-type": [

--- a/base.scss
+++ b/base.scss
@@ -1,6 +1,6 @@
+@import "./src/styles/scss/tools";
 @import "./src/styles/scss/reset";
 @import "./src/styles/scss/skeleton";
-@import "./src/styles/scss/tools";
 
 // Legacy - utility classes and other stuff that needs to be cleaned later.
 @import "./src/styles/scss/legacy";
@@ -106,6 +106,8 @@
 @import "./src/stories/Library/rich-text/rich-text";
 @import "./src/stories/Library/medias/medias";
 @import "./src/stories/Library/event-paragraphs/event-paragraphs";
+@import "./src/stories/Library/slider/slider";
+@import "./src/stories/Library/card/card";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "js:lint:watch": "chokidar './src/**/*.{js,jsx,ts,tsx}' -c 'yarn js:lint'",
     "js:format": "concurrently 'yarn:js:eslint -- --fix' 'yarn:js:prettier -- --write' --max-processes 1 --raw",
     "css:stylelint": "stylelint 'src/**/*.scss'",
-    "css:prettier": "prettier 'src/styles/**/*.scss'",
+    "css:prettier": "prettier 'src/**/*.scss'",
     "css:lint": "concurrently 'yarn:css:stylelint' 'yarn:css:prettier -- --check' --raw",
     "css:lint:watch": "chokidar 'src/**/*.scss' -c 'yarn css:lint'",
     "css:format": "concurrently 'yarn:css:stylelint -- --fix' 'yarn:css:prettier -- --write' --max-processes 1 --raw",
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@chanzuckerberg/axe-storybook-testing": "^6.0.1",
-    "@namics/stylelint-bem": "^7.0.0",
     "@storybook/addon-a11y": "^6.5.9",
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-essentials": "^6.5.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "chromatic": "npx chromatic --exit-zero-on-changes",
     "lint": "concurrently 'yarn:js:lint' 'yarn:css:lint' 'yarn:markdown:lint'",
     "format": "concurrently 'yarn:js:format' 'yarn:css:format' 'yarn:markdown:format'"
-
   },
   "browserslist": {
     "production": [
@@ -55,6 +54,7 @@
     "@types/node": "^16.0.0",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@types/react-helmet": "^6.1.11",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@whitespace/storybook-addon-html": "^5.0.0",
@@ -80,6 +80,7 @@
     "react": "^17.0.2",
     "react-docgen-typescript": "^2.1.0",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-scripts": "^4.0.3",
     "sass": "^1.69.7",
     "skeleton-screen-css": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "css:format": "concurrently 'yarn:css:stylelint -- --fix' 'yarn:css:prettier -- --write' --max-processes 1 --raw",
     "css:build": "sass base.scss:src/styles/css/base.css --style compressed",
     "css:watch": "yarn css:build -- --watch",
+    "build": "concurrently 'yarn:css:build' --raw",
     "markdown:lint": "markdownlint-cli2",
     "markdown:format": "markdownlint-cli2-fix",
     "watch": "concurrently 'yarn:js:lint:watch' 'yarn:css:lint:watch'",

--- a/src/stories/Library/Arrows/arrows.scss
+++ b/src/stories/Library/Arrows/arrows.scss
@@ -1,5 +1,4 @@
 // BEM plugin does not support interpolation.
-// stylelint-disable plugin/stylelint-bem-namics
 @mixin _icon-arrow-animated($direction, $size, $scaleX, $translatePx, $origin) {
   .arrow__hover--#{$direction}-#{$size} {
     cursor: pointer;
@@ -32,7 +31,6 @@
     }
   }
 }
-// stylelint-enable plugin/stylelint-bem-namics
 
 @include _icon-arrow-animated("right", "large", 1.165, 25px, left);
 @include _icon-arrow-animated("right", "small", 1.5, 30px, left);

--- a/src/stories/Library/Lists/list-materials/list-materials.scss
+++ b/src/stories/Library/Lists/list-materials/list-materials.scss
@@ -28,7 +28,7 @@
 }
 
 .list-materials__content__header {
-  @include text-ellipsis-truncation;
+  @include text-ellipsis-truncation();
   @include typography($typo__h5);
 }
 

--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -121,7 +121,7 @@ $list-reservation-space-desktop: 24px;
 }
 
 .list-reservation__header__text {
-  @include text-ellipsis-truncation;
+  @include text-ellipsis-truncation(2);
 }
 
 .list-reservation__status {

--- a/src/stories/Library/card/Card.stories.tsx
+++ b/src/stories/Library/card/Card.stories.tsx
@@ -1,0 +1,75 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import Card from "./Card";
+import ImageCredited from "../image-credited/ImageCredited";
+
+export default {
+  title: "Library / Card ('news card')",
+  component: Card,
+  decorators: [withDesign],
+  argTypes: {
+    variant: {
+      // Disabling controls, as the different variations are added already.
+      control: false,
+    },
+    typeTag: {
+      defaultValue: "Arrangement",
+      type: "string",
+    },
+    dateTag: {
+      defaultValue: "06 Dec 2022",
+      type: "string",
+    },
+    title: {
+      defaultValue: "Bøger som har gjort en forskel for romanens udvikling",
+      type: "string",
+    },
+    placeholderText: {
+      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
+      type: "string",
+    },
+    href: {
+      defaultValue: "https://google.com",
+      type: "string",
+    },
+    image: {
+      defaultValue: (
+        <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+      ),
+
+      type: "string",
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=1968-8159&mode=design&t=8uX61DMzCXLhbNod-4",
+    },
+  },
+} as ComponentMeta<typeof Card>;
+
+const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />;
+
+const XLarge = Template.bind({});
+XLarge.args = {
+  variant: "x-large",
+};
+
+const XLargeNoImage = Template.bind({});
+XLargeNoImage.args = {
+  variant: "x-large",
+  image: undefined,
+};
+
+const Large = Template.bind({});
+Large.args = {
+  variant: "large",
+};
+
+const LargeNoImage = Template.bind({});
+LargeNoImage.args = {
+  variant: "large",
+  image: undefined,
+};
+
+export { XLarge, XLargeNoImage, Large, LargeNoImage };

--- a/src/stories/Library/card/Card.stories.tsx
+++ b/src/stories/Library/card/Card.stories.tsx
@@ -51,6 +51,7 @@ export default {
 const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />;
 
 const XLarge = Template.bind({});
+
 XLarge.args = {
   variant: "x-large",
 };
@@ -72,4 +73,35 @@ LargeNoImage.args = {
   image: undefined,
 };
 
-export { XLarge, XLargeNoImage, Large, LargeNoImage };
+const Medium = Template.bind({});
+Medium.args = {
+  variant: "medium",
+};
+
+const MediumNoImage = Template.bind({});
+MediumNoImage.args = {
+  variant: "medium",
+  image: undefined,
+};
+
+const Small = Template.bind({});
+Small.args = {
+  variant: "small",
+};
+
+const SmallNoImage = Template.bind({});
+SmallNoImage.args = {
+  variant: "small",
+  image: undefined,
+};
+
+export {
+  XLarge,
+  XLargeNoImage,
+  Large,
+  LargeNoImage,
+  Medium,
+  MediumNoImage,
+  Small,
+  SmallNoImage,
+};

--- a/src/stories/Library/card/Card.tsx
+++ b/src/stories/Library/card/Card.tsx
@@ -2,7 +2,7 @@ import { FC, ReactNode } from "react";
 import clsx from "clsx";
 
 type CardProps = {
-  variant: string;
+  variant?: string;
   typeTag?: string;
   dateTag?: string;
   title?: string;

--- a/src/stories/Library/card/Card.tsx
+++ b/src/stories/Library/card/Card.tsx
@@ -1,0 +1,48 @@
+import { FC, ReactNode } from "react";
+import clsx from "clsx";
+
+type CardProps = {
+  variant: string;
+  typeTag?: string;
+  dateTag?: string;
+  title?: string;
+  image?: ReactNode;
+  placeholderText?: string;
+};
+
+const Card: FC<CardProps> = ({
+  variant,
+  image,
+  placeholderText,
+  title,
+  typeTag,
+  dateTag,
+}) => {
+  const classes = clsx("card", {
+    "card--has-no-image": !image,
+    "card--has-image": image,
+  });
+
+  return (
+    <article className={classes} data-variant={variant}>
+      <a href="https://google.com">
+        <figure className="card__media">
+          {image || (
+            <div className="card__placeholder-text">{placeholderText}</div>
+          )}
+        </figure>
+        <div className="card__tags">
+          {typeTag ? (
+            <span className="card__tag card__tag--type">{typeTag}</span>
+          ) : (
+            ""
+          )}
+          {dateTag ? <span className="card__tag">{dateTag}</span> : ""}
+        </div>
+        <h1 className="card__title">{title}</h1>
+      </a>
+    </article>
+  );
+};
+
+export default Card;

--- a/src/stories/Library/card/card.scss
+++ b/src/stories/Library/card/card.scss
@@ -1,0 +1,108 @@
+.card {
+  $_card-mobile-peek: 50px;
+
+  position: relative;
+  width: 200px;
+  max-width: 100%;
+  word-break: break-word;
+
+  .slider & {
+    // We dont want the max-width to be 100%, as we want peek-effect on mobile.
+    max-width: calc(100vw - #{$_card-mobile-peek});
+  }
+
+  @include media-query__name($breakpoint__large-card) {
+    width: 440px;
+  }
+
+  img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+
+  a {
+    text-decoration: none;
+  }
+}
+
+.card__media {
+  aspect-ratio: 1/1;
+  box-sizing: border-box;
+  background-color: var(--tint-color-120);
+  margin-bottom: $s-sm;
+}
+
+.card--has-image {
+  // This is necessary to get object-fit to work.
+  * {
+    height: 100%;
+  }
+}
+
+.card--has-no-image {
+  @extend %identity-pagefold;
+
+  .card__media {
+    @extend %identity-placeholder;
+  }
+}
+
+.card__placeholder-text {
+  @include typography($typo__card-placeholder);
+  @extend %identity-placeholder-inner-padding;
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+
+  align-items: end;
+  color: $color__text-primary-white;
+}
+
+.card[data-variant="large"] {
+  width: 327px;
+
+  @include media-query__name($breakpoint__large-card) {
+    width: 551px;
+  }
+
+  .card__media {
+    // Odd aspect ratio, taken from the design.
+    aspect-ratio: 551/312;
+  }
+}
+
+.card__tags {
+  display: flex;
+  margin-bottom: $s-sm;
+}
+
+.card__tag {
+  @include typography($typo__byline-tags);
+}
+
+// Placing spacing and spacer line between tags.
+.card__tag + .card__tag {
+  position: relative;
+  margin-left: $s-sm;
+  padding-left: $s-sm;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: $s-xs;
+    bottom: $s-xs;
+    left: 0;
+    width: 1px;
+    background-color: $color__text-primary-black;
+  }
+}
+
+.card__tag--type {
+  color: $color__text-inactive;
+}
+
+.card__title {
+  @include typography($typo__h3);
+}

--- a/src/stories/Library/card/card.scss
+++ b/src/stories/Library/card/card.scss
@@ -1,56 +1,17 @@
-.card {
-  $_card-mobile-peek: 50px;
-
-  position: relative;
-  width: 200px;
-  max-width: 100%;
-  word-break: break-word;
-
-  .slider & {
-    // We dont want the max-width to be 100%, as we want peek-effect on mobile.
-    max-width: calc(100vw - #{$_card-mobile-peek});
-  }
-
-  @include media-query__name($breakpoint__large-card) {
-    width: 440px;
-  }
-
-  img {
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-    object-position: center;
-  }
-
-  a {
-    text-decoration: none;
-  }
-}
-
 .card__media {
-  aspect-ratio: 1/1;
   box-sizing: border-box;
   background-color: var(--tint-color-120);
   margin-bottom: $s-sm;
 }
 
-.card--has-image {
-  // This is necessary to get object-fit to work.
-  * {
-    height: 100%;
-  }
-}
-
 .card--has-no-image {
-  @extend %identity-pagefold;
-
   .card__media {
     @extend %identity-placeholder;
   }
 }
 
 .card__placeholder-text {
-  @include typography($typo__card-placeholder);
+  @include typography($typo__card-placeholder--small);
   @extend %identity-placeholder-inner-padding;
   display: flex;
   height: 100%;
@@ -60,22 +21,18 @@
   color: $color__text-primary-white;
 }
 
-.card[data-variant="large"] {
-  width: 327px;
-
-  @include media-query__name($breakpoint__large-card) {
-    width: 551px;
-  }
-
-  .card__media {
-    // Odd aspect ratio, taken from the design.
-    aspect-ratio: 551/312;
+.card--has-image {
+  // This is necessary to get object-fit to work.
+  * {
+    height: 100%;
   }
 }
 
 .card__tags {
   display: flex;
   margin-bottom: $s-sm;
+
+  @include text-ellipsis-truncation(1);
 }
 
 .card__tag {
@@ -105,4 +62,103 @@
 
 .card__title {
   @include typography($typo__h3);
+}
+
+%card-variant--default {
+  width: 327px;
+
+  @include media-query__name($breakpoint__large-card) {
+    width: 551px;
+  }
+
+  .card__media {
+    // Odd aspect ratio, taken from the design.
+    aspect-ratio: 551/312;
+  }
+}
+
+.card {
+  @extend %card-variant--default;
+
+  position: relative;
+  max-width: 100%;
+  word-break: break-word;
+
+  img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+
+  a {
+    text-decoration: none;
+  }
+}
+
+%card-variant--large,
+.card[data-variant="large"] {
+  @extend %card-variant--default;
+}
+
+%card-variant--x-large,
+.card[data-variant="x-large"] {
+  width: 200px;
+
+  @include media-query__name($breakpoint__large-card) {
+    width: 440px;
+  }
+
+  &.card--has-no-image {
+    // We only want the page fold on 1:1 view-modes.
+    @extend %identity-pagefold;
+  }
+
+  .card__placeholder-text {
+    @include typography($typo__card-placeholder);
+  }
+
+  .card__media {
+    aspect-ratio: 1/1;
+  }
+}
+
+%card-variant--small,
+.card[data-variant="small"] {
+  @extend %card-variant--x-large;
+
+  width: 206px;
+
+  .card__tags,
+  .card__media {
+    margin-bottom: $s-xs;
+  }
+
+  // On desktop sizes this small, there is no space for placeholder text, and
+  // extra tags, but we can still show it for screenreaders.
+  @include media-query__name($breakpoint__large-card) {
+    width: 206px;
+
+    .card__placeholder-text {
+      font-size: 0;
+    }
+
+    .card__tag {
+      @include typography($typo__byline-tags--small);
+    }
+
+    .card__title {
+      @include typography($typo__h4);
+    }
+  }
+}
+
+%card-variant--medium,
+.card[data-variant="medium"] {
+  width: 321px;
+
+  .card__media {
+    // Odd aspect ratio, taken from the design.
+    aspect-ratio: 321/426;
+  }
 }

--- a/src/stories/Library/shadows/shadows.scss
+++ b/src/stories/Library/shadows/shadows.scss
@@ -6,7 +6,6 @@ $shadows: "low"
     "0px 0px 3px hsla(0deg, 0%, 0%, 0.04),  0 1px 16px hsla(0deg, 0%, 0%, 0.2), 6px 0px  24px hsla(0deg, 0%, 0%, 0.06)";
 
 /* BEM plugin does not support interpolation */
-// stylelint-disable plugin/stylelint-bem-namics
 @each $name, $shadow in $shadows {
   .shadow-#{$name} {
     box-shadow: #{$shadow};
@@ -19,4 +18,3 @@ $shadows: "low"
     }
   }
 }
-// stylelint-enable plugin/stylelint-bem-namics

--- a/src/stories/Library/slider/Slider.stories.tsx
+++ b/src/stories/Library/slider/Slider.stories.tsx
@@ -29,35 +29,44 @@ export default {
 
 const Template: ComponentStory<typeof Slider> = (args) => <Slider {...args} />;
 
-const title = "Bøger som har gjort en forskel for romanens udvikling";
-const typeTag = "Arrangement";
-const dateTag = "06 Dec 2022";
 const imageUrl =
   "https://images.unsplash.com/photo-1568667256549-094345857637?q=80&w=2815&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
 const image = <ImageCredited src={imageUrl} />;
-const placeholderText = "Stine Pilgaard vinder De Gyldne Laurbær";
 
-const cardLarge = (
+const card = (
   <Card
-    variant="large"
-    title={title}
-    typeTag={typeTag}
-    dateTag={dateTag}
+    title="Bøger som har gjort en forskel for romanens udvikling"
+    typeTag="Nyhed"
+    dateTag="06 Dec 2022"
     image={image}
   />
 );
 
-const cardLargeNoImage = (
+const cardNoImage = (
   <Card
-    variant="large"
-    title={title}
-    typeTag={typeTag}
-    dateTag={dateTag}
-    placeholderText={placeholderText}
+    title="Fars legestue, hver onsdag"
+    typeTag="Arrangement"
+    dateTag="06 Okt - 28 Dec 2022"
+    placeholderText="Fri leg for alle aldre"
   />
 );
 
 export const Many = Template.bind({});
 Many.args = {
-  items: [cardLarge, cardLargeNoImage, cardLarge, cardLargeNoImage],
+  items: [
+    card,
+    cardNoImage,
+    card,
+    cardNoImage,
+    cardNoImage,
+    card,
+    cardNoImage,
+    card,
+    card,
+    cardNoImage,
+    card,
+    cardNoImage,
+    card,
+    card,
+  ],
 };

--- a/src/stories/Library/slider/Slider.stories.tsx
+++ b/src/stories/Library/slider/Slider.stories.tsx
@@ -1,0 +1,63 @@
+import { ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+
+import Slider from "./Slider";
+import Card from "../card/Card";
+import ImageCredited from "../image-credited/ImageCredited";
+
+export default {
+  title: "Library / Slider",
+  component: Slider,
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=7711-76621",
+    },
+  },
+  argTypes: {
+    title: {
+      defaultValue: "Inspiration",
+      type: "string",
+    },
+    items: {
+      // Disabling controls, as the different variations are added already.
+      control: false,
+    },
+  },
+};
+
+const Template: ComponentStory<typeof Slider> = (args) => <Slider {...args} />;
+
+const title = "Bøger som har gjort en forskel for romanens udvikling";
+const typeTag = "Arrangement";
+const dateTag = "06 Dec 2022";
+const imageUrl =
+  "https://images.unsplash.com/photo-1568667256549-094345857637?q=80&w=2815&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+const image = <ImageCredited src={imageUrl} />;
+const placeholderText = "Stine Pilgaard vinder De Gyldne Laurbær";
+
+const cardLarge = (
+  <Card
+    variant="large"
+    title={title}
+    typeTag={typeTag}
+    dateTag={dateTag}
+    image={image}
+  />
+);
+
+const cardLargeNoImage = (
+  <Card
+    variant="large"
+    title={title}
+    typeTag={typeTag}
+    dateTag={dateTag}
+    placeholderText={placeholderText}
+  />
+);
+
+export const Many = Template.bind({});
+Many.args = {
+  items: [cardLarge, cardLargeNoImage, cardLarge, cardLargeNoImage],
+};

--- a/src/stories/Library/slider/Slider.tsx
+++ b/src/stories/Library/slider/Slider.tsx
@@ -1,0 +1,75 @@
+import { FC, ReactNode, useEffect } from "react";
+import { Helmet } from "react-helmet";
+
+type SliderProps = {
+  title?: string;
+  items: ReactNode[];
+};
+
+const Slider: FC<SliderProps> = ({ title, items }) => {
+  useEffect(() => {
+    require("./init-slider");
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"
+        />
+
+        <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js" />
+      </Helmet>
+
+      <div className="slider swiper">
+        <div className="slider__header">
+          {title ? <h2 className="slider__title">{title}</h2> : ""}
+
+          <div className="slider__controls" data-glide-el="controls">
+            <button
+              className="slider__control swiper-next"
+              aria-label="Scroll fremad"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="115"
+                height="26"
+                viewBox="0 0 115 26"
+                fill="black"
+              >
+                <path d="M114.707 13.2464C115.098 12.8559 115.098 12.2228 114.707 11.8322L108.343 5.46827C107.953 5.07774 107.319 5.07774 106.929 5.46827C106.538 5.85879 106.538 6.49196 106.929 6.88248L112.586 12.5393L106.929 18.1962C106.538 18.5867 106.538 19.2199 106.929 19.6104C107.319 20.0009 107.953 20.0009 108.343 19.6104L114.707 13.2464ZM0 13.5393H114V11.5393H0V13.5393Z" />
+              </svg>
+            </button>
+            <button
+              className="slider__control swiper-prev"
+              aria-label="Scroll tilbage"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="115"
+                height="25"
+                viewBox="0 0 115 25"
+                fill="black"
+              >
+                <path d="M0.292893 12.0906C-0.0976333 12.4811 -0.0976334 13.1143 0.292892 13.5048L6.65685 19.8688C7.04738 20.2593 7.68054 20.2593 8.07107 19.8688C8.46159 19.4783 8.46159 18.8451 8.07107 18.4546L2.41422 12.7977L8.07107 7.14087C8.46159 6.75034 8.46159 6.11718 8.07107 5.72665C7.68054 5.33613 7.04738 5.33613 6.65685 5.72665L0.292893 12.0906ZM115 11.7977L1 11.7977L1 13.7977L115 13.7977L115 11.7977Z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <ul className="swiper-wrapper">
+          {items.map((item, index) => {
+            return (
+              <li key={index} className="swiper-slide slider__item">
+                {item}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default Slider;

--- a/src/stories/Library/slider/init-slider.js
+++ b/src/stories/Library/slider/init-slider.js
@@ -1,0 +1,40 @@
+const sliders = document.querySelectorAll(".slider");
+
+// Sliders should have cards in different sizes.
+// We could do this server-side, but it is quite expensive, atleast in Drupal
+// because of caching, and because they depend on an outer context.
+sliders.forEach((slider) => {
+  const cards = slider.querySelectorAll(".card");
+
+  let index = 0;
+
+  cards.forEach((card) => {
+    index += 1;
+    let variant = "large";
+
+    if (index % 2 === 0) {
+      variant = "x-large";
+    }
+
+    card.setAttribute("data-variant", variant);
+  });
+});
+
+// Initialize the Swiper library, when the page is ready.
+window.addEventListener("load", () => {
+  // eslint-disable-next-line no-undef, @typescript-eslint/no-unused-vars
+  const swiper = new Swiper(".swiper", {
+    slidesPerView: "auto",
+    spaceBetween: "5%",
+    centeredSlidesBounds: true,
+    navigation: {
+      nextEl: ".swiper-next",
+      prevEl: ".swiper-prev",
+    },
+    breakpoints: {
+      1200: {
+        spaceBetween: 82,
+      },
+    },
+  });
+});

--- a/src/stories/Library/slider/init-slider.js
+++ b/src/stories/Library/slider/init-slider.js
@@ -1,32 +1,11 @@
-const sliders = document.querySelectorAll(".slider");
-
-// Sliders should have cards in different sizes.
-// We could do this server-side, but it is quite expensive, atleast in Drupal
-// because of caching, and because they depend on an outer context.
-sliders.forEach((slider) => {
-  const cards = slider.querySelectorAll(".card");
-
-  let index = 0;
-
-  cards.forEach((card) => {
-    index += 1;
-    let variant = "large";
-
-    if (index % 2 === 0) {
-      variant = "x-large";
-    }
-
-    card.setAttribute("data-variant", variant);
-  });
-});
-
 // Initialize the Swiper library, when the page is ready.
 window.addEventListener("load", () => {
   // eslint-disable-next-line no-undef, @typescript-eslint/no-unused-vars
   const swiper = new Swiper(".swiper", {
     slidesPerView: "auto",
     spaceBetween: "5%",
-    centeredSlidesBounds: true,
+    freeMode: true,
+    centeredSlidesBounds: false,
     navigation: {
       nextEl: ".swiper-next",
       prevEl: ".swiper-prev",

--- a/src/stories/Library/slider/slider.scss
+++ b/src/stories/Library/slider/slider.scss
@@ -36,17 +36,39 @@
 
   &[disabled] {
     opacity: 0;
-    width: 0;
   }
 }
 
 .slider__item {
+  $_card-mobile-peek: 50px;
+
   width: fit-content !important;
   margin-right: 5%;
+
+  .card {
+    // We dont want the max-width to be 100%, as we want peek-effect on mobile.
+    max-width: calc(100vw - #{$_card-mobile-peek});
+  }
 
   // For some reason, all no-image cards in the slider should be pulled
   // up higher than the image ones.
   .card--has-image {
     margin-top: $s-xl;
+  }
+
+  // The slider follows a very specific card pattern:
+  // 1: large, 2: x-large, 3: medium, 4: small - repeating.
+  @for $i from 1 through 4 {
+    &:nth-child(4n + #{$i}) .card {
+      @if $i == 1 {
+        @extend %card-variant--large;
+      } @else if $i == 2 {
+        @extend %card-variant--x-large;
+      } @else if $i == 3 {
+        @extend %card-variant--medium;
+      } @else if $i == 4 {
+        @extend %card-variant--small;
+      }
+    }
   }
 }

--- a/src/stories/Library/slider/slider.scss
+++ b/src/stories/Library/slider/slider.scss
@@ -1,0 +1,52 @@
+.slider {
+  @include vertical-spacing;
+}
+
+.slider__header {
+  @include layout-container;
+
+  display: flex;
+  margin-bottom: $s-lg;
+}
+
+.slider__title {
+  @extend %title-underline;
+  @include typography($typo__h2);
+
+  display: flex;
+}
+
+.slider__controls {
+  display: none;
+  flex-direction: column;
+  flex-grow: 1;
+  align-content: end;
+
+  @include media-query__small {
+    display: flex;
+  }
+}
+
+.slider__control {
+  width: 115px;
+  max-width: 100%;
+  margin-left: auto;
+  transition: opacity 0.2s ease-in-out;
+  cursor: pointer;
+
+  &[disabled] {
+    opacity: 0;
+    width: 0;
+  }
+}
+
+.slider__item {
+  width: fit-content !important;
+  margin-right: 5%;
+
+  // For some reason, all no-image cards in the slider should be pulled
+  // up higher than the image ones.
+  .card--has-image {
+    margin-top: $s-xl;
+  }
+}

--- a/src/styles/scss/legacy/pagefold.legacy.scss
+++ b/src/styles/scss/legacy/pagefold.legacy.scss
@@ -12,8 +12,6 @@ $pagefold-map: (
   "xlarge": 56,
 );
 
-// BEM plugin does not support interpolation.
-// stylelint-disable plugin/stylelint-bem-namics
 @each $size, $triangle-width in $pagefold-map {
   .m-#{$size} {
     margin: #{$size}px;
@@ -61,5 +59,3 @@ $pagefold-map: (
     }
   }
 }
-
-// stylelint-enable plugin/stylelint-bem-namics

--- a/src/styles/scss/legacy/spacings.legacy.scss
+++ b/src/styles/scss/legacy/spacings.legacy.scss
@@ -1,4 +1,3 @@
-// stylelint-disable plugin/stylelint-bem-namics
 $legacy_spacings: (
   4: $s-xs,
   8: $s-sm,
@@ -76,5 +75,3 @@ $legacy_spacings: (
     padding-top: $space;
   }
 }
-
-// stylelint-enable plugin/stylelint-bem-namics

--- a/src/styles/scss/tools/mixins.misc.scss
+++ b/src/styles/scss/tools/mixins.misc.scss
@@ -26,7 +26,6 @@
  * fixed by actually adding a class to the svg - or, a common wrapper class.
  */
 @mixin show-svg-on-hover($icon-container: "") {
-  // stylelint-disable-next-line plugin/stylelint-bem-namics
   #{$icon-container} > svg {
     visibility: hidden;
     opacity: 0;
@@ -40,7 +39,6 @@
     }
   }
 
-  // stylelint-disable-next-line plugin/stylelint-bem-namics
   &:hover #{$icon-container} > svg {
     visibility: visible;
     opacity: 1;

--- a/src/styles/scss/tools/mixins.misc.scss
+++ b/src/styles/scss/tools/mixins.misc.scss
@@ -55,3 +55,7 @@
   padding-right: $padding;
   box-sizing: border-box;
 }
+
+@mixin vertical-spacing {
+  margin-bottom: $s-2xl;
+}

--- a/src/styles/scss/tools/mixins.tools.scss
+++ b/src/styles/scss/tools/mixins.tools.scss
@@ -33,7 +33,7 @@
  *
  * @see mixin map-styling().
  * Example usage of this mixin, where line-height is excluded:
- * @iinclude typography($font__h4, (excludes: ('line-height'));
+ * @include typography($font__h4, (excludes: ('line-height'));
  *
  * @param {map} $font. See available maps in _variables.typography.scss.
  * @param {options} $options - List of options. Supports:
@@ -57,7 +57,7 @@
 /**
  * Applies text ellipsis styling with a customizable number of lines.
  *
- * This mixin applies text ellipsis using the -webkit-line-clamp property, 
+ * This mixin applies text ellipsis using the -webkit-line-clamp property,
  * The default number of lines is 2, but can be customized as needed.
  *
  * @param {number} $lines - The number of lines to display Default is 2.

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -1,4 +1,12 @@
-// stylelint-disable plugin/stylelint-bem-namics
+%text-ellipsis-two-lines {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
+
 %text-truncate {
   white-space: nowrap;
   overflow: hidden;
@@ -81,4 +89,3 @@
   }
 }
 
-// stylelint-enable plugin/stylelint-bem-namics

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -1,12 +1,3 @@
-%text-ellipsis-two-lines {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: left;
-}
-
 %text-truncate {
   white-space: nowrap;
   overflow: hidden;
@@ -122,6 +113,7 @@
 
   &::before {
     content: "";
+    display: block;
     position: absolute;
     top: 0;
     left: 0;
@@ -136,4 +128,3 @@
     }
   }
 }
-

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -25,6 +25,24 @@
   }
 }
 
+%title-underline {
+  position: relative;
+  &::before {
+    position: absolute;
+    content: "";
+    top: 1.5em;
+    left: $s-sm;
+    right: $s-sm;
+    height: 0.4em;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    // stylelint-disable -- Stylelint really does not enjoy embedded IMGs.
+    background-image: url('data:image/svg+xml,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 852.2 17" style="enable-background:new 0 0 852.2 17;" xml:space="preserve"><style type="text/css">.st0{fill:none;stroke:%23000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}</style><path class="st0" d="M7.9,8.7c52-1.3,131.1-3,227.7-4.3c83.7-1.1,243.5,1.2,325.2,4.3c43.3,1.6,166.2-4.9,284.4-2.7"/></svg>');
+    // stylelint-enable
+  }
+}
+
 %link-tag {
   @include typography($typo__body-placeholder);
 
@@ -59,10 +77,12 @@
 
 %identity-placeholder {
   background-color: var(--tint-color-120);
-  border: $s-lg solid var(--tint-color-100);
+  border: $s-lg solid $color__identity-primary;
 
-  @include media-query__small {
-    border-width: $s-2xl;
+  @each $breakpoint-name, $width in $placeholder-paddings {
+    @include media-query__name($breakpoint-name) {
+      border-width: $width;
+    }
   }
 }
 
@@ -86,6 +106,34 @@
     transform: translate(-50%, -50%);
     z-index: 1;
     background-color: $color__identity-primary;
+  }
+}
+
+%identity-placeholder-inner-padding {
+  @each $breakpoint-name, $width in $placeholder-paddings {
+    @include media-query__name($breakpoint-name) {
+      padding: $width * 0.5;
+    }
+  }
+}
+
+%identity-pagefold {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-bottom: solid var(--tint-color-120);
+    border-left: solid $color__page-bg;
+
+    @each $breakpoint-name, $width in $placeholder-paddings {
+      @include media-query__name($breakpoint-name) {
+        border-bottom-width: $width * 0.75;
+        border-left-width: $width * 0.75;
+      }
+    }
   }
 }
 

--- a/src/styles/scss/tools/variables.breakpoints.scss
+++ b/src/styles/scss/tools/variables.breakpoints.scss
@@ -6,3 +6,5 @@ $breakpoints: (
   "x-large": 1920px,
   "xx-large": 2200px,
 );
+
+$breakpoint__large-card: "medium";

--- a/src/styles/scss/tools/variables.colors.scss
+++ b/src/styles/scss/tools/variables.colors.scss
@@ -13,9 +13,15 @@ $color__identity-primary: hsl(
   1
 );
 
+$color__page-bg: $color__global-primary;
+
 $color__text-primary-white: $color__global-white;
 $color__text-primary-black: $color__global-black;
 $color__text-secondary-gray: $color__global-grey;
+$color__text-primary-white: #fff;
+$color__text-primary-black: #000;
+$color__text-secondary-gray: #484848;
+$color__text-inactive: $color__global-tertiary-2;
 
 $color__signal-success: #068802;
 $color__signal-aware: #f7bf42;

--- a/src/styles/scss/tools/variables.colors.scss
+++ b/src/styles/scss/tools/variables.colors.scss
@@ -18,9 +18,6 @@ $color__page-bg: $color__global-primary;
 $color__text-primary-white: $color__global-white;
 $color__text-primary-black: $color__global-black;
 $color__text-secondary-gray: $color__global-grey;
-$color__text-primary-white: #fff;
-$color__text-primary-black: #000;
-$color__text-secondary-gray: #484848;
 $color__text-inactive: $color__global-tertiary-2;
 
 $color__signal-success: #068802;

--- a/src/styles/scss/tools/variables.spacings.scss
+++ b/src/styles/scss/tools/variables.spacings.scss
@@ -23,3 +23,9 @@ $spacings: (
   6xl: $s-6xl,
   7xl: $s-7xl,
 );
+
+$placeholder-paddings: (
+  mobile: $s-lg,
+  small: $s-xl,
+  medium: $s-3xl,
+);

--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -291,6 +291,10 @@ $typo__byline-tags: (
     ),
 );
 
+$typo__byline-tags--small: (
+  mobile: map_get($typo__byline-tags, "mobile"),
+);
+
 $typo__rich-text-body: (
   mobile: (
     font-family: $font__body,
@@ -317,5 +321,19 @@ $typo__card-placeholder: (
   #{$breakpoint__large-card}: (
       font-size: 42px,
       line-height: 46px,
+    ),
+);
+
+$typo__card-placeholder--small: (
+  mobile: (
+    font-family: $font__title,
+    font-style: normal,
+    font-weight: $font__weight--normal,
+    font-size: 20px,
+    line-height: 24px,
+  ),
+  #{$breakpoint__large-card}: (
+      font-size: 28px,
+      line-height: 32px,
     ),
 );

--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -278,6 +278,19 @@ $typo__label: (
   ),
 );
 
+$typo__byline-tags: (
+  mobile: (
+    font-family: $font__title,
+    font-style: normal,
+    font-weight: $font__weight--normal,
+    font-size: 14px,
+    line-height: 24px,
+  ),
+  #{$breakpoint__large-card}: (
+      font-size: 20px,
+    ),
+);
+
 $typo__rich-text-body: (
   mobile: (
     font-family: $font__body,
@@ -291,4 +304,18 @@ $typo__rich-text-body: (
     font-size: 18px,
     line-height: 32px,
   ),
+);
+
+$typo__card-placeholder: (
+  mobile: (
+    font-family: $font__title,
+    font-style: normal,
+    font-weight: $font__weight--normal,
+    font-size: 16px,
+    line-height: 20px,
+  ),
+  #{$breakpoint__large-card}: (
+      font-size: 42px,
+      line-height: 46px,
+    ),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,14 +1782,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@namics/stylelint-bem@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@namics/stylelint-bem/-/stylelint-bem-7.0.0.tgz#58dafcb1be601c3f77267493faf6e17f3bf0d1fb"
-  integrity sha512-XimlWZbCotBQbwB5YwcB5d7HNhoY4YBWyfoMbDcEuUWOCEmXDbfwsSDJR+cytm+/Z+lDVRnHd+iM01AaF0+R4A==
-  dependencies:
-    css-selector-classes "0.1.2"
-    postcss-resolve-nested-selector "0.1.1"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3159,6 +3151,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^6.1.11":
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
+  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -4149,7 +4148,7 @@ array-union@^3.0.1:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
   integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
 
-array-uniq@^1.0.1, array-uniq@^1.0.2:
+array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
@@ -5895,19 +5894,6 @@ css-select@^4.1.3:
     domhandler "^4.3.1"
     domutils "^2.8.0"
     nth-check "^2.0.1"
-
-css-selector-classes@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/css-selector-classes/-/css-selector-classes-0.1.2.tgz#2403d8e560101c829c5f1df9308032a7a41fc376"
-  integrity sha512-I9BqkJUoQgd//YQfRKpk+ohVJBa1TnJjcbHGNdAy8mfrzUMpTkFDEIMQNkn8hiV1soBFGqBQcxJRoh81XhAVYw==
-  dependencies:
-    array-uniq "^1.0.2"
-    css-selector-parser "~1.0.3"
-
-css-selector-parser@~1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.0.4.tgz#65dfe614bd5fd175b64a0a3f193b870fc5790773"
-  integrity sha512-hu4/RJPZaghwTY/B7PpCt2s1Vq8qzT4UYhi279u4MB8TADfbpR3V3M9m4AnUVleQsrVkPqe/dGLbzxi4GgTg2A==
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -12644,7 +12630,7 @@ postcss-replace-overflow-wrap@^3.0.0:
   dependencies:
     postcss "^7.0.2"
 
-postcss-resolve-nested-selector@0.1.1, postcss-resolve-nested-selector@^0.1.1:
+postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
   integrity sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==
@@ -13221,6 +13207,21 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-fast-compare@^3.1.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -13320,6 +13321,11 @@ react-scripts@^4.0.3:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-sizeme@^3.0.1:
   version "3.0.2"


### PR DESCRIPTION
    Remove bem-namics rule from stylelint.

    It appears that it does not work as intended:
    It reports errors where it shouldnt, and doesnt
    report errors where it should.

    Ontop of that, it seems to cause a bug with // stylelint-disable-line.

    A lot of the files we choose to ignore it anyway,
    so we might aswell just remove it.

----

    Card slider, and placeholder/pagefold refactor. DDFFORM-86

    - Introduce a 'card' story, which corresponds to the 'news card'
      in Figma.
    - Cards can support images, or just a teaser text, shown in the
      page fold, placeholder style.
    - I've simplified the placeholder/pagefold functionality,
      using %placeholders and making them responsive, instead of
      defining specific sized HTML elements.
    - I've also included the 'SwiperJS' library, for the slider.
    - SwiperJS was chosen, as the elements in the slider needs to
      be able to be different sizes, whilst also allowing 'peeking',
      to the next slide.


-----


    Introduce more card view modes. DDFFORM-87

    Also re-factors the truncate placeholder, to be a
    mixin instead with the line amount as a parameter.