### PR TITLE
DDFLSBP-446 - Removed width: 100% on modal-pause__container to preven…

### DIFF
--- a/src/stories/Library/Modals/modal-pause/modal-pause.scss
+++ b/src/stories/Library/Modals/modal-pause/modal-pause.scss
@@ -21,7 +21,6 @@
   margin: 0 $s-lg;
   padding-top: 96px;
   max-width: 550px;
-  width: 100%;
 
   @include media-query__small {
     margin: 0 45px;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-446

#### Description

This PR removes the horizontal scrollbar on pause modal screens smaller than 1270px

#### Screenshot of the result

<img width="1549" alt="Screenshot 2024-02-08 at 09 56 21" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/6142323/76520492-9afc-4a2a-ad18-d16f5e76587c">

