### PR TITLE
Implement `show more` functionality as a utility

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -121,3 +121,4 @@
 
 @import "./src/styles/scss/shared";
 @import "./src/styles/scss/internal";
+@import "./src/stories/utils/show-more";

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -12,9 +12,9 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
   return (
     <header className="event-header">
       <section className="event-header__content">
-        <Tag hasBackground className="event-header__tag">
-          Udstilling
-        </Tag>
+        <div className="event-header__tags">
+          <Tag hasBackground>Udstilling</Tag>
+        </div>
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>
         <a

--- a/src/stories/Library/event-header/event-header.scss
+++ b/src/stories/Library/event-header/event-header.scss
@@ -24,7 +24,7 @@
   display: grid;
   grid-template-columns: $s-3xl 1fr $s-3xl;
   grid-template-areas:
-    ". tag  ."
+    ". tags  tags"
     ". date  ."
     ". title  ."
     "btn btn btn";
@@ -35,9 +35,11 @@
   }
 }
 
-.event-header__tag {
-  grid-area: tag;
-  width: max-content;
+.event-header__tags {
+  grid-area: tags;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   margin-bottom: $s-md;
   @include media-query__small {
     margin-bottom: $s-lg;

--- a/src/stories/utils/show-more.js
+++ b/src/stories/utils/show-more.js
@@ -1,0 +1,36 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const categories = document.querySelectorAll("[data-show-more-item]");
+  const toggleButton = document.querySelector("[data-show-more-button]");
+  const initialVisibleItems =
+    document.querySelector("[data-show-more-initial-visible-items]") ?? 2; // default to 2 if not set
+
+  // if there are no categories or only one category, hide the toggle button
+  // or if there are less categories than the initial visible items, hide the toggle button
+  if (categories.length <= 1 || categories.length <= initialVisibleItems) {
+    toggleButton.style.display = "none";
+    return;
+  }
+
+  // Get the show more and show less text from data attributes or use defaults
+  const showMoreText =
+    toggleButton.getAttribute("data-show-more-text") ?? "Show more";
+  const hideMoreText =
+    toggleButton.getAttribute("data-show-more-hide-text") ?? "Show less";
+
+  const visibleItems = initialVisibleItems - 1; // -1 because of is array index based
+
+  categories.forEach((item, index) => {
+    if (index > visibleItems) item.classList.add("show-more__hidden");
+  });
+
+  toggleButton.addEventListener("click", () => {
+    const isExpanded = toggleButton.getAttribute("aria-expanded") === "true";
+
+    categories.forEach((item, index) => {
+      if (index > visibleItems) item.classList.toggle("show-more__hidden");
+    });
+
+    toggleButton.innerText = isExpanded ? showMoreText : hideMoreText;
+    toggleButton.setAttribute("aria-expanded", !isExpanded);
+  });
+});

--- a/src/stories/utils/show-more.js
+++ b/src/stories/utils/show-more.js
@@ -7,15 +7,14 @@ document.addEventListener("DOMContentLoaded", () => {
   // if there are no categories or only one category, hide the toggle button
   // or if there are less categories than the initial visible items, hide the toggle button
   if (categories.length <= 1 || categories.length <= initialVisibleItems) {
-    toggleButton.style.display = "none";
+    toggleButton.classList.add("show-more__hidden");
     return;
   }
 
   // Get the show more and show less text from data attributes or use defaults
-  const showMoreText =
-    toggleButton.getAttribute("data-show-more-text") ?? "Show more";
+  const showMoreText = toggleButton.getAttribute("data-show-more-text") ?? "+";
   const hideMoreText =
-    toggleButton.getAttribute("data-show-more-hide-text") ?? "Show less";
+    toggleButton.getAttribute("data-show-more-hide-text") ?? "-";
 
   const visibleItems = initialVisibleItems - 1; // -1 because of is array index based
 

--- a/src/stories/utils/show-more.md
+++ b/src/stories/utils/show-more.md
@@ -1,0 +1,30 @@
+# How to Implement Show More/Less Functionality
+To integrate a "Show More/Less" feature, follow these steps.
+This feature is particularly useful for lists where you want to initially display a limited number of items and give users the option to view more.
+
+## HTML Structure
+First, organize your HTML elements as follows:
+
+- **ARIA Expanded**: Include the `aria-expanded="false"` attribute on the button to indicate whether the additional content is currently expanded or collapsed.
+- **List Items**: Apply the `data-show-more-item` attribute to each item you want to toggle.
+- **Toggle Button**: Include a button with the `data-show-more-button` attribute. This is what users will interact with.
+- **Show More Text (Optional)**: Include the `data-show-more-text` attribute on the button to specify the text that should be displayed when there is more content to be shown.
+- **Show Less Text (Optional)**: Include the `data-show-more-hide-text` attribute on the button to specify the text that should be displayed when there is less content to be shown.
+- **Initial Visible Items (Optional)**: Optionally include an element with `data-show-more-initial-visible-items` attribute to dynamically set the number of items visible initially. If not set, it defaults to 2.
+
+```html
+<div data-show-more-item>Item 1</div>
+<div data-show-more-item>Item 2</div>
+<!-- all items after this are hidden by default  -->
+<div data-show-more-item>Item 3</div>
+
+<button
+  class="cursor-pointer"
+  aria-expanded="false"
+  data-show-more-button
+  data-show-more-text="Custom Show more"
+  data-show-more-hide-text="Custom Show less"
+  data-show-more-initial-visible-items="3"
+>
+  Show more
+</button>

--- a/src/stories/utils/show-more.md
+++ b/src/stories/utils/show-more.md
@@ -8,23 +8,28 @@ First, organize your HTML elements as follows:
 - **ARIA Expanded**: Include the `aria-expanded="false"` attribute on the button to indicate whether the additional content is currently expanded or collapsed.
 - **List Items**: Apply the `data-show-more-item` attribute to each item you want to toggle.
 - **Toggle Button**: Include a button with the `data-show-more-button` attribute. This is what users will interact with.
+- **ARIA Controls**: Implement an `<ul>` or `<ol>` element assigned with the `id` attribute `show-more-item-list`. This element will encompass the list items. Additionally, include a toggle button with the attribute aria-controls="show-more-item-list". This attribute explicitly links the button to the list, enhancing the accessibility and interactivity of the content.
 - **Show More Text (Optional)**: Include the `data-show-more-text` attribute on the button to specify the text that should be displayed when there is more content to be shown.
 - **Show Less Text (Optional)**: Include the `data-show-more-hide-text` attribute on the button to specify the text that should be displayed when there is less content to be shown.
 - **Initial Visible Items (Optional)**: Optionally include an element with `data-show-more-initial-visible-items` attribute to dynamically set the number of items visible initially. If not set, it defaults to 2.
 
 ```html
-<div data-show-more-item>Item 1</div>
-<div data-show-more-item>Item 2</div>
-<!-- all items after this are hidden by default  -->
-<div data-show-more-item>Item 3</div>
+<ul id="show-more-item-list">
+  <li data-show-more-item>Item 1</li>
+  <li data-show-more-item>Item 2</li>
+  <!-- all items after this are hidden by default  -->
+  <li data-show-more-item>Item 3</li>
 
-<button
-  class="cursor-pointer"
-  aria-expanded="false"
-  data-show-more-button
-  data-show-more-text="Custom Show more"
-  data-show-more-hide-text="Custom Show less"
-  data-show-more-initial-visible-items="3"
->
-  Show more
+  <button
+    class="cursor-pointer"
+    aria-controls="show-more-item-list"
+    aria-expanded="false"
+    data-show-more-button
+    data-show-more-text="Custom Show more"
+    data-show-more-hide-text="Custom Show less"
+    data-show-more-initial-visible-items="3"
+  >
+    Show more
 </button>
+</ul>
+```

--- a/src/stories/utils/show-more.md
+++ b/src/stories/utils/show-more.md
@@ -1,17 +1,35 @@
 # How to Implement Show More/Less Functionality
+
 To integrate a "Show More/Less" feature, follow these steps.
-This feature is particularly useful for lists where you want to initially display a limited number of items and give users the option to view more.
+This feature is useful for lists where you want
+to initially display a limited number of items and give users
+the option to view more.
 
 ## HTML Structure
+
 First, organize your HTML elements as follows:
 
-- **ARIA Expanded**: Include the `aria-expanded="false"` attribute on the button to indicate whether the additional content is currently expanded or collapsed.
-- **List Items**: Apply the `data-show-more-item` attribute to each item you want to toggle.
-- **Toggle Button**: Include a button with the `data-show-more-button` attribute. This is what users will interact with.
-- **ARIA Controls**: Implement an `<ul>` or `<ol>` element assigned with the `id` attribute `show-more-item-list`. This element will encompass the list items. Additionally, include a toggle button with the attribute aria-controls="show-more-item-list". This attribute explicitly links the button to the list, enhancing the accessibility and interactivity of the content.
-- **Show More Text (Optional)**: Include the `data-show-more-text` attribute on the button to specify the text that should be displayed when there is more content to be shown.
-- **Show Less Text (Optional)**: Include the `data-show-more-hide-text` attribute on the button to specify the text that should be displayed when there is less content to be shown.
-- **Initial Visible Items (Optional)**: Optionally include an element with `data-show-more-initial-visible-items` attribute to dynamically set the number of items visible initially. If not set, it defaults to 2.
+- **Toggle Button**: Include a button with the `data-show-more-button`
+attribute. This is what users will interact with.
+- **ARIA Expanded**: Include the `aria-expanded="false"` attribute
+on the button to indicate whether the additional content
+is currently expanded or collapsed.
+- **ARIA Controls**: Implement an `<ul>` or `<ol>` element assigned
+with the `id` attribute `show-more-item-list`. This element will encompass
+the list items. Additionally, include a toggle button with the attribute `aria-controls="show-more-item-list`.
+This attribute explicitly links the button to the list,
+enhancing the accessibility and interactivity of the content.
+- **List Items**: Apply the `data-show-more-item` attribute
+to each item you want to toggle.
+- **Show More Text (Optional)**: Include the `data-show-more-text`
+attribute on the button to specify the text that should be displayed
+when there is more content to be shown.
+- **Show Less Text (Optional)**: Include the `data-show-more-hide-text`
+attribute on the button to specify the text that should
+be displayed when there is less content to be shown.
+- **Initial Visible Items (Optional)**: Optionally include an
+element with `data-show-more-initial-visible-items` attribute to dynamically
+set the number of items visible initially. If not set, it defaults to 2.
 
 ```html
 <ul id="show-more-item-list">
@@ -19,17 +37,16 @@ First, organize your HTML elements as follows:
   <li data-show-more-item>Item 2</li>
   <!-- all items after this are hidden by default  -->
   <li data-show-more-item>Item 3</li>
-
-  <button
-    class="cursor-pointer"
-    aria-controls="show-more-item-list"
-    aria-expanded="false"
-    data-show-more-button
-    data-show-more-text="Custom Show more"
-    data-show-more-hide-text="Custom Show less"
-    data-show-more-initial-visible-items="3"
-  >
-    Show more
-</button>
 </ul>
+<button
+  class="cursor-pointer"
+  aria-controls="show-more-item-list"
+  aria-expanded="false"
+  data-show-more-button
+  data-show-more-text="Custom Show more"
+  data-show-more-hide-text="Custom Show less"
+  data-show-more-initial-visible-items="3"
+>
+  Show more
+</button>
 ```

--- a/src/stories/utils/show-more.scss
+++ b/src/stories/utils/show-more.scss
@@ -1,0 +1,3 @@
+.show-more__hidden {
+  display: none;
+}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-130

#### Description
This pull request introduces the `show more` feature as a utility for use in Drupal / dpl-cms, specifically designed for `HorizontalTermLine` and `Tags`. 

It also includes a refactor of the `EventHeader` component, enabling it to manage multiple tags if needed.

#### Screenshot of the result