### PR TITLE
DDFFORM 356 adjust list materials modal

### DIFF
--- a/src/stories/Library/Lists/list-materials/ListMaterials.tsx
+++ b/src/stories/Library/Lists/list-materials/ListMaterials.tsx
@@ -43,22 +43,22 @@ export const ListMaterials: FC<ListMaterialsProps> = ({
               <StatusLabel {...statusMaterialType} />
             </div>
             <p className="list-materials__content__header mt-8">{title}</p>
-            <p className="text-small-caption">
+            <p className="text-small-caption mt-8">
               {author} ({year})
             </p>
           </div>
           <div className="list-materials__status">
             {statusMessage && (
-              <span className="list-materials__status__note-desktop">
+              <span className="list-materials__status__note-desktop mt-8">
                 {statusMessage}
               </span>
             )}
             <div>
-              <div className="status-label status-label--neutral">
+              <div className="list-materials__status-label status-label status-label--neutral">
                 Afleveres 27-04-2023
               </div>
               {statusMessage && (
-                <span className="list-materials__status__note-mobile">
+                <span className="list-materials__status__note-mobile mt-8">
                   {statusMessage}
                 </span>
               )}
@@ -88,13 +88,13 @@ export const ListMaterials: FC<ListMaterialsProps> = ({
               <div className="status-label status-label--outline">Bog</div>
             </div>
             <p className="list-materials__content__header mt-8">{title}</p>
-            <p className="text-small-caption">
+            <p className="text-small-caption mt-8">
               {author} ({year})
             </p>
           </div>
           <div className="list-materials__status">
             <div>
-              <div className="status-label status-label--neutral">
+              <div className="list-materials__status-label status-label status-label--neutral">
                 Afleveres 27-04-2023
               </div>
               <button

--- a/src/stories/Library/Lists/list-materials/list-materials.scss
+++ b/src/stories/Library/Lists/list-materials/list-materials.scss
@@ -3,11 +3,16 @@
   @include show-svg-on-hover(".list-materials__arrow");
   @include show-svg-on-hover(".arrow-button");
 
-  display: flex;
   min-height: 96px;
   padding: $s-md;
   background-color: $color__global-white;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-template-areas:
+    "checkbox content"
+    "checkbox status-content";
+  align-items: center;
+  position: relative;
   cursor: pointer;
 
   &:hover {
@@ -18,6 +23,7 @@
     padding: $s-md 32px;
     align-items: center;
     flex-direction: row;
+    display: flex;
   }
 
   &--bottom-buttons-visible {
@@ -34,12 +40,13 @@
 }
 
 .list-materials__checkbox {
-  display: flex;
-  align-items: center;
+  grid-area: checkbox;
 }
-
 .list-materials__content {
-  flex: 1;
+  grid-area: content;
+  @include media-query__small {
+    flex: 1;
+  }
 }
 
 .list-materials__content__header {
@@ -61,11 +68,20 @@
 }
 
 .list-materials__status {
-  display: flex;
-  flex-direction: row;
-  margin-top: 0;
-  align-items: center;
-  grid-gap: $s-md;
+  grid-area: status-content;
+
+  @include media-query__small {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: unset;
+    align-items: flex-end;
+  }
+}
+.list-materials__status-label {
+  position: absolute;
+  top: $s-md;
+  right: $s-md;
 }
 
 .list-materials__status__note-desktop {


### PR DESCRIPTION
- Start form sprint 8
- Make "EventListPage" more generic, to use it for non-events. DDFFORM-326
- Make sure that event-list-item object-fit always works.
- Refactor / Generalize event-item-* components, to be re-usable.
- Update src/stories/Blocks/content-list-page/ContentListPage.stories.tsx
- Add 'hidden' title for `ContentListItemStacked`
- Rename container classes in `ContentListItem`
- Refactor `ContentList` rendering logic
- Relocate `isStacked` logic as `ContentListItem` has been made generic
- Use clsx
- wip

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

