### PR TITLE
Fix empty list box text alignment

### DIFF
--- a/src/stories/Library/Lists/list-empty/ListEmpty.tsx
+++ b/src/stories/Library/Lists/list-empty/ListEmpty.tsx
@@ -8,8 +8,8 @@ interface ListEmptyProps {
 
 const ListEmpty = ({ text, links, className }: ListEmptyProps) => {
   return (
-    <div className={`dpl-list-empty ${className}`}>
-      {text}
+    <div className={`dpl-list-empty ${className ?? ""}`}>
+      <p>{text}</p>
       {links && (
         <div className="dpl-list-empty__links">
           {links.map((item, index) => (

--- a/src/stories/Library/Lists/list-empty/list-empty.scss
+++ b/src/stories/Library/Lists/list-empty/list-empty.scss
@@ -6,7 +6,7 @@
   justify-content: center;
   align-items: center;
   border: 1px dotted $color__global-grey;
-  text-align: left;
+  text-align: center;
   color: $color__text-secondary-gray;
   padding: 48px $s-xs;
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-248

#### Description
This PR introduces minor changes to alignment of the "your list is empty" box. The inner text is now centered for a tidier feel.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/30070622-b916-499b-a3b8-847174ae8f89)

#### Additional comments or questions
-

