### PR TITLE
Update faulty line-height, to not have broken double-lines.

### DIFF
--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -130,9 +130,6 @@ $typo__body-large: (
     font-style: normal,
     font-weight: $font__weight--normal,
     font-size: 16px,
-    line-height: 42px,
-  ),
-  small: (
     line-height: 160%,
   ),
   medium: (


### PR DESCRIPTION
42px appears to be some kind of typo - either way, a line-height of 42px when using 16px font-size is extreme and makes no sense. Let's use the 160% that is already being used for `small` instead.
