### PR TITLE
Fixing availability-labels texts color on iOS 15 (or later) [DDFLSBP-475]

### DIFF
--- a/src/stories/Library/availability-label/availability-label.scss
+++ b/src/stories/Library/availability-label/availability-label.scss
@@ -1,4 +1,5 @@
 .availability-label {
+  color: $color__global-grey;
   position: relative;
   display: inline-flex;
   flex-direction: row;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-475

#### Description

Setting a specific color for availability-labels texts that would otherwise adopt the default iOS 15 (or later) blue color.

#### Screenshot of the result

Before:

![Simulator Screenshot - iPhone 15 - 2024-03-04 at 15 22 44](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/da047d1b-c809-42f9-b08e-c4db41d397ab)

After:

![Simulator Screenshot - iPhone 15 - 2024-03-04 at 15 22 54](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/cee54970-9740-4802-83a6-4bdb2c86b28e)

#### Additional comments or questions

*
