### PR TITLE
Fix/reservation list item skeletons

### DIFF
--- a/src/stories/Blocks/reservation-page/reservation-page-skeleton.scss
+++ b/src/stories/Blocks/reservation-page/reservation-page-skeleton.scss
@@ -1,6 +1,6 @@
 // Since we are using the Skeleton Screen Css classes connected to the existing styling
 // we deliberately not follow the BEM naming convention here.
-.reservation-list-page.ssc {
+.reservation-list-page {
   .ssc-square {
     height: 72px;
 

--- a/src/stories/Blocks/reservation-page/reservation-page-skeleton.scss
+++ b/src/stories/Blocks/reservation-page/reservation-page-skeleton.scss
@@ -12,12 +12,4 @@
   .ssc-circle {
     height: 90px;
   }
-
-  & .list-reservation__information {
-    min-width: 200px;
-
-    @include media-query__x-small("max-width") {
-      min-width: 100px;
-    }
-  }
 }

--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -84,6 +84,11 @@ $list-reservation-space-desktop: 24px;
   margin-left: $list-reservation-space-mobile;
   align-items: baseline;
   justify-content: space-between;
+  min-width: 200px;
+
+  @include media-query__x-small("max-width") {
+    min-width: 100px;
+  }
 
   @include media-query__small {
     margin-left: $list-reservation-space-desktop;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-397

#### Description
Adjust the class targeting for the reservation page skeleton screens. In order to pull the individual list items out of the skeleton in the React apps, we need to target them outside of the ssc skeleton class.

#### Screenshot of the result
-
#### Additional comments or questions
-
