### PR TITLE
Refactor header, to automatically enable burger-menu when needed.

### DIFF
--- a/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
+++ b/src/stories/Blocks/autosuggest/Autosuggest.stories.tsx
@@ -25,42 +25,12 @@ export default {
 const Template: ComponentStory<typeof Autosuggest> = (
   args: AutosuggestProps
 ) => (
-  // Apart from <Autosuggest />, everything else is here just for the story
-  // context. The autosuggest styling is directly dependent on the header component,
-  // Please keep up to date with Header.tsx
-  <header className="header" style={{ height: "144px" }}>
-    <div className="header__logo-desktop">
-      <p className="text-body-medium-regular">Context</p>
-    </div>
-    <div className="header__menu">
-      <nav className="header__menu-first">
-        <p className="text-body-medium-regular">Context</p>
-      </nav>
-      <div className="header__menu-second">
-        <div className="header__menu-search">
-          <input
-            className="header__menu-search-input text-body-medium-regular"
-            type="text"
-            placeholder="This field is here just for context."
-          />
-          <img
-            className="header__menu-search-icon"
-            src="icons/basic/icon-search.svg"
-            alt="search icon"
-          />
-          <img
-            className="header__menu-dropdown-icon"
-            src="icons/collection/ExpandMore.svg"
-            alt="expand dropdown icon"
-          />
-          <Autosuggest {...args} />
-        </div>
-      </div>
-    </div>
-    <div className="header__clock">
-      <p className="text-body-medium-regular">Context</p>
-    </div>
-  </header>
+  // Inline styling should be avoided, but this is not really a part of the
+  // component - rather, a fix, to make sure the autosuggests look correct,
+  // even when they're not in the menu structure.
+  <div className="this-is-just-for-storybook" style={{ position: "relative" }}>
+    <Autosuggest {...args} />
+  </div>
 );
 
 export const Default = Template.bind({});

--- a/src/stories/Blocks/header/Header.tsx
+++ b/src/stories/Blocks/header/Header.tsx
@@ -27,10 +27,6 @@ const list = [
     title: "Litteratur",
     href: "/",
   },
-  {
-    title: "Børn & forældre",
-    href: "/",
-  },
 ];
 
 export const Header = (props: HeaderProps) => {
@@ -46,6 +42,7 @@ export const Header = (props: HeaderProps) => {
   useEffect(() => {
     require("./header-toggle");
     require("./header-sticky");
+    require("./header-state");
   }, []);
 
   return (
@@ -93,7 +90,7 @@ export const Header = (props: HeaderProps) => {
                   <li className="header__menu-navigation-item">
                     <a
                       href={i.href}
-                      className="header__menu-navigation-link text-body-medium-regular hide-linkstyle"
+                      className="header__menu-navigation-link  hide-linkstyle"
                     >
                       {i.title}
                     </a>

--- a/src/stories/Blocks/header/header-state.js
+++ b/src/stories/Blocks/header/header-state.js
@@ -1,0 +1,46 @@
+// Function for checking the size of the desktop links container.
+function desktopLinksContainerCheckSize() {
+  const container = document.querySelector(".header__menu-navigation");
+
+  // By default, assume we are using the burger menu.
+  document.documentElement.classList.add("has-burger-menu");
+  document.documentElement.classList.remove("has-desktop-menu");
+
+  // The reserved width is for the logo and service buttons.
+  const reservedWidth = 250 + 70 + 70 + 105;
+  // Calculate available space subtracting the reserved width from the total inner window width.
+  const availableSpace = window.innerWidth - reservedWidth;
+
+  // If the width of the menu container is greater than the available space,
+  // we keep the burger menu. Otherwise, we swap to the desktop menu format.
+  if (container.scrollWidth > availableSpace) {
+    document.documentElement.classList.add("has-burger-menu");
+    document.documentElement.classList.remove("has-desktop-menu");
+  } else {
+    document.documentElement.classList.remove("has-burger-menu");
+    document.documentElement.classList.add("has-desktop-menu");
+  }
+}
+
+// Function for initializing the header state based on window size and container width.
+function initHeaderState() {
+  // Finds the node with class 'header__menu-navigation' which is not initialized.
+  const desktopLinks = document.querySelector(
+    ".header__menu-navigation:not(.is-header-initialized)"
+  );
+
+  // If the desktop links exist, check their size
+  // and add a resize event listener to check the size whenever the window is resized.
+  if (desktopLinks) {
+    desktopLinksContainerCheckSize(desktopLinks);
+
+    window.addEventListener("resize", desktopLinksContainerCheckSize, true);
+    document.addEventListener("load", desktopLinksContainerCheckSize, true);
+
+    // Mark the links as initialized
+    desktopLinks.classList.add("is-header-initialized");
+  }
+}
+
+// Call the initHeaderState function to execute all the above operations.
+initHeaderState();

--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -2,29 +2,17 @@
   border: 1px solid $color__global-tertiary-1;
   width: 100%;
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 250px 1fr 105px;
   background-color: $color__global-primary;
   position: sticky;
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 500ms;
   z-index: $z-20;
-
-  @include media-query__small {
-    grid-template-columns: 1fr 105px;
-  }
-
-  @include media-query__medium {
-    grid-template-columns: 250px 1fr 105px;
-  }
 }
 
 .header__logo-desktop {
-  display: none;
   border-right: 1px solid $color__global-tertiary-1;
-  @include media-query__medium {
-    display: block;
-  }
 }
 
 .header__logo-desktop-link {
@@ -54,26 +42,19 @@
 }
 
 .header__menu-navigation {
-  display: none;
-
-  @include media-query__medium {
-    display: flex;
-    padding: 0 12px;
-    height: 100%;
-  }
+  display: inline-flex;
+  padding: 0 12px;
+  height: 100%;
+  white-space: nowrap;
 }
 
 .header__menu-navigation-mobile {
-  display: flex;
+  display: none;
 
   @include media-query__small {
     .pagefold-triangle-small {
       display: none;
     }
-  }
-
-  @include media-query__medium {
-    display: none;
   }
 }
 
@@ -90,6 +71,8 @@
 }
 
 .header__menu-navigation-link {
+  @include typography($typo__desktop-menu-item);
+
   padding: 0 12px;
   height: 100%;
   display: flex;
@@ -262,10 +245,6 @@
   width: 100vw;
   height: 100vh;
   grid-template-columns: 384px 1fr;
-
-  @include media-query__small {
-    grid-template-columns: 384px 1fr;
-  }
 }
 
 .header__overlay-main {
@@ -291,4 +270,33 @@
   /* stylelint-disable-line */
   position: fixed;
   padding: 30px;
+}
+
+// has-burger-menu is added dynamically using JS, by calculating if there
+// is enough space to show the desktop menu, and otherwise enabling the
+// burger menu. @see header-state.js
+.has-burger-menu {
+  .header {
+    grid-template-columns: 1fr;
+
+    @include media-query__small {
+      grid-template-columns: 1fr 105px;
+    }
+  }
+
+  .header__menu-navigation {
+    position: absolute;
+    top: -999px;
+
+    // This is important, to avoid screen readers seeing double links.
+    visibility: hidden;
+  }
+
+  .header__logo-desktop {
+    display: none;
+  }
+
+  .header__menu-navigation-mobile {
+    display: flex;
+  }
 }

--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -161,6 +161,17 @@ $typo__body-placeholder: (
   ),
 );
 
+$typo__desktop-menu-item: (
+  mobile: (
+    font-family: $font__body,
+    font-style: normal,
+    font-weight: $font__weight--normal,
+    line-height: 32px,
+    color: $color__text-secondary-gray,
+    font-size: 18px,
+  ),
+);
+
 // "Body Copy - M - medium"
 $typo__body-medium: (
   mobile: (


### PR DESCRIPTION
`.has-burger-menu` is added dynamically using JS, by calculating if there is enough space to show the desktop menu, and otherwise enabling the burger menu.
This required some re-factoring of the header menu system, as I need to measure the width of the desktop menu at all times. So, instead of display: none, we're just hiding it visually.

DDFFORM-220
