### PR TITLE
DDFLSBP-153 - Removed 100% width on modal-loan to make the modal cent…

### DIFF
--- a/src/stories/Library/Modals/modal-loan/modal-loan.scss
+++ b/src/stories/Library/Modals/modal-loan/modal-loan.scss
@@ -1,7 +1,6 @@
 .modal-loan {
   flex-direction: column;
   align-items: center;
-  width: 100%;
 }
 
 .modal-loan__container {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-153

#### Description

This PR centers the blocked user modal like the rest of the modals by removing width: 100% from the modal.

#### Screenshot of the result

<img width="1916" alt="Screenshot 2024-02-07 at 15 54 34" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/6142323/19d13ee1-1833-4090-a995-3f15977de8cb">


