### PR TITLE
Don't capitalize all words in the counter label text, only first letter

### DIFF
--- a/src/stories/Library/counter/counter.scss
+++ b/src/stories/Library/counter/counter.scss
@@ -29,7 +29,10 @@
   font-weight: 500;
   line-height: 19px;
   text-align: center;
-  text-transform: capitalize;
+
+  &::first-letter {
+    text-transform: uppercase;
+  }
 }
 
 .counter__icon {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-409

#### Description
We now only capitalize the first letter of the counter label text, as opposed to every word.

#### Screenshot of the result
-

#### Additional comments or questions
-

