### PR TITLE
Remove link style from `content-list-item__location`

### DIFF
--- a/src/stories/Library/content-list-item/content-list-item.scss
+++ b/src/stories/Library/content-list-item/content-list-item.scss
@@ -134,7 +134,6 @@ $_stacked-reduce-width: 20px;
 }
 
 .content-list-item__location {
-  @extend %link-tag;
   @include typography($typo__small-caption);
 }
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-405

#### Description
This pull request removes the `link-tag` styling from `content-list-item__location` as they are not used as links.
