### PR TITLE
Fix tag categories

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -118,7 +118,7 @@
 @import "./src/stories/Library/nav-teaser/nav-teaser";
 @import "./src/stories/Library/nav-grid/nav-grid";
 @import "./src/stories/Library/hero/hero";
-@import "./src/stories/Library/tag/tag-categories/tag-categories";
+@import "./src/stories/Library/tag/tag-list/tag-list";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Blocks/page/page.scss
+++ b/src/stories/Blocks/page/page.scss
@@ -29,16 +29,15 @@
       padding-top: $s-3xl;
     }
 
-    // Add paddig on childs except .hero-cta
-    > * {
-      padding: 0 $s-3xl;
-      @include media-query__small {
-        padding: 0;
-      }
-    }
+    // Add margin to all child elements on small screens except .hero-cta
+    > *:not(.hero-cta) {
+      margin-left: $s-3xl;
+      margin-right: $s-3xl;
 
-    > .hero-cta {
-      padding: 0;
+      @include media-query__small {
+        margin-left: 0;
+        margin-right: 0;
+      }
     }
   }
 

--- a/src/stories/Library/article-header/ArticleHeader.tsx
+++ b/src/stories/Library/article-header/ArticleHeader.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import ArrowLink from "../links/arrow-link/ArrowLink";
-import { Tag } from "../tag/Tag";
+import Tag from "../tag/Tag";
 import HorizontalTermLine, {
   HorizontalTermLineProps,
 } from "../horizontal-term-line/HorizontalTermLine";

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import TagCategories from "../tag/tag-categories/TagCategories";
+import TagList from "../tag/tag-list/TagList";
 import ImageCredited from "../image-credited/ImageCredited";
 
 type EventHeaderProps = {
@@ -12,7 +12,7 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
   return (
     <header className="event-header">
       <section className="hero-content">
-        <TagCategories tags={["design & teknologi"]} />
+        <TagList tags={["design & teknologi"]} />
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>
         <a href="/" className="btn-primary btn-filled btn-large hero-cta">

--- a/src/stories/Library/event-header/EventHeader.tsx
+++ b/src/stories/Library/event-header/EventHeader.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import TagList from "../tag/tag-list/TagList";
+import Tag from "../tag/Tag";
 import ImageCredited from "../image-credited/ImageCredited";
 
 type EventHeaderProps = {
@@ -12,7 +12,9 @@ const EventHeader: FC<EventHeaderProps> = ({ title, date, image }) => {
   return (
     <header className="event-header">
       <section className="hero-content">
-        <TagList tags={["design & teknologi"]} />
+        <Tag hasBackground size="large" className="event-tag">
+          design & teknologi
+        </Tag>
         <time className="event-header__date">{date}</time>
         <h1 className="event-header__title">{title}</h1>
         <a href="/" className="btn-primary btn-filled btn-large hero-cta">

--- a/src/stories/Library/event-header/event-header.scss
+++ b/src/stories/Library/event-header/event-header.scss
@@ -2,6 +2,13 @@
   @extend %hero-2-column;
 }
 
+.event-tag {
+  margin-bottom: $s-md;
+  @include media-query__small {
+    margin-bottom: $s-lg;
+  }
+}
+
 .event-header__date {
   @include typography($typo__h4);
 

--- a/src/stories/Library/event-list-item/EventListItem.tsx
+++ b/src/stories/Library/event-list-item/EventListItem.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
-import { Tag } from "../tag/Tag";
+import Tag from "../tag/Tag";
 
 export type EventListItemProps = {
   image: string;

--- a/src/stories/Library/hero/Hero.tsx
+++ b/src/stories/Library/hero/Hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ImageCredited from "../image-credited/ImageCredited";
-import TagCategories from "../tag/tag-categories/TagCategories";
+import TagList from "../tag/tag-list/TagList";
 import { ReactComponent as ArrowLargeRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-large-right.svg";
 
 export type HeroProps = {
@@ -21,7 +21,7 @@ const Hero: React.FunctionComponent<HeroProps> = ({
   return (
     <section className="hero">
       <a href="/" className="hero-content arrow arrow__hover--right-large">
-        <TagCategories tags={["Arrangement"]} />
+        <TagList tags={["Arrangement"]} />
         <div className="hero__details">
           {contentType && (
             <>

--- a/src/stories/Library/hero/Hero.tsx
+++ b/src/stories/Library/hero/Hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ImageCredited from "../image-credited/ImageCredited";
-import TagList from "../tag/tag-list/TagList";
+import Tag from "../tag/Tag";
 import { ReactComponent as ArrowLargeRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-large-right.svg";
 
 export type HeroProps = {
@@ -21,7 +21,9 @@ const Hero: React.FunctionComponent<HeroProps> = ({
   return (
     <section className="hero">
       <a href="/" className="hero-content arrow arrow__hover--right-large">
-        <TagList tags={["Arrangement"]} />
+        <Tag hasBackground size="large" className="hero-tag">
+          Arrangement
+        </Tag>
         <div className="hero__details">
           {contentType && (
             <>

--- a/src/stories/Library/hero/hero.scss
+++ b/src/stories/Library/hero/hero.scss
@@ -2,6 +2,13 @@
   @extend %hero-2-column;
 }
 
+.hero-tag {
+  margin-bottom: $s-md;
+  @include media-query__small {
+    margin-bottom: $s-lg;
+  }
+}
+
 .hero__details {
   @include typography($typo__h5);
   display: flex;

--- a/src/stories/Library/tag/Tag.stories.tsx
+++ b/src/stories/Library/tag/Tag.stories.tsx
@@ -1,13 +1,11 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 
-import { Tag as TagComp } from "./Tag";
-
-type TagProps = typeof TagComp;
+import Tag, { TagProps } from "./Tag";
 
 export default {
   title: "Library / Tag / Tag",
-  component: TagComp,
+  component: Tag,
   decorators: [withDesign],
   parameters: {
     design: {
@@ -28,14 +26,23 @@ export default {
   },
 };
 
-export const Default: ComponentStory<TagProps> = ({ children, ...args }) => (
-  <TagComp {...args}>{children}</TagComp>
+const Template: ComponentStory<typeof Tag> = (args: TagProps) => (
+  <Tag {...args} />
 );
+export const Default = Template.bind({});
+Default.args = {};
 
-export const LargeWithBackground: ComponentStory<TagProps> = ({
-  children,
-  ...args
-}) => <TagComp {...args}>{children}</TagComp>;
+export const Large = Template.bind({});
+Large.args = {
+  size: "large",
+};
+
+export const WithBackground = Template.bind({});
+WithBackground.args = {
+  hasBackground: true,
+};
+
+export const LargeWithBackground = Template.bind({});
 LargeWithBackground.args = {
   size: "large",
   hasBackground: true,

--- a/src/stories/Library/tag/Tag.tsx
+++ b/src/stories/Library/tag/Tag.tsx
@@ -1,13 +1,13 @@
 import clsx from "clsx";
 
-type TagProps = {
+export type TagProps = {
   children: React.ReactNode;
   size?: "small" | "large";
   hasBackground?: boolean;
   className?: string;
 };
 
-export const Tag = ({
+const Tag = ({
   children,
   size = "small",
   hasBackground = false,

--- a/src/stories/Library/tag/tag-list/TagList.stories.tsx
+++ b/src/stories/Library/tag/tag-list/TagList.stories.tsx
@@ -1,10 +1,10 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
-import TagCategories from "./TagCategories";
+import TagList from "./TagList";
 
 export default {
-  title: "Library / Tag Categories",
-  component: TagCategories,
+  title: "Library / Tag List",
+  component: TagList,
   decorators: [withDesign],
   parameters: {
     design: {
@@ -19,10 +19,10 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof TagCategories>;
+} as ComponentMeta<typeof TagList>;
 
-const Template: ComponentStory<typeof TagCategories> = (args) => (
-  <TagCategories {...args} />
+const Template: ComponentStory<typeof TagList> = (args) => (
+  <TagList {...args} />
 );
 
 export const Default = Template.bind({});

--- a/src/stories/Library/tag/tag-list/TagList.tsx
+++ b/src/stories/Library/tag/tag-list/TagList.tsx
@@ -1,11 +1,11 @@
 import { FC, useEffect } from "react";
 import { Tag } from "../Tag";
 
-type TagCategoriesProps = {
+type TagListProps = {
   tags: string[];
 };
 
-const TagCategories: FC<TagCategoriesProps> = ({ tags }) => {
+const TagList: FC<TagListProps> = ({ tags }) => {
   useEffect(() => {
     require("../../../utils/show-more");
   }, []);
@@ -17,7 +17,7 @@ const TagCategories: FC<TagCategoriesProps> = ({ tags }) => {
   return (
     <>
       {tags.length > 1 && (
-        <div data-show-more-list className="tag-categories">
+        <div data-show-more-list className="tag-list">
           <ul>
             {tags.map((tag, index) => (
               <li data-show-more-item>
@@ -37,7 +37,7 @@ const TagCategories: FC<TagCategoriesProps> = ({ tags }) => {
         </div>
       )}
       {tags.length === 1 && (
-        <div className="tag-categories">
+        <div className="tag-list">
           <Tag hasBackground size="large">
             {tags[0]}
           </Tag>
@@ -47,4 +47,4 @@ const TagCategories: FC<TagCategoriesProps> = ({ tags }) => {
   );
 };
 
-export default TagCategories;
+export default TagList;

--- a/src/stories/Library/tag/tag-list/TagList.tsx
+++ b/src/stories/Library/tag/tag-list/TagList.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { Tag } from "../Tag";
+import Tag from "../Tag";
 
 type TagListProps = {
   tags: string[];

--- a/src/stories/Library/tag/tag-list/tag-list.scss
+++ b/src/stories/Library/tag/tag-list/tag-list.scss
@@ -2,10 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-bottom: $s-md;
-  @include media-query__small {
-    margin-bottom: $s-lg;
-  }
 
   ul,
   ol {

--- a/src/stories/Library/tag/tag-list/tag-list.scss
+++ b/src/stories/Library/tag/tag-list/tag-list.scss
@@ -1,4 +1,4 @@
-.tag-categories {
+.tag-list {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;


### PR DESCRIPTION
#### Depend on:
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/733

#### Description

This PR accomplishes two things: 
- Rename `TagCategories` to `TagList`. 
- Replaces `TagList` with `Tag` in instances where `TagList` is not necessary.