### PR TITLE
Setup 'categories' exposed filter on event search page. DDFFORM-184

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -121,6 +121,7 @@
 @import "./src/stories/Library/tag/tag-list/tag-list";
 @import "./src/stories/Library/nav-spot/nav-spot";
 @import "./src/stories/Library/nav-spots/nav-spots";
+@import "./src/stories/Library/input-label/input-label";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Blocks/event-list-page/EventListPage.tsx
+++ b/src/stories/Blocks/event-list-page/EventListPage.tsx
@@ -1,11 +1,30 @@
 import React from "react";
 import EventList from "../../Library/event-list/EventList";
 import eventListData from "../../Library/event-list/EventListData";
+import { InputLabel } from "../../Library/input-label/InputLabel";
+import { Dropdown } from "../../Library/dropdown/Dropdown";
+
+const list = [
+  {
+    title: "Bob Dylan 80 år",
+    href: "/",
+  },
+  {
+    title: "5 Nordiske fuldtræffere",
+    href: "/",
+  },
+];
 
 const EventListPage: React.FC = () => {
   return (
     <div className="event-list-page">
       <h1 className="event-list-page__heading">Arrangementer</h1>
+      <div className="event-list-page__filters">
+        <div className="event-list-page__filter">
+          <InputLabel text="Kategorier" />
+          <Dropdown list={list} ariaLabel="Kategorier" arrowIcon="chevron" />
+        </div>
+      </div>
       <EventList events={eventListData} />
     </div>
   );

--- a/src/stories/Blocks/event-list-page/event-list-page.scss
+++ b/src/stories/Blocks/event-list-page/event-list-page.scss
@@ -7,3 +7,11 @@
   @include layout-container($block-max-width__large);
   @include typography($typo__h2);
 }
+
+.event-list-page__filters {
+  @include layout-container($block-max-width__large);
+
+  display: flex;
+  margin-top: $s-lg;
+  margin-bottom: $s-lg;
+}

--- a/src/stories/Library/dropdown/dropdown.scss
+++ b/src/stories/Library/dropdown/dropdown.scss
@@ -1,3 +1,5 @@
+$_dropdown-icon-size: 50px;
+
 .dropdown {
   width: 100%;
   position: relative;
@@ -17,18 +19,22 @@
 }
 
 .dropdown__select {
+  $_padding: 20px;
+
   appearance: none;
   -webkit-appearance: none;
   min-width: 230px;
   width: 100%;
-  height: 50px;
+  height: $_dropdown-icon-size;
   cursor: pointer;
   background-color: transparent;
   color: $color__global-black;
   border-radius: 0;
   border: 1px solid;
   border-color: inherit;
-  padding: 0 50px 0 20px;
+  padding: 0;
+  padding-left: $_padding;
+  padding-right: $_dropdown-icon-size + $_padding;
   text-overflow: ellipsis;
   white-space: nowrap;
 
@@ -51,8 +57,8 @@
   position: absolute;
   right: 0;
   top: 0;
-  height: 50px;
-  width: 50px;
+  height: $_dropdown-icon-size;
+  width: $_dropdown-icon-size;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/stories/Library/event-list-item/event-list-item.scss
+++ b/src/stories/Library/event-list-item/event-list-item.scss
@@ -33,6 +33,7 @@ $_event-list-item--image-width: 222px;
 }
 
 .event-list-item__image {
+  width: 100%;
   height: 100%;
   object-fit: cover;
   position: relative;

--- a/src/stories/Library/input-label/InputLabel.stories.tsx
+++ b/src/stories/Library/input-label/InputLabel.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentStory } from "@storybook/react";
+
+import { InputLabel as InputLabelComp } from "./InputLabel";
+
+type DropdownProps = typeof InputLabelComp;
+
+export default {
+  title: "Library / Input label",
+  component: InputLabelComp,
+  argTypes: {
+    text: {
+      defaultValue: "Her er en label",
+    },
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+const Template: ComponentStory<DropdownProps> = (args) => (
+  <InputLabelComp {...args} />
+);
+
+export const InputLabel = Template.bind({});

--- a/src/stories/Library/input-label/InputLabel.tsx
+++ b/src/stories/Library/input-label/InputLabel.tsx
@@ -1,0 +1,7 @@
+export type InputLabelProps = {
+  text: string;
+};
+
+export const InputLabel: React.FC<InputLabelProps> = ({ text }) => {
+  return <label className="input-label">{text}</label>;
+};

--- a/src/stories/Library/input-label/input-label.scss
+++ b/src/stories/Library/input-label/input-label.scss
@@ -1,0 +1,7 @@
+.input-label {
+  @include typography($typo__small-caption);
+  width: 100%;
+  height: $s-lg;
+  margin-bottom: $s-sm;
+  padding-top: $s-xs;
+}


### PR DESCRIPTION
A few minor updates, displaying the dropdown on the event-list-page element.

Also introduces a few small fixes, such as padding on the dropdown.

Easiest to review commit by commit.

See it here:

https://616ffdab9acbf5003ad5fd2b-fakpuatovd.chromatic.com/?path=/story/blocks-event-list-page--default