### PR TITLE
Make sure header doesnt break out zoom on mobile. DDFFORM-517

### DIFF
--- a/src/stories/Blocks/header/header-sticky.js
+++ b/src/stories/Blocks/header/header-sticky.js
@@ -26,14 +26,20 @@ window.addEventListener("DOMContentLoaded", () => {
     lastScrollY = scrollY > 0 ? scrollY : 0;
 
     // Control header direction class.
+    const headerContainerSelector = ".header";
+
     if (scrollDirection === "down") {
-      const headerHeight = document.querySelector("header").offsetHeight;
+      const headerHeight = document.querySelector(
+        headerContainerSelector
+      ).offsetHeight;
       const headerDownTopPosition = headerHeight + headerDownTopPositionOffset;
       document.querySelector(
-        "header"
+        headerContainerSelector
       ).style.top = `-${headerDownTopPosition}px`;
     } else {
-      document.querySelector("header").style.top = `${headerYStartPosition}px`;
+      document.querySelector(
+        headerContainerSelector
+      ).style.top = `${headerYStartPosition}px`;
     }
   };
 

--- a/src/styles/scss/shared.scss
+++ b/src/styles/scss/shared.scss
@@ -48,6 +48,10 @@
   cursor: pointer;
 }
 
+.overflow-hidden {
+  overflow: hidden;
+}
+
 // When class is used on a block element it will show a loading ellipsis animation.
 .text-loading:after {
   overflow: hidden;


### PR DESCRIPTION
We cant really reflect the overflow hidden change in the design system, as we have no story that combines the header, page etc, but it needs to be set on the div that wraps around all the content.

On CMS, where all the elements are combined, you are current allowed to zoom out way further than you should on mobile.

<img width="490" alt="Screenshot 2024-04-08 at 15 16 51" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/12376583/b7b7872c-5806-41e4-a38c-6732b9fa876f">
