### PR TITLE
Refactor link styling in `ListDescription` component

### DIFF
--- a/src/stories/Library/Lists/list-description/ListDescription.tsx
+++ b/src/stories/Library/Lists/list-description/ListDescription.tsx
@@ -30,7 +30,7 @@ const ListDescription: React.FC<{ data: ListData; className?: string }> = ({
               {value.map((val) => (
                 <Fragment key={val}>
                   {type === "standard" && <span>{val}</span>}
-                  {type === "link" && <span className="link-tag">{val}</span>}
+                  {type === "link" && <a href="#">{val}</a>}
                 </Fragment>
               ))}
             </dd>

--- a/src/stories/Library/Lists/list-description/list-description.scss
+++ b/src/stories/Library/Lists/list-description/list-description.scss
@@ -27,7 +27,11 @@ dl.list-description {
     flex-direction: column;
   }
 
-  .link-tag {
+  // TODO: Reevaluate this when implementing logic to determine if 'link-tag' styled
+  // values in dpl-react should be 'a' tags or 'span' tags as currently implemented.
+  .link-tag,
+  a {
+    @extend %link-tag;
     @include typography($typo__small-caption);
 
     color: $color__text-primary-black;
@@ -52,7 +56,12 @@ dl.list-description {
       grid-gap: 8px;
       gap: 8px;
     }
-    .link-tag {
+
+    // TODO: Reevaluate this when implementing logic to determine if 'link-tag' styled
+    // values in dpl-react should be 'a' tags or 'span' tags as currently implemented.
+    .link-tag,
+    a {
+      @extend %link-tag;
       @include typography($typo__body-placeholder);
       line-height: 120%;
     }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-404

#### Description

This pull request refactors the link styling in the `ListDescription` component. It adds correct link markup and styles the link according to the Drupal rendering method.

https://github.com/danskernesdigitalebibliotek/dpl-react/blob/develop/src/components/material/MaterialDetailsList.tsx
I have reviewed the `ListDescription` component in dpl-react and noticed that it currently does not render any links. Therefore, this will need to be revisited when we implement logic to display links in the `ListDescription` in the future.