### PR TITLE
Move modal close button

### DIFF
--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -74,7 +74,7 @@
   background-color: $color__global-primary;
   position: fixed;
   top: 0;
-  right: 17px;
+  right: 0;
   // We need both padding & margin so that when the icon rotates, we don't see
   // the background color bleed outside the modal.
   padding: $s-md;
@@ -85,7 +85,7 @@
   &.modal-btn-close--offset {
     @include media-query__small {
       top: $s-5xl;
-      right: $s-5xl;
+      right: cals($s-5xl + 17px);
     }
   }
 

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -74,7 +74,7 @@
   background-color: $color__global-primary;
   position: fixed;
   top: 0;
-  right: 0;
+  right: 17;
   // We need both padding & margin so that when the icon rotates, we don't see
   // the background color bleed outside the modal.
   padding: $s-md;

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -85,7 +85,7 @@
   &.modal-btn-close--offset {
     @include media-query__small {
       top: $s-5xl;
-      right: cals($s-5xl + 17px);
+      right: calc($s-5xl + 17px);
     }
   }
 

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -74,7 +74,7 @@
   background-color: $color__global-primary;
   position: fixed;
   top: 0;
-  right: 17;
+  right: 17px;
   // We need both padding & margin so that when the icon rotates, we don't see
   // the background color bleed outside the modal.
   padding: $s-md;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-500

#### Description
Move modal close button 17px to the left so scrollbar isn't obscured - 17 because that is the width of the scrollbar on Windows, which is the thickest one.

#### Screenshot of the result
-
#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

