### PR TITLE
DDFFORM 174 update font size small caption

### DIFF
--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -263,14 +263,13 @@ $typo__small-caption: (
     font-family: $font__body,
     font-style: normal,
     font-weight: $font__weight--normal,
-    font-size: 10px,
+    font-size: 12px,
     line-height: 16px,
   ),
   small: (
     line-height: 160%,
   ),
   medium: (
-    font-size: 12px,
     line-height: 120%,
   ),
 );


### PR DESCRIPTION
- Changing the font-size for `small text caption` because it is too small too meet accessbility for the places it is used.


#### Link to issue

[Jira link](https://reload.atlassian.net/jira/software/c/projects/DDFFORM/boards/485?assignee=557058%3A9a3dd056-14db-4baf-917f-d89c6c42dceb&selectedIssue=DDFFORM-174)

#### Description

This superseded #476. Description is copied from that PR. 

This PR changes the base font-size of 'Small text caption" from 10px to 12px. 

The font is used across the system, but it is too small for optimal readability. 

I've left the chromatic changes unaccepted on purpose, so that the review can look through them and see what they think. 


#### Screenshot of the result

See chromatic tests. 

