### PR TITLE
Super simple blockquote design, for rich-text. DDFFORM-492

### DIFF
--- a/src/stories/Library/rich-text/RichText.tsx
+++ b/src/stories/Library/rich-text/RichText.tsx
@@ -30,10 +30,12 @@ export const RichText = () => {
       <h3>
         Narsil enjoying shattered bigger leaderless retrieve dreamed dwarf.
       </h3>
-      <p>
-        Ravens wonder wanted runs me crawl gaining lots faster! Khazad-dum
-        surprise baby season ranks. I bid you all a very fond farewell.
-      </p>
+      <blockquote>
+        <p>
+          Ravens wonder wanted runs me crawl gaining lots faster! Khazad-dum
+          surprise baby season ranks. I bid you all a very fond farewell.
+        </p>
+      </blockquote>
       <ol>
         <li>Narsil.</li>
         <li>Elros.</li>

--- a/src/stories/Library/rich-text/rich-text.scss
+++ b/src/stories/Library/rich-text/rich-text.scss
@@ -75,6 +75,25 @@ $_max-width-rich-text: $block-max-width__small;
     }
   }
 
+  blockquote {
+    $_quote-indicator-width: 10px;
+
+    position: relative;
+    padding-top: $s-md;
+    padding-bottom: $s-md;
+    padding-left: $_quote-indicator-width + $s-md;
+
+    &::before {
+      position: absolute;
+      content: "";
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: $_quote-indicator-width;
+      background-color: $color__identity-primary;
+    }
+  }
+
   table {
     // There is no perfect way of making tables responsive.
     // A quick fix, is to make the text smaller on smaller screens.


### PR DESCRIPTION
There is no design on this element, but if we add nothing, then there is no visual indication that this is a blockquote. This just adds a very simple, visual indicator.

https://reload.atlassian.net/browse/DDFFORM-492

<img width="857" alt="Screenshot 2024-04-08 at 16 38 51" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/12376583/fec88021-8f49-4fb5-94f5-a1efb35e3663">
