### PR TITLE
Remove unnecessary SVG transform in event-list-item.scss

### DIFF
--- a/src/stories/Library/event-list-item/event-list-item.scss
+++ b/src/stories/Library/event-list-item/event-list-item.scss
@@ -266,8 +266,4 @@ $_stacked-reduce-width: 20px;
   .event-list-item-stacked__time {
     justify-self: start;
   }
-
-  .event-list-item-stacked > svg {
-    transform: translateX(-#{calc($_stacked-reduce-width / 2)});
-  }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-297

#### Description

There is enough space to keep the hover arrow in the same grid.