### PR TITLE
Paragraph tweaks

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -107,7 +107,7 @@
 @import "./src/stories/Library/medias/medias";
 @import "./src/stories/Library/slider/slider";
 @import "./src/stories/Library/card/card";
-@import "./src/stories/Library/paragraph/paragraph";
+@import "./src/stories/Library/paragraphs/paragraphs";
 @import "./src/stories/Library/video-embed/video-embed";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest

--- a/src/stories/Library/link-with-icon/link-with-icon.scss
+++ b/src/stories/Library/link-with-icon/link-with-icon.scss
@@ -22,8 +22,10 @@
     margin-bottom: 0;
   }
 
+  // Removing the spacing/double border between items next to eachother.
   & + .link-with-icon {
     margin-top: 0;
+    border-top: 0;
   }
 
   @include media-query__small {

--- a/src/stories/Library/paragraph/paragraph.scss
+++ b/src/stories/Library/paragraph/paragraph.scss
@@ -1,9 +1,0 @@
-.paragraph {
-  @include vertical-spacing;
-}
-
-// 'Links' paragraphs should go flush against each-other.
-.paragraph--links + .paragraph--links {
-  // 1px to also collapse the border.
-  margin-top: -($_vertical-spacing--large + 1px);
-}

--- a/src/stories/Library/paragraphs/Paragraphs.tsx
+++ b/src/stories/Library/paragraphs/Paragraphs.tsx
@@ -5,17 +5,17 @@ import VideoEmbed from "../video-embed/VideoEmbed";
 export const EventParagraphs = () => {
   return (
     <section className="paragraphs">
-      <div className="paragraph paragraph--rich-text">
+      <div className="paragraphs__item paragraphs__item--rich-text">
         <RichTextEvent />
       </div>
-      <div className="paragraph paragraph--links">
+      <div className="paragraphs__item paragraphs__item--links">
         <LinkWithIcon
           href="https://example.com"
           linkText="External Link"
           linkType="external"
         />
       </div>
-      <div className="paragraph paragraph--links">
+      <div className="paragraphs__item paragraphs__item--links">
         <LinkWithIcon href="/" linkText="internal Link" linkType="internal" />
       </div>
     </section>
@@ -25,13 +25,13 @@ export const EventParagraphs = () => {
 export const ArticleParagraphs = () => {
   return (
     <section className="paragraphs">
-      <div className="paragraph paragraph--rich-text">
+      <div className="paragraphs__item paragraph--rich-text">
         <RichText />
       </div>
-      <div className="paragraph paragraph--video">
+      <div className="paragraphs__item paragraph--video">
         <VideoEmbed src="https://www.youtube.com/embed/CmzKQ3PSrow" />
       </div>
-      <div className="paragraph paragraph--links">
+      <div className="paragraphs__item paragraphs__item--links">
         <LinkWithIcon
           href="https://example.com"
           linkText="External Link"

--- a/src/stories/Library/paragraphs/paragraphs.scss
+++ b/src/stories/Library/paragraphs/paragraphs.scss
@@ -1,0 +1,13 @@
+.paragraphs__item {
+  @include vertical-spacing;
+}
+
+// 'Links' + 'Files' paragraphs should go flush against each-other.
+.paragraphs__item--links,
+.paragraphs__item--files {
+  + .paragraphs__item--files,
+  + .paragraphs__item--links {
+    // -1px to also collapse the border.
+    margin-top: -($_vertical-spacing--large + 1px);
+  }
+}


### PR DESCRIPTION
Fix spacing between links/files paragraph items + Better class name.

- Make sure 'files' paragraph works in same way as 'links'
- Use `.paragraphs__item` instead of `.paragraph`, to avoid that
  we style on a class name that Drupal might use in situations
  we are not interested in.