### PR TITLE
Add padding to modal headings [DDFLSBP-462]

### DIFF
--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -11,6 +11,10 @@
   height: 100vh;
   overflow: auto;
 
+  h2 {
+    padding-right: $s-xl;
+  }
+
   &__screen-reader-description {
     @include hide-visually;
   }
@@ -19,10 +23,18 @@
     height: calc(100vh - 200px);
     width: calc(100vw - 200px);
     margin: $s-5xl 0 0 $s-5xl;
+
+    h2 {
+      padding-right: $s-4xl;
+    }
   }
 
   @include media-query__medium {
     padding: $s-4xl $s-7xl;
+    
+    h2 {
+      padding-right: initial;
+    }
   }
 
   &.modal--no-padding {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-462

#### Description

Add padding to modal headings to prevent them from being obscured by the close button.

#### Screenshot of the result

<img width="785" alt="Skærmbillede 2024-03-18 kl  08 20 24" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/d82a1d8a-90b2-4c7a-a06d-b681eeef0005">

<img width="488" alt="Skærmbillede 2024-03-18 kl  08 20 49" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/4465332a-454f-41d7-8373-482ba1b968ce">

#### Additional comments or questions

*
