### PR TITLE
Refactor `Footer`, `FooterColumn`, `Logo` and `Accordion` stories

### DIFF
--- a/src/stories/Blocks/footer/Footer.stories.tsx
+++ b/src/stories/Blocks/footer/Footer.stories.tsx
@@ -1,11 +1,10 @@
 import { withDesign } from "storybook-addon-designs";
 import { Meta } from "@storybook/react";
-
-import { Footer as FooterComp } from "./Footer";
+import Footer from "./Footer";
 
 export default {
   title: "Blocks / Footer",
-  component: FooterComp,
+  component: Footer,
   decorators: [withDesign],
   parameters: {
     design: {
@@ -15,4 +14,4 @@ export default {
   },
 } as Meta;
 
-export const Footer = () => <FooterComp />;
+export const Default = () => <Footer />;

--- a/src/stories/Blocks/footer/Footer.tsx
+++ b/src/stories/Blocks/footer/Footer.tsx
@@ -1,9 +1,9 @@
 import Pagefold from "../../Library/pagefold/Pagefold";
-import { Accordion } from "../../Library/accordion/Accordion";
+import Accordion from "../../Library/accordion/Accordion";
 import { Dropdown } from "../../Library/dropdown/Dropdown";
-import { Logo } from "../../Library/logo/Logo";
+import Logo from "../../Library/logo/Logo";
 import { Links } from "../../Library/links/Links";
-import { FooterColumn } from "./FooterColumn";
+import FooterColumn from "./FooterColumn";
 import list from "../../Library/accordion/accordionList";
 
 const dropdownList = [
@@ -21,7 +21,7 @@ const dropdownList = [
   },
 ];
 
-export const Footer = () => {
+const Footer = () => {
   return (
     <footer className="footer">
       <h2 className="hide-visually">Globale links</h2>

--- a/src/stories/Blocks/footer/FooterColumn.tsx
+++ b/src/stories/Blocks/footer/FooterColumn.tsx
@@ -5,7 +5,7 @@ type FooterColumnProps = {
   links: string[];
 };
 
-export const FooterColumn = ({ title, links }: FooterColumnProps) => {
+const FooterColumn = ({ title, links }: FooterColumnProps) => {
   return (
     <div className="footer-column">
       <h3 className="text-header-h4">{title}</h3>

--- a/src/stories/Blocks/header/Header.tsx
+++ b/src/stories/Blocks/header/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Logo } from "../../Library/logo/Logo";
+import Logo from "../../Library/logo/Logo";
 import Pagefold from "../../Library/pagefold/Pagefold";
 
 export type HeaderProps = {

--- a/src/stories/Library/accordion/Accordion.stories.tsx
+++ b/src/stories/Library/accordion/Accordion.stories.tsx
@@ -1,14 +1,11 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
-
-import { Accordion as AccordionComp } from "./Accordion";
+import Accordion, { AccordionProps } from "./Accordion";
 import list from "./accordionList";
-
-type AccordionProps = typeof AccordionComp;
 
 export default {
   title: "Library / Accordion",
-  component: AccordionComp,
+  component: Accordion,
   decorators: [withDesign],
   parameters: {
     design: {
@@ -24,8 +21,8 @@ export default {
   },
 };
 
-const Template: ComponentStory<AccordionProps> = (args) => (
-  <AccordionComp {...args} />
+const Template: ComponentStory<typeof Accordion> = (args: AccordionProps) => (
+  <Accordion {...args} />
 );
 
-export const Accordion = Template.bind({});
+export const Default = Template.bind({});

--- a/src/stories/Library/accordion/Accordion.tsx
+++ b/src/stories/Library/accordion/Accordion.tsx
@@ -7,11 +7,12 @@ type AccordionRow = {
     href: string;
   }>;
 };
-type AccordionProps = {
+
+export type AccordionProps = {
   list: AccordionRow[];
 };
 
-export const Accordion: React.FC<AccordionProps> = ({ list }) => {
+const Accordion: React.FC<AccordionProps> = ({ list }) => {
   useEffect(() => {
     /* eslint-disable-next-line global-require */
     require("./initaccordion");
@@ -55,4 +56,4 @@ declare global {
   }
 }
 
-export default {};
+export default Accordion;

--- a/src/stories/Library/logo/Logo.stories.tsx
+++ b/src/stories/Library/logo/Logo.stories.tsx
@@ -1,12 +1,10 @@
 import { ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
-import { Logo as LogoComp } from "./Logo";
-
-type LogoProps = typeof LogoComp;
+import Logo, { LogoProps } from "./Logo";
 
 export default {
   title: "Library / Logo",
-  component: LogoComp,
+  component: Logo,
   decorators: [withDesign],
   argTypes: {
     libraryName: {
@@ -25,10 +23,12 @@ export default {
   },
 };
 
-const Template: ComponentStory<LogoProps> = (args) => <LogoComp {...args} />;
+const Template: ComponentStory<typeof Logo> = (args: LogoProps) => (
+  <Logo {...args} />
+);
 
-export const Logo = Template.bind({});
-Logo.args = {
+export const Default = Template.bind({});
+Default.args = {
   fallback: false,
   altText: "logo",
 };

--- a/src/stories/Library/logo/Logo.tsx
+++ b/src/stories/Library/logo/Logo.tsx
@@ -1,13 +1,13 @@
 import "../../../styles/css/base.css";
 import logo from "./logo.png";
 
-type LogoProps = {
+export type LogoProps = {
   fallback: boolean;
   libraryName: string;
   altText: string;
 };
 
-export const Logo = (props: LogoProps) => {
+const Logo = (props: LogoProps) => {
   const { fallback, libraryName, altText } = props;
 
   return fallback ? (


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-223

#### Description

I have refactored the footer stories to align with our standard approach for creating stories. This will result in Chromatic treating them as new stories. As I have another branch where I am performing extensive cleanup and component separation within the footer, it is crucial for this to be merged first. This will allow Chromatic to assist me in the subsequent branch.