### PR TITLE
Add larger mobile bottom padding to modals on mobile devices

### DIFF
--- a/src/stories/Library/Modals/modal-details/modal-details.scss
+++ b/src/stories/Library/Modals/modal-details/modal-details.scss
@@ -13,7 +13,7 @@ $MODAL_DETAILS_CONTAINER_WIDTH: 1000px;
 .modal-details__container {
   width: 100%;
   max-width: 100%;
-  padding-bottom: $s-2xl;
+  padding-bottom: $s-4xl;
 
   @include media-query__small {
     margin: 0;

--- a/src/stories/Library/Modals/modal-login/modal-login.scss
+++ b/src/stories/Library/Modals/modal-login/modal-login.scss
@@ -17,6 +17,11 @@
   &__container {
     justify-content: flex-start;
     width: 100%;
+    padding-bottom: $s-4xl;
+
+    @include media-query__small {
+      padding-bottom: 0px;
+    }
   }
 
   &__btn-create-profile {


### PR DESCRIPTION

#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-415

#### Description
This PR adds larger mobile bottom padding to modals on mobile devices in order for the URL bar on iOS not to hide the action button(s) located in the bottom of some modals.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/7e02f6a6-3474-4e7c-aa8e-5108bc0b6cbd)

#### Additional comments or questions
-
