### PR TITLE
Fix issue with selected hour starting half an hour later

### DIFF
--- a/src/stories/Library/opening-hours-editor/opening-hours-editor.scss
+++ b/src/stories/Library/opening-hours-editor/opening-hours-editor.scss
@@ -58,3 +58,9 @@
   padding: 5px 10px;
   cursor: pointer;
 }
+
+// Override Drupal's default margin for tables inside .fc to eliminate top and bottom spacing
+// Fixes the issue where the selected hour starts half an hour later than the actual selection.
+.fc table {
+  margin: 0;
+}


### PR DESCRIPTION
#### Link to issue


#### Description
Override Drupal's default table margins to eliminate top and bottom spacing, fixing the issue where the selected hour starts half an hour later than the actual selection.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/49920322/29d1690a-5760-4d78-8eaa-479826290178

