### PR TITLE
Nav spots ('Fremhævet navigationskomponent') - DDFFORM-165

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -119,6 +119,8 @@
 @import "./src/stories/Library/nav-grid/nav-grid";
 @import "./src/stories/Library/hero/hero";
 @import "./src/stories/Library/tag/tag-list/tag-list";
+@import "./src/stories/Library/nav-spot/nav-spot";
+@import "./src/stories/Library/nav-spots/nav-spots";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Library/nav-spot/NavSpot.stories.tsx
+++ b/src/stories/Library/nav-spot/NavSpot.stories.tsx
@@ -1,0 +1,57 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import NavSpot from "./NavSpot";
+import ImageCredited from "../image-credited/ImageCredited";
+
+export default {
+  title: "Library / Nav-spot (Navigationsmodul)",
+  component: NavSpot,
+  decorators: [withDesign],
+  argTypes: {
+    variant: {
+      // Disabling controls, as the different variations are added already.
+      control: false,
+    },
+    title: {
+      defaultValue: "Bøger som har gjort en forskel for romanens udvikling",
+      type: "string",
+    },
+    subtitle: {
+      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
+      type: "string",
+    },
+    media: {
+      defaultValue: (
+        <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+      ),
+      type: "string",
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=1958-7664&mode=design&t=nK04fkaFk3f9pafj-4",
+    },
+  },
+} as ComponentMeta<typeof NavSpot>;
+
+const Template: ComponentStory<typeof NavSpot> = (args) => (
+  <NavSpot {...args} />
+);
+
+const Large = Template.bind({});
+Large.args = {
+  variant: "large",
+};
+
+const Medium = Template.bind({});
+Medium.args = {
+  variant: "medium",
+};
+
+const Small = Template.bind({});
+Small.args = {
+  variant: "small",
+};
+
+export { Large, Medium, Small };

--- a/src/stories/Library/nav-spot/NavSpot.tsx
+++ b/src/stories/Library/nav-spot/NavSpot.tsx
@@ -1,0 +1,31 @@
+import { FC, ReactNode } from "react";
+import { ReactComponent as Arrow } from "../Arrows/icon-arrow-ui/icon-arrow-ui-large-right.svg";
+
+type NavSpotProps = {
+  variant?: string;
+  title: string;
+  subtitle?: string;
+  media?: ReactNode;
+};
+
+const NavSpot: FC<NavSpotProps> = ({ variant, title, subtitle, media }) => {
+  return (
+    <article
+      className="nav-spot arrow__hover--right-large"
+      data-variant={variant}
+    >
+      <a href="#" className="nav-spot__content">
+        {media ? <figure className="nav-spot__media">{media}</figure> : ""}
+        <div className="nav-spot__text">
+          <h1 className="nav-spot__title">{title}</h1>
+
+          {subtitle ? <p className="nav-spot__subtitle">{subtitle}</p> : ""}
+
+          <Arrow />
+        </div>
+      </a>
+    </article>
+  );
+};
+
+export default NavSpot;

--- a/src/stories/Library/nav-spot/nav-spot.scss
+++ b/src/stories/Library/nav-spot/nav-spot.scss
@@ -1,0 +1,90 @@
+$_text-padding: $s-xl;
+
+%nav-spot--default {
+  @include typography($typo__body-large);
+
+  .nav-spot__text {
+    padding-top: $_text-padding;
+  }
+
+  .nav-spot__title {
+    @include typography($typo__h2);
+
+    margin-bottom: $s-md;
+  }
+
+  .nav-spot__subtitle {
+    margin-bottom: $s-md;
+  }
+
+  .nav-spot__content {
+    text-decoration: none;
+  }
+
+  .nav-spot__media {
+    aspect-ratio: 16/9;
+
+    * {
+      height: 100%;
+    }
+
+    img {
+      height: 100%;
+      width: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+  }
+
+  @include media-query__medium("max-width") {
+    .nav-spot__text {
+      padding-left: $_text-padding;
+      padding-right: $_text-padding;
+    }
+  }
+}
+
+.nav-spot {
+  @extend %nav-spot--default;
+}
+
+%nav-spot--large,
+.nav-spot[data-variant="large"] {
+  background-color: white;
+
+  .nav-spot__media {
+    margin-bottom: 0;
+  }
+
+  .nav-spot__text {
+    padding: $_text-padding;
+    flex-grow: 1;
+    align-self: center;
+  }
+
+  @include media-query__medium {
+    .nav-spot__content {
+      display: flex;
+    }
+
+    .nav-spot__media {
+      width: 60%;
+    }
+  }
+}
+
+%nav-spot--small,
+.nav-spot[data-variant="small"] {
+  .nav-spot__title {
+    @include typography($typo__h3);
+  }
+  .nav-spot__media {
+    aspect-ratio: 1/1;
+  }
+
+  @include media-query__medium("max-width") {
+    .nav-spot__text {
+      padding-left: 0;
+    }
+  }
+}

--- a/src/stories/Library/nav-spots/NavSpots.stories.tsx
+++ b/src/stories/Library/nav-spots/NavSpots.stories.tsx
@@ -1,0 +1,53 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import NavSpots from "./NavSpots";
+import NavSpot from "../nav-spot/NavSpot";
+import ImageCredited from "../image-credited/ImageCredited";
+
+const media = (
+  <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+);
+const teaser = (
+  <NavSpot
+    title="Digital læselyst"
+    subtitle="Find inspiration, tips og værktøjer til hvordan dit barn kommer videre med læsningen."
+    media={media}
+  />
+);
+
+export default {
+  title: "Library / Nav spots (Navigationsmodul)",
+  component: NavSpots,
+  decorators: [withDesign],
+  argTypes: {
+    items: {
+      // Disabling controls, as the different card variants are added already.
+      control: false,
+      defaultValue: [teaser, teaser],
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=1958-7664&mode=design&t=nK04fkaFk3f9pafj-4",
+    },
+  },
+} as ComponentMeta<typeof NavSpots>;
+
+const Template: ComponentStory<typeof NavSpots> = (args) => (
+  <NavSpots {...args} />
+);
+
+const Many = Template.bind({});
+
+Many.args = {
+  items: [teaser, teaser],
+};
+
+const Single = Template.bind({});
+
+Single.args = {
+  items: [teaser],
+};
+
+export { Many, Single };

--- a/src/stories/Library/nav-spots/NavSpots.tsx
+++ b/src/stories/Library/nav-spots/NavSpots.tsx
@@ -1,0 +1,20 @@
+import { FC, ReactNode } from "react";
+import clsx from "clsx";
+
+type NavSpotsProps = {
+  items: ReactNode[];
+};
+
+const NavSpots: FC<NavSpotsProps> = ({ items }) => {
+  return (
+    <div className={clsx("nav-spots", `nav-spots--count-${items.length}`)}>
+      <div className="nav-spots__items">
+        {items.map((item) => {
+          return <div className="nav-spots__item">{item}</div>;
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default NavSpots;

--- a/src/stories/Library/nav-spots/nav-spots.scss
+++ b/src/stories/Library/nav-spots/nav-spots.scss
@@ -1,0 +1,37 @@
+.nav-spots {
+  @include layout-container($block-max-width__large, 0);
+}
+
+.nav-spots--count-1 {
+  .nav-spot {
+    @extend %nav-spot--large;
+  }
+}
+
+.nav-spots--count-2 {
+  $_gap: $s-4xl;
+
+  .nav-spots__item + .nav-spots__item {
+    padding-top: $_gap;
+    padding-left: $_gap;
+    box-sizing: border-box;
+
+    .nav-spot {
+      @extend %nav-spot--small;
+    }
+  }
+
+  @include media-query__medium {
+    .nav-spots__items {
+      display: flex;
+    }
+
+    .nav-spots__item {
+      width: 60%;
+    }
+
+    .nav-spots__item + .nav-spots__item {
+      width: 40%;
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new type of teaser (`nav-spot`), along with a grid-like container (`nav-spots`).
This is more or less the same story, concept etc. as `card-grid`, `nav-grid` and probably others.
Depending on how many items are in `nav-spots`, the individual teasers will be shown in different variants - just like how we do with `card-grid`.

#### Link to issue

https://reload.atlassian.net/browse/DDFFORM-165

https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=1958-7664&mode=design&t=jxpPtsnK91BZqfNm-4


See it in action here:

https://616ffdab9acbf5003ad5fd2b-knpbqbfhfh.chromatic.com/?path=/story/library-nav-spots-navigationsmodul--many

https://616ffdab9acbf5003ad5fd2b-knpbqbfhfh.chromatic.com/?path=/story/library-nav-spots-navigationsmodul--single