### PR TITLE
Card+Card-grid size tweaks. DDFFORM-180 DDFFORM-182

### DIFF
--- a/src/stories/Library/card-grid/CardGrid.stories.tsx
+++ b/src/stories/Library/card-grid/CardGrid.stories.tsx
@@ -66,6 +66,7 @@ const Few = Template.bind({});
 Few.args = {
   title: undefined,
   linkText: undefined,
+  items: [cardNoImage, card, cardNoImage],
 };
 
 export { Many, Few };

--- a/src/stories/Library/card-grid/card-grid.scss
+++ b/src/stories/Library/card-grid/card-grid.scss
@@ -4,7 +4,15 @@
 $_card-grid-gap: $s-lg;
 
 .card-grid {
-  @include layout-container("none");
+  @include layout-container();
+
+  .card__placeholder-text {
+    @include typography($typo__card-placeholder--grid);
+  }
+}
+
+.card-grid--full-width {
+  @include layout-container(none);
 }
 
 .card-grid__header {
@@ -85,6 +93,8 @@ $_card-grid-gap: $s-lg;
   );
 
   // The card widths on the largest (desktop) screen.
+  // These sizes are only being used on full-width grids, as the cards will
+  // become too massive otherwise.
   $_card-widths--large: (
     "x-large": 45%,
     "small": 15%,
@@ -102,8 +112,10 @@ $_card-grid-gap: $s-lg;
         width: map_get($_card-widths--medium, $name);
       }
 
-      @include media-query__large {
-        width: map_get($_card-widths--large, $name);
+      .card-grid--full-width & {
+        @include media-query__large {
+          width: map_get($_card-widths--large, $name);
+        }
       }
 
       .card {

--- a/src/stories/Library/card-grid/card-grid.scss
+++ b/src/stories/Library/card-grid/card-grid.scss
@@ -105,6 +105,7 @@ $_card-grid-gap: $s-lg;
   @each $key, $name in $_card-patterns {
     // The design is very specific about the masonry design. See the sizes
     // defined in the arrays above, which we loop through here.
+    // stylelint-disable max-nesting-depth -- I know it's awful nesting, but i have no choice.
     &:nth-child(#{$key}) {
       width: map_get($_card-widths--small, $name);
 
@@ -126,7 +127,6 @@ $_card-grid-gap: $s-lg;
         // placeholder box, that there is no space for the text, on larger
         // screens. On smaller screens, it takes up 50% of the page, so
         // there, there is plenty of space.
-        // stylelint-disable max-nesting-depth -- I know it's awful nesting, but i have no choice.
         @if ($name == "small") {
           @include media-query__small {
             .card__placeholder-text {
@@ -134,8 +134,8 @@ $_card-grid-gap: $s-lg;
             }
           }
         }
-        // stylelint-enable max-nesting-depth
       }
     }
+    // stylelint-enable max-nesting-depth
   }
 }

--- a/src/stories/Library/card/card.scss
+++ b/src/stories/Library/card/card.scss
@@ -119,6 +119,8 @@
   }
 
   .card__media {
+    @extend %identity-placeholder;
+
     aspect-ratio: 1/1;
   }
 }
@@ -155,7 +157,11 @@
 
 %card-variant--medium,
 .card[data-variant="medium"] {
-  width: 321px;
+  width: 200px;
+
+  @include media-query__name($breakpoint__large-card) {
+    width: 321px;
+  }
 
   .card__media {
     // Odd aspect ratio, taken from the design.

--- a/src/stories/Library/card/card.scss
+++ b/src/stories/Library/card/card.scss
@@ -11,7 +11,7 @@
 }
 
 .card__placeholder-text {
-  @include typography($typo__card-placeholder--small);
+  @include typography($typo__card-placeholder--medium);
   @extend %identity-placeholder-inner-padding;
   display: flex;
   height: 100%;
@@ -125,9 +125,11 @@
 
 %card-variant--small,
 .card[data-variant="small"] {
-  @extend %card-variant--x-large;
-
   width: 206px;
+
+  .card__media {
+    aspect-ratio: 1/1;
+  }
 
   .card__tags,
   .card__media {
@@ -137,8 +139,6 @@
   // On desktop sizes this small, there is no space for placeholder text, and
   // extra tags, but we can still show it for screenreaders.
   @include media-query__name($breakpoint__large-card) {
-    width: 206px;
-
     .card__placeholder-text {
       font-size: 0;
     }

--- a/src/stories/Library/slider/slider.scss
+++ b/src/stories/Library/slider/slider.scss
@@ -50,21 +50,19 @@
     max-width: calc(100vw - #{$_card-mobile-peek});
   }
 
-  // For some reason, all no-image cards in the slider should be pulled
-  // up higher than the image ones.
-  .card--has-image {
-    margin-top: $s-xl;
-  }
-
   // The slider follows a very specific card pattern:
   // 1: large, 2: x-large, 3: medium, 4: small - repeating.
   @for $i from 1 through 4 {
     &:nth-child(4n + #{$i}) .card {
       @if $i == 1 {
+        margin-top: $s-xl;
+
         @extend %card-variant--large;
       } @else if $i == 2 {
         @extend %card-variant--x-large;
       } @else if $i == 3 {
+        margin-top: $s-xl;
+
         @extend %card-variant--medium;
       } @else if $i == 4 {
         @extend %card-variant--small;

--- a/src/styles/scss/tools/variables.spacings.scss
+++ b/src/styles/scss/tools/variables.spacings.scss
@@ -27,5 +27,5 @@ $spacings: (
 $placeholder-paddings: (
   mobile: $s-lg,
   small: $s-xl,
-  medium: $s-3xl,
+  medium: $s-2xl,
 );

--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -325,7 +325,7 @@ $typo__card-placeholder: (
     ),
 );
 
-$typo__card-placeholder--small: (
+$typo__card-placeholder--medium: (
   mobile: (
     font-family: $font__title,
     font-style: normal,
@@ -336,5 +336,19 @@ $typo__card-placeholder--small: (
   #{$breakpoint__large-card}: (
       font-size: 28px,
       line-height: 32px,
+    ),
+);
+
+$typo__card-placeholder--grid: (
+  mobile: (
+    font-family: $font__title,
+    font-style: normal,
+    font-weight: $font__weight--normal,
+    font-size: 16px,
+    line-height: 20px,
+  ),
+  #{$breakpoint__large-card}: (
+      font-size: 20px,
+      line-height: 24px,
     ),
 );


### PR DESCRIPTION
Adjust card-grid max width, to avoid massive cards. DDFFORM-180

---

Fix cards sizing, and slider 'jumping' DDFFORM-182

- Make every second item in slider have margin-top, to pull it down, instead of based on no-image.
- Add missing mobile styling for tall (medium) cards.
- Add framing to XL card teasers with images
- Adjust the framing and padding on cards, to make them more sensible on smaller screens.