### PR TITLE
Fix styling

### DIFF
--- a/src/styles/scss/reset.scss
+++ b/src/styles/scss/reset.scss
@@ -40,6 +40,7 @@ body {
   scroll-behavior: smooth;
   text-rendering: optimizespeed;
   line-height: 1.5;
+  background-color: $color__page-bg;
 }
 
 /* A elements that don't have a class get default styles */


### PR DESCRIPTION

Set the page background on the whole body, to avoid margin issues.

Up until now, we've added the page background on various
individual components, but this is a problem if there is
margin between elements, when we want the BG to continue.