### PR TITLE
Group modal card skeletons

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -112,6 +112,7 @@
 @import "./src/stories/Library/card-grid/card-grid";
 @import "./src/stories/Library/promo-title/promo-title";
 @import "./src/stories/Library/Modals/group-modal-item-skeleton";
+@import "./src/stories/Library/Lists/list-dashboard/list-dashboard-skeleton";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/base.scss
+++ b/base.scss
@@ -111,6 +111,7 @@
 @import "./src/stories/Library/video-embed/video-embed";
 @import "./src/stories/Library/card-grid/card-grid";
 @import "./src/stories/Library/promo-title/promo-title";
+@import "./src/stories/Library/Modals/group-modal-item-skeleton";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Library/Lists/list-dashboard/ListDashboard.stories.tsx
+++ b/src/stories/Library/Lists/list-dashboard/ListDashboard.stories.tsx
@@ -34,6 +34,10 @@ export default {
       control: "string",
       defaultValue: "/",
     },
+    isSkeleton: {
+      control: "boolean",
+      defaultValue: false,
+    },
   },
   parameters: {
     design: {
@@ -50,3 +54,8 @@ const Template: ComponentStory<typeof ListDashboard> = (args) => (
 );
 
 export const DashboardList = Template.bind({});
+
+export const SkeletonScreen = Template.bind({});
+SkeletonScreen.args = {
+  isSkeleton: true,
+};

--- a/src/stories/Library/Lists/list-dashboard/ListDashboard.tsx
+++ b/src/stories/Library/Lists/list-dashboard/ListDashboard.tsx
@@ -1,6 +1,7 @@
 import { StatusLabel, StatusLabelProps } from "../../status-label/StatusLabel";
 import { Number, NumberProps } from "../../number/Number";
 import { ReactComponent as ArrowSmallRight } from "../../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
+import ListDashboardItemSkeleton from "./ListDashboardItemSkeleton";
 
 export type ListDashboardProps = {
   title: string;
@@ -8,6 +9,7 @@ export type ListDashboardProps = {
   number: NumberProps;
   label: StatusLabelProps;
   showDot: boolean;
+  isSkeleton?: boolean;
 };
 
 export const ListDashboard: React.FC<ListDashboardProps> = ({
@@ -16,7 +18,12 @@ export const ListDashboard: React.FC<ListDashboardProps> = ({
   number,
   label,
   showDot,
+  isSkeleton,
 }) => {
+  if (isSkeleton) {
+    return <ListDashboardItemSkeleton />;
+  }
+
   return (
     <a
       href={href}

--- a/src/stories/Library/Lists/list-dashboard/ListDashboardItemSkeleton.tsx
+++ b/src/stories/Library/Lists/list-dashboard/ListDashboardItemSkeleton.tsx
@@ -1,0 +1,10 @@
+const ListDashboardItemSkeleton: React.FC = () => {
+  return (
+    <div className="list-dashboard ssc">
+      <div className="ssc-circle" />
+      <div className="ssc-head-line w-40" />
+    </div>
+  );
+};
+
+export default ListDashboardItemSkeleton;

--- a/src/stories/Library/Lists/list-dashboard/list-dashboard-skeleton.scss
+++ b/src/stories/Library/Lists/list-dashboard/list-dashboard-skeleton.scss
@@ -1,0 +1,20 @@
+// We don't have any of these dimensions in variables, but we want to preserve
+// the skeleton components' dimensions the same as the actual components.
+.list-dashboard.ssc {
+  height: 72px;
+
+  @include media-query__small {
+    height: 88px;
+  }
+
+  & .ssc-circle {
+    width: 40px;
+    height: 40px;
+    margin-right: 24px;
+
+    @include media-query__small {
+      width: 56px;
+      height: 56px;
+    }
+  }
+}

--- a/src/stories/Library/Modals/GroupModalItemSkeleton.tsx
+++ b/src/stories/Library/Modals/GroupModalItemSkeleton.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import { Checkbox } from "../Forms/checkbox/Checkbox";
+
+export type GroupModalItemSkeletonProps = {
+  withLeftOutset?: boolean;
+};
+
+const GroupModalItemSkeleton: FC<GroupModalItemSkeletonProps> = ({
+  withLeftOutset = false,
+}) => {
+  return (
+    <li className="ssc">
+      <div className="list-materials list-materials--disabled">
+        {withLeftOutset && (
+          <div className="list-materials__checkbox mr-32">
+            <Checkbox isChecked={false} hiddenLabel label="Select" />
+          </div>
+        )}
+        <div className="list-materials__content">
+          <div className="list-materials__content-status">
+            <div className="ssc-head-line status-label w-10" />
+          </div>
+          <div className="ssc-head-line status-label w-60 mt-8" />
+          <div className="ssc-head-line status-label w-50" />
+          <div className="ssc-line w-30" />
+        </div>
+        <div className="list-materials__status">
+          <div>
+            <div className="ssc-head-line status-label w-100 mt-8" />
+            <div className="ssc-line w-100" />
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default GroupModalItemSkeleton;

--- a/src/stories/Library/Modals/group-modal-item-skeleton.scss
+++ b/src/stories/Library/Modals/group-modal-item-skeleton.scss
@@ -1,0 +1,7 @@
+.list-materials {
+  &__status {
+    & .ssc-head-line {
+      min-width: 143px;
+    }
+  }
+}

--- a/src/stories/Library/Modals/modal-loan/ModalLoan.stories.tsx
+++ b/src/stories/Library/Modals/modal-loan/ModalLoan.stories.tsx
@@ -19,6 +19,16 @@ const Template: ComponentStory<typeof ModalLoan> = (args) => (
   <ModalLoan {...args} />
 );
 
+export const ModalLoanLoading = Template.bind({});
+ModalLoanLoading.args = {
+  title: "Afleveres 12. oktober 2021",
+  description: "Kan afleveres på alle Rudersdals biblioteker",
+  showExpired: true,
+  showModal: true,
+  buttonsUpTop: true,
+  isLoadingItems: true,
+};
+
 export const ModalLoanExpired = Template.bind({});
 ModalLoanExpired.args = {
   title: "Afleveres 12. oktober 2021",

--- a/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
+++ b/src/stories/Library/Modals/modal-loan/ModalLoan.tsx
@@ -9,6 +9,7 @@ import {
 import { WarningStatus } from "../../warning-status/WarningStatus";
 import Modal from "../Modal";
 import ResultPager from "../../card-list-page/ResultPager";
+import GroupModalItemSkeleton from "../GroupModalItemSkeleton";
 
 type LoanMaterials = Array<{
   materialType?: string;
@@ -96,6 +97,7 @@ export type ModalLoanProps = {
   showModal: boolean;
   showExpired: boolean;
   buttonsUpTop: boolean;
+  isLoadingItems?: boolean;
 };
 
 export const ModalLoan: React.FC<ModalLoanProps> = ({
@@ -104,6 +106,7 @@ export const ModalLoan: React.FC<ModalLoanProps> = ({
   showExpired,
   showModal,
   buttonsUpTop,
+  isLoadingItems = false,
 }) => {
   const [isAllChecked, setChecked] = useState(false);
   const isExpired = showExpired;
@@ -163,17 +166,23 @@ export const ModalLoan: React.FC<ModalLoanProps> = ({
             </div>
           )}
           <ul className="modal-loan__list-materials">
-            {loanList.map(({ list }) => (
+            {isLoadingItems &&
+              [0, 1].map(() => <GroupModalItemSkeleton withLeftOutset />)}
+            {!isLoadingItems && (
               <>
-                {list.map((listItem, index) => (
-                  <ListMaterials
-                    key={`${index}-${isAllChecked}`}
-                    {...listItem}
-                    isChecked={listItem.isChecked}
-                  />
+                {loanList.map(({ list }) => (
+                  <>
+                    {list.map((listItem, index) => (
+                      <ListMaterials
+                        key={`${index}-${isAllChecked}`}
+                        {...listItem}
+                        isChecked={listItem.isChecked}
+                      />
+                    ))}
+                  </>
                 ))}
               </>
-            ))}
+            )}
           </ul>
           <ResultPager
             currentResults={1}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-427

#### Description
This PR introduces group modal item skeletons with styling and a brand new story.
As a last minute decision, I added dashboard list item skeletons too - to be used on the dashboard and in the user menu.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/540419a8-76e9-4104-88bc-ebf568d21c63)

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/a729c747-3a62-498a-85d4-e9791c692b42)

#### Additional comments or questions
-

