### PR TITLE
Taxonomy categories and tags

### DIFF
--- a/src/stories/Blocks/article/Article.stories.tsx
+++ b/src/stories/Blocks/article/Article.stories.tsx
@@ -23,6 +23,16 @@ export default {
     date: {
       defaultValue: "08. April 21",
     },
+    tags: {
+      defaultValue: [
+        "dans",
+        "contemporary",
+        "modern",
+        "scenekunst",
+        "digt",
+        "3-8 årige",
+      ],
+    },
   },
   parameters: {
     design: {

--- a/src/stories/Blocks/article/Article.stories.tsx
+++ b/src/stories/Blocks/article/Article.stories.tsx
@@ -14,6 +14,9 @@ export default {
       defaultValue:
         "Jesper Stein har begået en hudløst ærlig og tankevækkende skildring af en skilsmisseramt familie. En selvbiografisk roman, som har ramt læserne  i hjertet.",
     },
+    tag: {
+      defaultValue: "Netmedier",
+    },
     author: {
       defaultValue: "Lene Kuhlmann Frandsen",
     },

--- a/src/stories/Blocks/article/Article.stories.tsx
+++ b/src/stories/Blocks/article/Article.stories.tsx
@@ -14,7 +14,7 @@ export default {
       defaultValue:
         "Jesper Stein har begået en hudløst ærlig og tankevækkende skildring af en skilsmisseramt familie. En selvbiografisk roman, som har ramt læserne  i hjertet.",
     },
-    tag: {
+    category: {
       defaultValue: "Netmedier",
     },
     author: {

--- a/src/stories/Blocks/article/Article.tsx
+++ b/src/stories/Blocks/article/Article.tsx
@@ -1,14 +1,10 @@
 import { FC } from "react";
-import ArticleHeader from "../../Library/article-header/ArticleHeader";
+import ArticleHeader, {
+  ArticleHeaderProps,
+} from "../../Library/article-header/ArticleHeader";
 import { ArticleParagraphs } from "../../Library/paragraphs/Paragraphs";
 
-type ArticleProps = {
-  title: string;
-  subtitle: string;
-  category: string;
-  author: string;
-  date: string;
-};
+type ArticleProps = ArticleHeaderProps;
 
 const Article: FC<ArticleProps> = ({
   title,
@@ -16,6 +12,7 @@ const Article: FC<ArticleProps> = ({
   category,
   author,
   date,
+  tags,
 }) => {
   return (
     <article className="article">
@@ -25,6 +22,7 @@ const Article: FC<ArticleProps> = ({
         category={category}
         author={author}
         date={date}
+        tags={tags}
       />
       <ArticleParagraphs />
     </article>

--- a/src/stories/Blocks/article/Article.tsx
+++ b/src/stories/Blocks/article/Article.tsx
@@ -5,18 +5,24 @@ import { ArticleParagraphs } from "../../Library/paragraphs/Paragraphs";
 type ArticleProps = {
   title: string;
   subtitle: string;
-  tag: string;
+  category: string;
   author: string;
   date: string;
 };
 
-const Article: FC<ArticleProps> = ({ title, subtitle, tag, author, date }) => {
+const Article: FC<ArticleProps> = ({
+  title,
+  subtitle,
+  category,
+  author,
+  date,
+}) => {
   return (
     <article className="article">
       <ArticleHeader
         title={title}
         subtitle={subtitle}
-        tag={tag}
+        category={category}
         author={author}
         date={date}
       />

--- a/src/stories/Blocks/article/Article.tsx
+++ b/src/stories/Blocks/article/Article.tsx
@@ -5,16 +5,18 @@ import { ArticleParagraphs } from "../../Library/paragraphs/Paragraphs";
 type ArticleProps = {
   title: string;
   subtitle: string;
+  tag: string;
   author: string;
   date: string;
 };
 
-const Article: FC<ArticleProps> = ({ title, subtitle, author, date }) => {
+const Article: FC<ArticleProps> = ({ title, subtitle, tag, author, date }) => {
   return (
     <article className="article">
       <ArticleHeader
         title={title}
         subtitle={subtitle}
+        tag={tag}
         author={author}
         date={date}
       />

--- a/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
+++ b/src/stories/Library/Modals/modal-facet-browser/FacetBrowser.tsx
@@ -2,7 +2,7 @@ import Disclosure from "../../disclosure/Disclosure";
 import { Button } from "../../Buttons/button/Button";
 import Modal from "../Modal";
 import facetBrowserDummyData from "./facet-browser-dummy-data";
-import { Tag } from "../../tag/Tag";
+import { TagButton } from "../../tag/tag-button/TagButton";
 
 export type FacetBrowserProps = {
   title: string;
@@ -44,7 +44,7 @@ const FacetBrowser: React.FC<FacetBrowserProps> = ({
         >
           <div className="facet-browser__facet-group">
             {facet.tags.map((tag) => (
-              <Tag key={tag}>{tag}</Tag>
+              <TagButton key={tag}>{tag}</TagButton>
             ))}
           </div>
           <button className="link-tag cursor-pointer facet-browser__more-btn">

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -23,6 +23,7 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({
   tags,
 }) => {
   const tagData: HorizontalTermLineProps = {
+    headingLevel: "h2",
     title: "Tags",
     linkList: tags.map((tag) => {
       return { text: tag, url: "#" };

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -1,14 +1,17 @@
 import { FC } from "react";
-import RowButtons from "../Buttons/row-button/RowButtons";
 import ArrowLink from "../links/arrow-link/ArrowLink";
 import { Tag } from "../tag/Tag";
+import HorizontalTermLine, {
+  HorizontalTermLineProps,
+} from "../horizontal-term-line/HorizontalTermLine";
 
-type ArticleHeaderProps = {
+export type ArticleHeaderProps = {
   title: string;
   subtitle: string;
   category?: string;
   author: string;
   date: string;
+  tags: string[];
 };
 
 const ArticleHeader: FC<ArticleHeaderProps> = ({
@@ -17,7 +20,14 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({
   category,
   author,
   date,
+  tags,
 }) => {
+  const tagData: HorizontalTermLineProps = {
+    title: "Tags",
+    linkList: tags.map((tag) => {
+      return { text: tag, url: "#" };
+    }),
+  };
   return (
     <header className="article-header">
       <ArrowLink label="Go back" className="article-header__back-link" />
@@ -37,7 +47,9 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({
         </a>
         <time className="article-header__date">{date}</time>
       </p>
-      <RowButtons labels={["Netmedier", "Licenser", "This is hiddden"]} />
+      <div className="article-header__tags">
+        <HorizontalTermLine collapsible={false} {...tagData} />
+      </div>
     </header>
   );
 };

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -23,7 +23,9 @@ const ArticleHeader: FC<ArticleHeaderProps> = ({
       <ArrowLink label="Go back" className="article-header__back-link" />
       {tag && (
         <div className="article-header__tags">
-          <Tag hasBackground>{tag}</Tag>
+          <Tag size="large" hasBackground>
+            {tag}
+          </Tag>
         </div>
       )}
       <h1 className="article-header__title">{title}</h1>

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -1,10 +1,12 @@
 import { FC } from "react";
 import RowButtons from "../Buttons/row-button/RowButtons";
 import ArrowLink from "../links/arrow-link/ArrowLink";
+import { Tag } from "../tag/Tag";
 
 type ArticleHeaderProps = {
   title: string;
   subtitle: string;
+  tag?: string;
   author: string;
   date: string;
 };
@@ -12,12 +14,18 @@ type ArticleHeaderProps = {
 const ArticleHeader: FC<ArticleHeaderProps> = ({
   title,
   subtitle,
+  tag,
   author,
   date,
 }) => {
   return (
     <header className="article-header">
       <ArrowLink label="Go back" className="article-header__back-link" />
+      {tag && (
+        <div className="article-header__tags">
+          <Tag hasBackground>{tag}</Tag>
+        </div>
+      )}
       <h1 className="article-header__title">{title}</h1>
       <p className="article-header__subtitle">{subtitle}</p>
       <p className="article-header__info">

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -6,7 +6,7 @@ import { Tag } from "../tag/Tag";
 type ArticleHeaderProps = {
   title: string;
   subtitle: string;
-  tag?: string;
+  category?: string;
   author: string;
   date: string;
 };
@@ -14,17 +14,17 @@ type ArticleHeaderProps = {
 const ArticleHeader: FC<ArticleHeaderProps> = ({
   title,
   subtitle,
-  tag,
+  category,
   author,
   date,
 }) => {
   return (
     <header className="article-header">
       <ArrowLink label="Go back" className="article-header__back-link" />
-      {tag && (
-        <div className="article-header__tags">
+      {category && (
+        <div className="article-header__categories">
           <Tag size="large" hasBackground>
-            {tag}
+            {category}
           </Tag>
         </div>
       )}

--- a/src/stories/Library/card-list-page/FacetLine.tsx
+++ b/src/stories/Library/card-list-page/FacetLine.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Dropdown } from "../dropdown/Dropdown";
-import { Tag } from "../tag/Tag";
+import { TagButton } from "../tag/tag-button/TagButton";
 
 export type FacetLineItem<TType extends "facet" | "term"> = {
   title: string;
@@ -20,9 +20,9 @@ const FacetLine: FC<FacetLineProps> = ({ items }) => {
         if (type === "term") {
           return (
             <li key={index} className="facet-line__item">
-              <Tag isClickable={false}>
+              <TagButton isClickable={false}>
                 {title} ({score})
-              </Tag>
+              </TagButton>
             </li>
           );
         }
@@ -46,7 +46,7 @@ const FacetLine: FC<FacetLineProps> = ({ items }) => {
         return null;
       })}
       <li className="facet-line__item">
-        <Tag isClickable={false}>+ Flere filtre</Tag>
+        <TagButton isClickable={false}>+ Flere filtre</TagButton>
       </li>
     </ul>
   );

--- a/src/stories/Library/card-list-page/FacetLineSelectedTerms.tsx
+++ b/src/stories/Library/card-list-page/FacetLineSelectedTerms.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Tag } from "../tag/Tag";
+import { TagButton } from "../tag/tag-button/TagButton";
 import { FacetLineItem } from "./FacetLine";
 
 export interface FacetLineSelectedProps {
@@ -11,9 +11,9 @@ const FacetLineSelectedTerms: FC<FacetLineSelectedProps> = ({ items }) => {
     <ul className="facet-line-selected-terms">
       {items.map(({ title }) => (
         <li className="facet-line-selected-terms__item">
-          <Tag showCloseIcon hasBackground>
+          <TagButton showCloseIcon hasBackground>
             {title}
-          </Tag>
+          </TagButton>
         </li>
       ))}
     </ul>

--- a/src/stories/Library/event-description/EventDescription.tsx
+++ b/src/stories/Library/event-description/EventDescription.tsx
@@ -29,7 +29,11 @@ const EventDescription: FC<EventDescriptionProps> = ({
         </p>
         <div className="event-description__links">
           {horizontalTermLineData.map((item, index) => (
-            <HorizontalTermLine {...item} key={generateId(index)} />
+            <HorizontalTermLine
+              {...item}
+              collapsible={false}
+              key={generateId(index)}
+            />
           ))}
         </div>
       </div>

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { TagButton } from "../tag/tag-button/TagButton";
+import { Tag } from "../tag/Tag";
 import ImageCredited from "../image-credited/ImageCredited";
 
 type EventHeaderProps = {
@@ -13,7 +13,7 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
     <header className="event-header">
       <section className="event-header__content">
         <div className="event-header__tags">
-          <TagButton hasBackground>Udstilling</TagButton>
+          <Tag hasBackground>Udstilling</Tag>
         </div>
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Tag } from "../tag/Tag";
+import { TagButton } from "../tag/tag-button/TagButton";
 import ImageCredited from "../image-credited/ImageCredited";
 
 type EventHeaderProps = {
@@ -13,7 +13,7 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
     <header className="event-header">
       <section className="event-header__content">
         <div className="event-header__tags">
-          <Tag hasBackground>Udstilling</Tag>
+          <TagButton hasBackground>Udstilling</TagButton>
         </div>
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -13,7 +13,9 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
     <header className="event-header">
       <section className="event-header__content">
         <div className="event-header__tags">
-          <Tag hasBackground>Udstilling</Tag>
+          <Tag size="large" hasBackground>
+            Udstilling
+          </Tag>
         </div>
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>

--- a/src/stories/Library/event-list-item/EventListItem.tsx
+++ b/src/stories/Library/event-list-item/EventListItem.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
-import { TagButton } from "../tag/tag-button/TagButton";
+import { Tag } from "../tag/Tag";
 
 export type EventListItemProps = {
   image: string;
@@ -34,9 +34,9 @@ export const EventListItem: React.FC<EventListItemProps> = ({
         <img src={image} alt={title} className="event-list-item__image" />
       </div>
       <div className="event-list-item__content">
-        <TagButton hasBackground className="event-list-item__tag">
+        <Tag hasBackground className="event-list-item__tag">
           {tagText}
-        </TagButton>
+        </Tag>
         <div className="event-list-item__date">{date}</div>
         <h2 className="event-list-item__title">{title}</h2>
         <p className="event-list-item__description">{description}</p>

--- a/src/stories/Library/event-list-item/EventListItem.tsx
+++ b/src/stories/Library/event-list-item/EventListItem.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
-import { Tag } from "../tag/Tag";
+import { TagButton } from "../tag/tag-button/TagButton";
 
 export type EventListItemProps = {
   image: string;
@@ -34,9 +34,9 @@ export const EventListItem: React.FC<EventListItemProps> = ({
         <img src={image} alt={title} className="event-list-item__image" />
       </div>
       <div className="event-list-item__content">
-        <Tag hasBackground className="event-list-item__tag">
+        <TagButton hasBackground className="event-list-item__tag">
           {tagText}
-        </Tag>
+        </TagButton>
         <div className="event-list-item__date">{date}</div>
         <h2 className="event-list-item__title">{title}</h2>
         <p className="event-list-item__description">{description}</p>

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -10,6 +10,7 @@ export interface HorizontalTermLineProps {
   title: string;
   subTitle?: string;
   linkList: HorizontalTermLineList[];
+  collapsible?: boolean;
 }
 
 export function generateId(index: number | string) {
@@ -21,8 +22,9 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   title,
   subTitle,
   linkList,
+  collapsible = true,
 }) => {
-  const numberOfItemsToShow = 2;
+  const numberOfItemsToShow = collapsible ? 2 : linkList.length;
   const [showMore, setShowMore] = useState(false);
   const itemsToShow = showMore
     ? linkList
@@ -44,7 +46,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
         </span>
       ))}
 
-      {showMoreButton && (
+      {collapsible && showMoreButton && (
         <ButtonExpand showMore={showMore} setShowMore={setShowMore} />
       )}
     </div>

--- a/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/stories/Library/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import ButtonExpand from "../Buttons/button/button-expand/ButtonExpand";
+import Heading, { HeadingLevelType } from "../heading/Heading";
 
 export interface HorizontalTermLineList {
   url: string;
@@ -11,6 +12,7 @@ export interface HorizontalTermLineProps {
   subTitle?: string;
   linkList: HorizontalTermLineList[];
   collapsible?: boolean;
+  headingLevel?: HeadingLevelType;
 }
 
 export function generateId(index: number | string) {
@@ -23,6 +25,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   subTitle,
   linkList,
   collapsible = true,
+  headingLevel = "h3",
 }) => {
   const numberOfItemsToShow = collapsible ? 2 : linkList.length;
   const [showMore, setShowMore] = useState(false);
@@ -33,10 +36,10 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
 
   return (
     <div className="text-small-caption horizontal-term-line">
-      <h3 className="text-label-bold">
+      <Heading level={headingLevel} className="text-label-bold">
         {`${title}`}{" "}
         {subTitle && <span className="text-small-caption">{subTitle} </span>}
-      </h3>
+      </Heading>
 
       {itemsToShow.map((link, index) => (
         <span key={generateId(index)}>

--- a/src/stories/Library/tag/Tag.stories.tsx
+++ b/src/stories/Library/tag/Tag.stories.tsx
@@ -1,0 +1,42 @@
+import { ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+
+import { Tag as TagComp } from "./Tag";
+
+type TagProps = typeof TagComp;
+
+export default {
+  title: "Library / Tag / Tag",
+  component: TagComp,
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=836%3A5757",
+    },
+    layout: "centered",
+  },
+  argTypes: {
+    children: {
+      control: { type: "text" },
+      defaultValue: "Litteratur",
+    },
+    hasBackground: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+  },
+};
+
+export const Default: ComponentStory<TagProps> = ({ children, ...args }) => (
+  <TagComp {...args}>{children}</TagComp>
+);
+
+export const LargeWithBackground: ComponentStory<TagProps> = ({
+  children,
+  ...args
+}) => <TagComp {...args}>{children}</TagComp>;
+LargeWithBackground.args = {
+  size: "large",
+  hasBackground: true,
+};

--- a/src/stories/Library/tag/Tag.tsx
+++ b/src/stories/Library/tag/Tag.tsx
@@ -1,0 +1,30 @@
+import clsx from "clsx";
+
+type TagProps = {
+  children: React.ReactNode;
+  size?: "small" | "large";
+  hasBackground?: boolean;
+  className?: string;
+};
+
+export const Tag = ({
+  children,
+  size = "small",
+  hasBackground = false,
+  className,
+}: TagProps) => {
+  return (
+    <div
+      className={clsx(
+        "tag",
+        hasBackground && "tag--fill",
+        `tag--${size}`,
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Tag;

--- a/src/stories/Library/tag/tag-button/TagButton.stories.tsx
+++ b/src/stories/Library/tag/tag-button/TagButton.stories.tsx
@@ -1,12 +1,12 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 
-import { Tag as TagComp } from "./Tag";
+import { TagButton as TagComp } from "./TagButton";
 
 type TagProps = typeof TagComp;
 
 export default {
-  title: "Library / Tag",
+  title: "Library / Tag / Tag button",
   component: TagComp,
   decorators: [withDesign],
   parameters: {

--- a/src/stories/Library/tag/tag-button/TagButton.tsx
+++ b/src/stories/Library/tag/tag-button/TagButton.tsx
@@ -11,7 +11,7 @@ type TagProps = {
   className?: string;
 };
 
-export const Tag = ({
+export const TagButton = ({
   children,
   hasBackground = false,
   size = "small",
@@ -46,4 +46,4 @@ export const Tag = ({
   );
 };
 
-export default Tag;
+export default TagButton;

--- a/src/stories/Library/tag/tag-link/TagLink.stories.tsx
+++ b/src/stories/Library/tag/tag-link/TagLink.stories.tsx
@@ -1,0 +1,55 @@
+import { ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+
+import { TagLink as TagComp } from "./TagLink";
+
+type TagProps = typeof TagComp;
+
+export default {
+  title: "Library / Tag / Tag link",
+  component: TagComp,
+  decorators: [withDesign],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=836%3A5757",
+    },
+    layout: "centered",
+  },
+  argTypes: {
+    children: {
+      name: "text",
+      control: { type: "text" },
+      defaultValue: "Litteratur",
+    },
+    hasBackground: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+    showCloseIcon: {
+      control: { type: "boolean" },
+      defaultValue: false,
+    },
+  },
+};
+
+export const Default: ComponentStory<TagProps> = ({ children, ...args }) => (
+  <TagComp {...args}>{children}</TagComp>
+);
+
+export const LargeWithBackground: ComponentStory<TagProps> = ({
+  children,
+  ...args
+}) => <TagComp {...args}>{children}</TagComp>;
+LargeWithBackground.args = {
+  size: "large",
+  hasBackground: true,
+};
+
+export const Removable: ComponentStory<TagProps> = ({ children, ...args }) => (
+  <TagComp {...args}>{children}</TagComp>
+);
+Removable.args = {
+  showCloseIcon: true,
+  hasBackground: true,
+};

--- a/src/stories/Library/tag/tag-link/TagLink.tsx
+++ b/src/stories/Library/tag/tag-link/TagLink.tsx
@@ -1,0 +1,40 @@
+import clsx from "clsx";
+
+type TagProps = {
+  children: React.ReactNode;
+  size?: "small" | "large";
+  hasBackground?: boolean;
+  showCloseIcon?: boolean;
+  className?: string;
+};
+
+export const TagLink = ({
+  children,
+  size = "small",
+  hasBackground = false,
+  showCloseIcon = false,
+  className,
+}: TagProps) => {
+  return (
+    <a
+      href="#"
+      className={clsx(
+        "tag",
+        hasBackground && "tag--fill",
+        `tag--${size}`,
+        className
+      )}
+    >
+      {children}
+      {showCloseIcon && (
+        <img
+          className="tag-icon"
+          src="icons/basic/icon-cross.svg"
+          alt="close icon"
+        />
+      )}
+    </a>
+  );
+};
+
+export default TagLink;

--- a/src/stories/Library/tag/tag.scss
+++ b/src/stories/Library/tag/tag.scss
@@ -5,6 +5,7 @@
   border: 1px solid $color__global-tertiary-1;
   padding: $s-sm $s-md;
   @include typography($typo__tags);
+  text-decoration: none;
 
   &.tag--fill {
     background-color: $color__global-secondary;


### PR DESCRIPTION
#### Link to issue

[Please add a link to the issue being addressed by this change.
](https://reload.atlassian.net/browse/DDFFORM-130)

#### Description

This PR adds support for category and tags for events and articles.

A notable change is the rendering of categories. According to Figma they should use the large tag component on the full view of events and articles.

#### Screenshot of the result

Check out Chromatic.
