### PR TITLE
Refactor media placeholder, making it a seperate component. DDFFORM-360

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -6,6 +6,7 @@
 @import "./src/styles/scss/legacy";
 
 // Library
+@import "./src/stories/Library/media-container/media-container";
 @import "./src/stories/Library/links/links";
 @import "./src/stories/Library/link-filters/link-filters";
 @import "./src/stories/Library/Arrows/arrows";

--- a/src/stories/Blocks/event-page/EventPage.stories.tsx
+++ b/src/stories/Blocks/event-page/EventPage.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import Event from "./EventPage";
+import ImageCredited from "../../Library/image-credited/ImageCredited";
 
 export default {
   title: "Blocks / Event page",
@@ -16,8 +17,12 @@ export default {
       type: "string",
     },
     image: {
-      defaultValue:
-        "https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080",
+      defaultValue: (
+        <ImageCredited src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080" />
+      ),
+    },
+    placeholderText: {
+      defaultValue: "Noget spændende tekst",
       type: "string",
     },
     descriptionDescription: {

--- a/src/stories/Blocks/event-page/EventPage.stories.tsx
+++ b/src/stories/Blocks/event-page/EventPage.stories.tsx
@@ -18,7 +18,11 @@ export default {
     },
     image: {
       defaultValue: (
-        <ImageCredited src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080" />
+        <ImageCredited
+          description="Photo by Smith on Unsplash"
+          year="©2021"
+          src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080"
+        />
       ),
     },
     placeholderText: {

--- a/src/stories/Blocks/event-page/EventPage.tsx
+++ b/src/stories/Blocks/event-page/EventPage.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 import Hero from "../../Library/Heros/hero/Hero";
 import EventDescription, {
   EventDescriptionProps,
@@ -8,12 +8,14 @@ import { EventParagraphs } from "../../Library/paragraphs/Paragraphs";
 type EventPageProps = {
   title: string;
   date: string;
-  image: string;
+  placeholderText?: string;
+  image?: ReactNode;
 } & EventDescriptionProps;
 
 const EventPage: FC<EventPageProps> = ({
   title,
   date,
+  placeholderText,
   image,
   descriptionDescription,
   horizontalTermLineData,
@@ -25,6 +27,7 @@ const EventPage: FC<EventPageProps> = ({
         title={title}
         date={date}
         image={image}
+        placeholderText={placeholderText}
         cta="Køb billet"
         tag="Arrangement"
       />

--- a/src/stories/Blocks/page/Page.stories.tsx
+++ b/src/stories/Blocks/page/Page.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import Page from "./Page";
+import ImageCredited from "../../Library/image-credited/ImageCredited";
 
 export default {
   title: "Blocks / Pages",
@@ -25,6 +26,7 @@ const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 export const frontPage = Template.bind({});
 frontPage.args = {
   hero: {
+    placeholderText: "Forsiden har intet billede",
     contentType: "Arrangement",
     date: "06 Dec 2022",
     title: "Stine Pilgaard vinder De Gyldne Laurbær",
@@ -36,8 +38,13 @@ frontPage.args = {
 export const branchPage = Template.bind({});
 branchPage.args = {
   hero: {
-    image:
-      "https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080",
+    image: (
+      <ImageCredited
+        src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080"
+        description="Photo by Unsplash"
+        year="©2021"
+      />
+    ),
     contentType: "Fillial",
     title: "Søborg",
     description:

--- a/src/stories/Blocks/page/Page.tsx
+++ b/src/stories/Blocks/page/Page.tsx
@@ -14,6 +14,7 @@ const Page: FC<PageProps> = ({ hero }) => {
           <Paragraph modifier="hero">
             <Hero
               image={hero.image}
+              placeholderText={hero.placeholderText}
               contentType={hero.contentType}
               date={hero.date}
               title={hero.title}

--- a/src/stories/Library/Heros/hero-link/HeroLink.stories.tsx
+++ b/src/stories/Library/Heros/hero-link/HeroLink.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import HeroLink from "./HeroLink";
+import ImageCredited from "../../image-credited/ImageCredited";
 
 export default {
   title: "Library / Hero with link",
@@ -19,10 +20,17 @@ export default {
       control: { type: "text" },
     },
     image: {
-      name: "Image",
-      defaultValue:
-        "https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080",
-      control: { type: "text" },
+      defaultValue: (
+        <ImageCredited
+          src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080"
+          description="Photo by Unsplash"
+          year="©2021"
+        />
+      ),
+    },
+    placeholderText: {
+      defaultValue: "En spændende tekst",
+      type: "string",
     },
     contentType: {
       name: "Type",

--- a/src/stories/Library/Heros/hero-link/HeroLink.tsx
+++ b/src/stories/Library/Heros/hero-link/HeroLink.tsx
@@ -11,6 +11,7 @@ export type HeroLinkProps = {
 const HeroLink: React.FunctionComponent<HeroLinkProps> = ({
   url,
   image,
+  placeholderText,
   contentType,
   date,
   title,
@@ -34,7 +35,7 @@ const HeroLink: React.FunctionComponent<HeroLinkProps> = ({
         />
       </a>
 
-      <HeroVisual image={image} />
+      <HeroVisual image={image} placeholderText={placeholderText} />
     </section>
   );
 };

--- a/src/stories/Library/Heros/hero/Hero.stories.tsx
+++ b/src/stories/Library/Heros/hero/Hero.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import Hero from "./Hero";
+import ImageCredited from "../../image-credited/ImageCredited";
 
 export default {
   title: "Library / Hero",
@@ -14,10 +15,18 @@ export default {
   },
   argTypes: {
     image: {
-      name: "Image",
-      defaultValue:
-        "https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080",
-      control: { type: "text" },
+      defaultValue: (
+        <ImageCredited
+          src="https://images.unsplash.com/photo-1531058020387-3be344556be6?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8ZXZlbnR8fHx8fHwxNzAyOTEwMzE0&ixlib=rb-4.0.3&q=8
+0&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080"
+          description="Photo by Unsplash"
+          year="©2021"
+        />
+      ),
+    },
+    placeholderText: {
+      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
+      type: "string",
     },
     contentType: {
       name: "Type",

--- a/src/stories/Library/Heros/hero/Hero.tsx
+++ b/src/stories/Library/Heros/hero/Hero.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import clsx from "clsx";
 import HeroInner, { HeroInnerProps } from "./HeroInner";
 import HeroVisual from "./HeroVisual";
 
 export type HeroProps = {
-  image?: string;
+  image?: ReactNode;
+  placeholderText?: string;
 } & HeroInnerProps;
 
 const HeroLink: React.FunctionComponent<HeroProps> = ({
   image,
+  placeholderText,
   contentType,
   date,
   title,
@@ -35,7 +37,7 @@ const HeroLink: React.FunctionComponent<HeroProps> = ({
         />
       </div>
 
-      <HeroVisual image={image} />
+      <HeroVisual image={image} placeholderText={placeholderText} />
     </section>
   );
 };

--- a/src/stories/Library/Heros/hero/HeroVisual.tsx
+++ b/src/stories/Library/Heros/hero/HeroVisual.tsx
@@ -1,21 +1,19 @@
-import React from "react";
-import ImageCredited from "../../image-credited/ImageCredited";
+import React, { ReactNode } from "react";
+import MediaContainer from "../../media-container/MediaContainer";
 
 export type HeroInnerProps = {
-  image?: string;
+  image?: ReactNode;
+  placeholderText?: string;
 };
 
-const HeroVisual: React.FunctionComponent<HeroInnerProps> = ({ image }) => {
+const HeroVisual: React.FunctionComponent<HeroInnerProps> = ({
+  image,
+  placeholderText,
+}) => {
   return (
     <div className="hero__visual">
       <div className="hero__visual-inner">
-        {image && (
-          <ImageCredited
-            src={image}
-            description="Photo by Unsplash"
-            year="©2021"
-          />
-        )}
+        <MediaContainer placeholderText={placeholderText} media={image} />
       </div>
     </div>
   );

--- a/src/stories/Library/Heros/hero/hero.scss
+++ b/src/stories/Library/Heros/hero/hero.scss
@@ -23,8 +23,8 @@ $_hero-column-breakpoint: "small";
 }
 
 .hero__visual-inner {
-  height: 100%;
   width: 100%;
+  aspect-ratio: 5/4;
 }
 
 .hero {

--- a/src/stories/Library/Heros/hero/hero.scss
+++ b/src/stories/Library/Heros/hero/hero.scss
@@ -1,5 +1,13 @@
 $_hero-column-breakpoint: "small";
 
+// On mobile, it makes no sense to show the placeholder text,
+// as it just serves the purpose to fill out the hero on desktop.
+@include media-query__name($_hero-column-breakpoint, "max-width") {
+  .hero--has-no-media .hero__visual {
+    display: none;
+  }
+}
+
 .hero__content,
 .hero__visual {
   @include media-query__name($_hero-column-breakpoint) {
@@ -35,14 +43,6 @@ $_hero-column-breakpoint: "small";
   // if hero-content is a link, remove text-decoration for all children
   > a {
     text-decoration: none;
-  }
-}
-
-@include media-query__name($_hero-column-breakpoint) {
-  .hero.hero--has-no-media {
-    .hero__visual-inner {
-      @include identity-placeholder;
-    }
   }
 }
 

--- a/src/stories/Library/card-grid/card-grid.scss
+++ b/src/stories/Library/card-grid/card-grid.scss
@@ -5,10 +5,7 @@ $_card-grid-gap: $s-lg;
 
 .card-grid {
   @include layout-container();
-
-  .card__placeholder-text {
-    @include typography($typo__card-placeholder--grid);
-  }
+  @include media-container--grid;
 }
 
 .card-grid--full-width {
@@ -129,9 +126,7 @@ $_card-grid-gap: $s-lg;
         // there, there is plenty of space.
         @if ($name == "small") {
           @include media-query__small {
-            .card__placeholder-text {
-              font-size: 0;
-            }
+            @include media-container--small;
           }
         }
       }

--- a/src/stories/Library/card/Card.stories.tsx
+++ b/src/stories/Library/card/Card.stories.tsx
@@ -24,10 +24,6 @@ export default {
       defaultValue: "Bøger som har gjort en forskel for romanens udvikling",
       type: "string",
     },
-    placeholderText: {
-      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
-      type: "string",
-    },
     href: {
       defaultValue: "https://google.com",
       type: "string",
@@ -36,7 +32,9 @@ export default {
       defaultValue: (
         <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
       ),
-
+    },
+    placeholderText: {
+      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
       type: "string",
     },
   },

--- a/src/stories/Library/card/Card.tsx
+++ b/src/stories/Library/card/Card.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from "react";
 import clsx from "clsx";
+import MediaContainer from "../media-container/MediaContainer";
 
 type CardProps = {
   variant?: string;
@@ -19,18 +20,16 @@ const Card: FC<CardProps> = ({
   dateTag,
 }) => {
   const classes = clsx("card", {
-    "card--has-no-image": !image,
-    "card--has-image": image,
+    "card--has-no-media": !image,
+    "card--has-media": !!image,
   });
 
   return (
     <article className={classes} data-variant={variant}>
       <a href="https://google.com">
-        <figure className="card__media">
-          {image || (
-            <div className="card__placeholder-text">{placeholderText}</div>
-          )}
-        </figure>
+        <div className="card__media">
+          <MediaContainer placeholderText={placeholderText} media={image} />
+        </div>
         <div className="card__tags">
           {typeTag ? (
             <span className="card__tag card__tag--type">{typeTag}</span>

--- a/src/stories/Library/card/card.scss
+++ b/src/stories/Library/card/card.scss
@@ -4,23 +4,6 @@
   margin-bottom: $s-sm;
 }
 
-.card--has-no-image {
-  .card__media {
-    @extend %identity-placeholder;
-  }
-}
-
-.card__placeholder-text {
-  @extend %identity-placeholder-text;
-}
-
-.card--has-image {
-  // This is necessary to get object-fit to work.
-  * {
-    height: 100%;
-  }
-}
-
 .card__tags {
   display: flex;
   margin-bottom: $s-sm;
@@ -96,24 +79,27 @@
 
 %card-variant--x-large,
 .card[data-variant="x-large"] {
+  @include media-container--card;
+
   width: 200px;
 
   @include media-query__name($breakpoint__large-card) {
     width: 440px;
   }
 
-  &.card--has-no-image {
+  &.card--has-no-media {
     // We only want the page fold on 1:1 view-modes.
     @extend %identity-pagefold;
   }
 
-  .card__placeholder-text {
-    @include typography($typo__card-placeholder);
+  &.card--has-media {
+    .card__media {
+      @extend %identity-placeholder;
+    }
   }
 
+  // stylelint-disable-next-line no-descending-specificity -- Stylelint wants us to re-order the file, but it actually would make it less readable.
   .card__media {
-    @extend %identity-placeholder;
-
     aspect-ratio: 1/1;
   }
 }
@@ -122,21 +108,21 @@
 .card[data-variant="small"] {
   width: 206px;
 
+  // stylelint-disable-next-line no-descending-specificity -- Stylelint wants us to re-order the file, but it actually would make it less readable.
   .card__media {
     aspect-ratio: 1/1;
   }
 
-  .card__tags,
-  .card__media {
+  // stylelint-disable-next-line no-descending-specificity -- Stylelint wants us to re-order the file, but it actually would make it less readable.
+  .card__media,
+  .card__tags {
     margin-bottom: $s-xs;
   }
 
   // On desktop sizes this small, there is no space for placeholder text, and
   // extra tags, but we can still show it for screenreaders.
   @include media-query__name($breakpoint__large-card) {
-    .card__placeholder-text {
-      font-size: 0;
-    }
+    @include media-container--small;
 
     .card__tag {
       @include typography($typo__byline-tags--small);
@@ -156,6 +142,7 @@
     width: 321px;
   }
 
+  // stylelint-disable-next-line no-descending-specificity -- Stylelint wants us to re-order the file, but it actually would make it less readable.
   .card__media {
     // Odd aspect ratio, taken from the design.
     aspect-ratio: 321/426;

--- a/src/stories/Library/content-list-item/ContentListItem.stories.tsx
+++ b/src/stories/Library/content-list-item/ContentListItem.stories.tsx
@@ -1,18 +1,13 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import { ContentListItem } from "./ContentListItem";
+import ImageCredited from "../image-credited/ImageCredited";
 
 export default {
   title: "Library / Content List Item",
   component: ContentListItem,
   decorators: [withDesign],
   argTypes: {
-    image: {
-      defaultValue:
-        "https://plus.unsplash.com/premium_photo-1696886122527-e4303b76aa8f?q=80&w=5156&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-
-      control: { type: "text" },
-    },
     tagText: {
       defaultValue: "Foredrag",
       control: { type: "text" },
@@ -45,6 +40,15 @@ export default {
     href: {
       defaultValue: "/",
       control: { type: "text" },
+    },
+    image: {
+      defaultValue: (
+        <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+      ),
+    },
+    placeholderText: {
+      defaultValue: "Stine Pilgaard vinder De Gyldne Laurbær",
+      type: "string",
     },
   },
   parameters: {

--- a/src/stories/Library/content-list-item/ContentListItem.tsx
+++ b/src/stories/Library/content-list-item/ContentListItem.tsx
@@ -1,9 +1,12 @@
+import { ReactNode } from "react";
 import { ReactComponent as ArrowSmallRight } from "../Arrows/icon-arrow-ui/icon-arrow-ui-small-right.svg";
 import Tag from "../tag/Tag";
+import MediaContainer from "../media-container/MediaContainer";
 
 export type ContentListItemProps = {
   eventSeriesId?: string;
-  image: string;
+  image?: ReactNode;
+  placeholderText?: string;
   tagText: string;
   title: string;
   description: string;
@@ -17,6 +20,7 @@ export type ContentListItemProps = {
 
 export const ContentListItem: React.FC<ContentListItemProps> = ({
   image,
+  placeholderText,
   tagText,
   title,
   description,
@@ -33,7 +37,7 @@ export const ContentListItem: React.FC<ContentListItemProps> = ({
   return (
     <a href={href} className="content-list-item arrow__hover--right-small">
       <div className="content-list-item__image-container">
-        <img src={image} alt={title} className="content-list-item__image" />
+        <MediaContainer media={image} placeholderText={placeholderText} />
       </div>
       <div className="content-list-item__content">
         {tagText && (

--- a/src/stories/Library/content-list-item/content-list-item.scss
+++ b/src/stories/Library/content-list-item/content-list-item.scss
@@ -68,23 +68,10 @@ $_stacked-reduce-width: 20px;
 }
 
 .content-list-item__image-container {
-  @extend %identity-placeholder-pseudo;
   grid-area: image;
   position: relative;
   width: 100%;
   aspect-ratio: 4 / 3;
-
-  // We want to treat everything inside the image-container as image related.
-  // To make object-fit work, it is important that everything has 100%
-  // height and width set. We cannot know 100% what markup Drupal will use,
-  // so we'll use a wildcard here.
-  * {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    position: relative;
-    z-index: $z-10;
-  }
 }
 
 .content-list-item__content {
@@ -201,6 +188,8 @@ $_stacked-reduce-width: 20px;
   }
 
   .content-list-item__image-container {
+    @include media-container--small;
+
     grid-area: image;
     max-height: $_content-list-item--image-height;
     min-height: $_content-list-item--image-height;

--- a/src/stories/Library/content-list/ContentList.stories.tsx
+++ b/src/stories/Library/content-list/ContentList.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import ContentList from "./ContentList";
-import contentListData from "./ContentListData";
+import ContentListData from "./ContentListData";
 
 export default {
   title: "Library / Content List",
@@ -20,5 +20,5 @@ const Template: ComponentStory<typeof ContentList> = (args) => (
 export const Default = Template.bind({});
 
 Default.args = {
-  items: contentListData,
+  items: ContentListData,
 };

--- a/src/stories/Library/content-list/ContentListData.tsx
+++ b/src/stories/Library/content-list/ContentListData.tsx
@@ -1,11 +1,12 @@
 import { ContentListItemProps } from "../content-list-item/ContentListItem";
+import ImageCredited from "../image-credited/ImageCredited";
 
 const contentListData: ContentListItemProps[] = [
   {
     eventSeriesId: "a",
-    image:
-      "https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "Foredrag",
     title: "Kunst og kultur i middelalderen",
     description: "En dybdegåendenalysef kunst og kultur i middelalderen.",
@@ -17,8 +18,9 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "b",
-    image:
-      "https://images.unsplash.com/photo-1502086223501-7ea6ecd79368?q=80&w=1438&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "arrangement",
     title: "Fars Legestue",
     description: "Kom forbi til hygge i Fars Legestue",
@@ -30,8 +32,9 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "b",
-    image:
-      "https://images.unsplash.com/photo-1502086223501-7ea6ecd79368?q=80&w=1438&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "arrangement",
     title: "Fars Legestue",
     description: "Kom forbi til hygge i Fars Legestue",
@@ -43,8 +46,9 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "b",
-    image:
-      "https://images.unsplash.com/photo-1502086223501-7ea6ecd79368?q=80&w=1438&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "arrangement",
     title: "Fars Legestue",
     description: "Kom forbi til hygge i Fars Legestue",
@@ -56,8 +60,9 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "b",
-    image:
-      "https://images.unsplash.com/photo-1502086223501-7ea6ecd79368?q=80&w=1438&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "arrangement",
     title: "Fars Legestue",
     description: "Kom forbi til hygge i Fars Legestue",
@@ -69,9 +74,7 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "a",
-    image:
-      "https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-
+    placeholderText: "Placeholder tekst",
     tagText: "Foredrag",
     title: "Kunst og kultur i middelalderen",
     description: "En dybdegåendenalysef kunst og kultur i middelalderen.",
@@ -83,9 +86,9 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "a",
-    image:
-      "https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
     tagText: "Foredrag",
     title: "Kunst og kultur i middelalderen",
     description: "En dybdegåendenalysef kunst og kultur i middelalderen.",
@@ -97,9 +100,7 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "a",
-    image:
-      "https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-
+    placeholderText: "Placeholder tekst",
     tagText: "Foredrag",
     title: "Kunst og kultur i middelalderen",
     description: "En dybdegåendenalysef kunst og kultur i middelalderen.",
@@ -111,8 +112,7 @@ const contentListData: ContentListItemProps[] = [
   },
   {
     eventSeriesId: "b",
-    image:
-      "https://images.unsplash.com/photo-1502086223501-7ea6ecd79368?q=80&w=1438&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    placeholderText: "Placeholder tekst",
     tagText: "arrangement",
     title: "Fars Legestue",
     description: "Kom forbi til hygge i Fars Legestue",

--- a/src/stories/Library/image-credited/ImageCredited.tsx
+++ b/src/stories/Library/image-credited/ImageCredited.tsx
@@ -20,7 +20,9 @@ const ImageCredited: FC<ImageCreditedProps> = ({
     <figure className={clsx("image-credited", className)}>
       {src ? (
         <>
-          <img src={src} className="image-credited__img" alt={alt} />
+          <div className="image-credited__image">
+            <img src={src} alt={alt} />
+          </div>
           {(description || year) && (
             <figcaption className="image-credited__info">
               <span>{description}</span>

--- a/src/stories/Library/image-credited/image-credited.scss
+++ b/src/stories/Library/image-credited/image-credited.scss
@@ -1,5 +1,9 @@
-.image-credited__img {
+.image-credited__image {
   width: 100%;
+
+  * {
+    width: 100%;
+  }
 }
 
 .image-credited__info {

--- a/src/stories/Library/media-container/MediaContainer.stories.tsx
+++ b/src/stories/Library/media-container/MediaContainer.stories.tsx
@@ -8,7 +8,11 @@ export default {
   argTypes: {
     media: {
       defaultValue: (
-        <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+        <ImageCredited
+          description="Beskrivelse"
+          year="2021"
+          src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+        />
       ),
       type: "string",
     },

--- a/src/stories/Library/media-container/MediaContainer.stories.tsx
+++ b/src/stories/Library/media-container/MediaContainer.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import MediaContainer from "./MediaContainer";
+import ImageCredited from "../image-credited/ImageCredited";
+
+export default {
+  title: "Library / Media container",
+  component: MediaContainer,
+  argTypes: {
+    media: {
+      defaultValue: (
+        <ImageCredited src="https://images.unsplash.com/photo-1585779034823-7e9ac8faec70?q=80&w=3024&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+      ),
+      type: "string",
+    },
+    placeholderText: {
+      defaultValue: "En placeholder tekst",
+      type: "string",
+    },
+  },
+} as ComponentMeta<typeof MediaContainer>;
+
+const Template: ComponentStory<typeof MediaContainer> = (args) => (
+  <MediaContainer {...args} />
+);
+
+export const Default = Template.bind({});
+export const noMedia = Template.bind({});
+noMedia.args = {
+  media: undefined,
+};

--- a/src/stories/Library/media-container/MediaContainer.tsx
+++ b/src/stories/Library/media-container/MediaContainer.tsx
@@ -15,13 +15,15 @@ const MediaContainer: FC<ImageCreditedProps> = ({
   });
 
   return (
-    <figure className={clsx(classes)}>
-      {media ?? (
+    <div className={clsx(classes)}>
+      {media ? (
+        <div className="media-container__media"> {media} </div>
+      ) : (
         <div className="media-container__placeholder-text">
           {placeholderText}
         </div>
       )}
-    </figure>
+    </div>
   );
 };
 

--- a/src/stories/Library/media-container/MediaContainer.tsx
+++ b/src/stories/Library/media-container/MediaContainer.tsx
@@ -1,0 +1,28 @@
+import clsx from "clsx";
+import { FC, ReactNode } from "react";
+
+type ImageCreditedProps = {
+  media?: ReactNode;
+  placeholderText?: string;
+};
+
+const MediaContainer: FC<ImageCreditedProps> = ({
+  media,
+  placeholderText = "",
+}) => {
+  const classes = clsx("media-container", {
+    "media-container--placeholder": !media,
+  });
+
+  return (
+    <figure className={clsx(classes)}>
+      {media ?? (
+        <div className="media-container__placeholder-text">
+          {placeholderText}
+        </div>
+      )}
+    </figure>
+  );
+};
+
+export default MediaContainer;

--- a/src/stories/Library/media-container/media-container.scss
+++ b/src/stories/Library/media-container/media-container.scss
@@ -35,8 +35,15 @@
   &--placeholder {
     @include identity-placeholder;
   }
+}
 
-  * {
+.media-container__media {
+  height: 100%;
+  width: 100%;
+
+  // This is necessary to make object fit work.
+  > figure {
+    width: 100%;
     height: 100%;
   }
 

--- a/src/stories/Library/media-container/media-container.scss
+++ b/src/stories/Library/media-container/media-container.scss
@@ -1,0 +1,53 @@
+@mixin media-container--grid {
+  .media-container {
+    .media-container__placeholder-text {
+      @include typography($typo__card-placeholder--grid);
+    }
+  }
+}
+
+@mixin media-container--card {
+  .media-container {
+    .media-container__placeholder-text {
+      @include typography($typo__card-placeholder);
+    }
+  }
+}
+
+@mixin media-container--small {
+  .media-container {
+    &--placeholder {
+      @include identity-placeholder($placeholder-paddings--small);
+    }
+
+    .media-container__placeholder-text {
+      font-size: 14px;
+      line-height: 16px;
+      padding: $s-md;
+    }
+  }
+}
+
+.media-container {
+  height: 100%;
+  width: 100%;
+
+  &--placeholder {
+    @include identity-placeholder;
+  }
+
+  * {
+    height: 100%;
+  }
+
+  img {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+}
+
+.media-container__placeholder-text {
+  @extend %identity-placeholder-text;
+}

--- a/src/stories/Library/media-container/media-container.scss
+++ b/src/stories/Library/media-container/media-container.scss
@@ -42,7 +42,7 @@
   width: 100%;
 
   // This is necessary to make object fit work.
-  > figure {
+  * {
     width: 100%;
     height: 100%;
   }

--- a/src/stories/Library/media-container/media-container.scss
+++ b/src/stories/Library/media-container/media-container.scss
@@ -42,7 +42,9 @@
   width: 100%;
 
   // This is necessary to make object fit work.
-  * {
+  .image-credited__image,
+  figure,
+  img {
     width: 100%;
     height: 100%;
   }

--- a/src/stories/Library/nav-spot/NavSpot.tsx
+++ b/src/stories/Library/nav-spot/NavSpot.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from "react";
-import clsx from "clsx";
 import { ReactComponent as Arrow } from "../Arrows/icon-arrow-ui/icon-arrow-ui-large-right.svg";
+import MediaContainer from "../media-container/MediaContainer";
 
 type NavSpotProps = {
   variant?: string;
@@ -17,19 +17,15 @@ const NavSpot: FC<NavSpotProps> = ({
   media,
   placeholderText,
 }) => {
-  const classes = clsx("nav-spot", "arrow__hover--right-large", {
-    "nav-spot--has-no-media": !media,
-    "nav-spot--has-media": media,
-  });
-
   return (
-    <article className={classes} data-variant={variant}>
+    <article
+      className="nav-spot arrow__hover--right-large"
+      data-variant={variant}
+    >
       <a href="#" className="nav-spot__content">
-        <figure className="nav-spot__media">
-          {media || (
-            <div className="nav-spot__placeholder-text">{placeholderText}</div>
-          )}
-        </figure>
+        <div className="nav-spot__media">
+          <MediaContainer placeholderText={placeholderText} media={media} />
+        </div>
 
         <div className="nav-spot__text">
           <h1 className="nav-spot__title">{title}</h1>

--- a/src/stories/Library/nav-spot/nav-spot.scss
+++ b/src/stories/Library/nav-spot/nav-spot.scss
@@ -23,17 +23,6 @@ $_text-padding: $s-xl;
 
   .nav-spot__media {
     aspect-ratio: 16/9;
-
-    * {
-      height: 100%;
-    }
-
-    img {
-      height: 100%;
-      width: 100%;
-      object-fit: cover;
-      object-position: center;
-    }
   }
 
   @include media-query__medium("max-width") {
@@ -46,16 +35,6 @@ $_text-padding: $s-xl;
 
 .nav-spot {
   @extend %nav-spot--default;
-}
-
-.nav-spot--has-no-media {
-  .nav-spot__media {
-    @extend %identity-placeholder;
-  }
-}
-
-.nav-spot__placeholder-text {
-  @extend %identity-placeholder-text;
 }
 
 %nav-spot--large,

--- a/src/styles/scss/tools/placeholder.scss
+++ b/src/styles/scss/tools/placeholder.scss
@@ -82,11 +82,11 @@
   @include typography($typo__body-small);
 }
 
-@mixin identity-placeholder {
+@mixin identity-placeholder($paddings: $placeholder-paddings) {
   background-color: var(--tint-color-120);
   border: $s-lg solid $color__identity-primary;
 
-  @each $breakpoint-name, $width in $placeholder-paddings {
+  @each $breakpoint-name, $width in $paddings {
     @include media-query__name($breakpoint-name) {
       border-width: $width;
     }

--- a/src/styles/scss/tools/variables.spacings.scss
+++ b/src/styles/scss/tools/variables.spacings.scss
@@ -29,3 +29,9 @@ $placeholder-paddings: (
   small: $s-xl,
   medium: $s-2xl,
 );
+
+$placeholder-paddings--small: (
+  mobile: $s-md,
+  small: $s-lg,
+  medium: $s-xl,
+);


### PR DESCRIPTION
Before now, we used various scss mixins to re-use the same placeholder component, that shows up when no image is available. Instead, we'll make a media-container component that can be re-used along with it's own CSS classes.

----

Please review it, by starting to look at the visual changes in chromatic :)
I've also tweaked some of the examples, so we see teasers without images.


-----


**This should not be merged, before we also have the CMS PR ready!**

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/861