### PR TITLE
Remove content inner scrollbar from modals

### DIFF
--- a/src/stories/Library/Arrows/arrows.scss
+++ b/src/stories/Library/Arrows/arrows.scss
@@ -47,4 +47,11 @@
   // This width mimics what the expanded svg width. The class is intended to be
   // used when the arrow needs to be within a button so they look the same.
   width: 101px;
+
+  &:focus {
+    svg {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
 }

--- a/src/stories/Library/Lists/list-materials/list-materials.scss
+++ b/src/stories/Library/Lists/list-materials/list-materials.scss
@@ -33,6 +33,8 @@
 }
 
 .list-materials--disabled {
+  @include show-svg-on-hover(".list-materials__arrow");
+
   .checkbox {
     .checkbox__icon {
       opacity: 0;

--- a/src/stories/Library/Modals/modal-details/modal-details.scss
+++ b/src/stories/Library/Modals/modal-details/modal-details.scss
@@ -12,7 +12,6 @@ $MODAL_DETAILS_CONTAINER_WIDTH: 1000px;
 
 .modal-details__container {
   width: 100%;
-  overflow: auto;
   max-width: 100%;
   padding-bottom: $s-2xl;
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-142

#### Description
The scrollbar is now only on the very right side of the modal and there isn't any blank space on the bottom of the modal where content is cut off.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/b0c27414-1c78-46e3-a90d-2d1c051aeb7e)

#### Additional comments or questions
-

