### PR TITLE
Add Patron page and skeleton [DDFLSBP-486]

### DIFF
--- a/src/stories/Blocks/patron-page/ContactInfoSection.tsx
+++ b/src/stories/Blocks/patron-page/ContactInfoSection.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Input from "../../Library/Forms/input/Input";
+import { Checkbox } from "../../Library/Forms/checkbox/Checkbox";
+
+const ContactInfoSection: React.FC = () => {
+  return (
+    <section data-cy="patron-page-contact-info">
+      <h2 className="text-header-h4 mt-64 mb-16">Contact information</h2>
+      <p className="text-body-small-regular mb-32">
+        Patron contact info body text
+      </p>
+      <Input label="Phone number" type="text" id="phone" description="" />
+      <Checkbox
+        label="Receive text messages about your loans, reservations, and so forth"
+        isChecked={false}
+        hiddenLabel={false}
+        classNames="checkbox mt-8 mb-16"
+      />
+      <Input label="E-mail" type="text" id="email" description="" />
+      <Checkbox
+        label="Receive emails about your loans, reservations, and so forth"
+        isChecked={false}
+        hiddenLabel={false}
+        classNames="checkbox mt-8 mb-16"
+      />
+    </section>
+  );
+};
+
+export default ContactInfoSection;

--- a/src/stories/Blocks/patron-page/PatronPage.stories.tsx
+++ b/src/stories/Blocks/patron-page/PatronPage.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import PatronPage from "./PatronPage";
+
+export default {
+  title: "Blocks / Patron Page",
+  component: PatronPage,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/xouARmJCONbzbZhpD8XpcM/Brugerprofil?type=design&node-id=1239-66174&mode=design",
+    },
+    layout: "fullscreen",
+  },
+  argTypes: {
+    skeletonVersion: {
+      control: "boolean",
+      defaultValue: false,
+    },
+  },
+} as ComponentMeta<typeof PatronPage>;
+
+const Template: ComponentStory<typeof PatronPage> = (args) => {
+  return <PatronPage {...args} />;
+};
+
+export const Default = Template.bind({});
+
+export const SkeletonVersion = Template.bind({});
+SkeletonVersion.args = {
+  skeletonVersion: true,
+};

--- a/src/stories/Blocks/patron-page/PatronPage.tsx
+++ b/src/stories/Blocks/patron-page/PatronPage.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import PatronInfo from "../../Library/patron-info/PatronInfo";
 import Input from "../../Library/Forms/input/Input";
-import { Checkbox } from "../../Library/Forms/checkbox/Checkbox";
 import { StatusLoans } from "../status-loans/statusLoans";
 import { Dropdown } from "../../Library/dropdown/Dropdown";
 import { Links } from "../../Library/links/Links";
+import PatronPageSkeleton from "./PatronPageSkeleton";
+import ContactInfoSection from "./ContactInfoSection";
 
 export interface PatronPageProps {
   skeletonVersion?: boolean;
 }
 
 const PatronPage: React.FC<PatronPageProps> = ({ skeletonVersion = false }) => {
-  if (skeletonVersion) return <>hello skeleton</>;
+  if (skeletonVersion) return <PatronPageSkeleton />;
 
   const statusBarsData = [
     {
@@ -38,7 +39,6 @@ const PatronPage: React.FC<PatronPageProps> = ({ skeletonVersion = false }) => {
   return (
     <form className="dpl-patron-page">
       <h1 className="text-header-h1 my-32">Patron profile page</h1>
-
       <h2 className="text-header-h4 mt-32 mb-16">Basic details</h2>
 
       {/* Patron info section */}
@@ -50,27 +50,7 @@ const PatronPage: React.FC<PatronPageProps> = ({ skeletonVersion = false }) => {
       />
 
       <div className="patron-page-info">
-        {/* Contact info section */}
-        <section data-cy="patron-page-contact-info">
-          <h2 className="text-header-h4 mt-64 mb-16">Contact information</h2>
-          <p className="text-body-small-regular mb-32">
-            Patron contact info body text
-          </p>
-          <Input label="Phone number" type="text" id="phone" description="" />
-          <Checkbox
-            label="Receive text messages about your loans, reservations, and so forth"
-            isChecked={false}
-            hiddenLabel={false}
-            classNames="checkbox mt-8 mb-16"
-          />
-          <Input label="E-mail" type="text" id="email" description="" />
-          <Checkbox
-            label="Receive emails about your loans, reservations, and so forth"
-            isChecked={false}
-            hiddenLabel={false}
-            classNames="checkbox mt-8 mb-16"
-          />
-        </section>
+        <ContactInfoSection />
 
         {/* Digital loans section */}
         <section className="dpl-status-loans">

--- a/src/stories/Blocks/patron-page/PatronPage.tsx
+++ b/src/stories/Blocks/patron-page/PatronPage.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import PatronInfo from "../../Library/patron-info/PatronInfo";
+import Input from "../../Library/Forms/input/Input";
+import { Checkbox } from "../../Library/Forms/checkbox/Checkbox";
+import { StatusLoans } from "../status-loans/statusLoans";
+import { Dropdown } from "../../Library/dropdown/Dropdown";
+import { Links } from "../../Library/links/Links";
+
+export interface PatronPageProps {
+  skeletonVersion?: boolean;
+}
+
+const PatronPage: React.FC<PatronPageProps> = ({ skeletonVersion = false }) => {
+  if (skeletonVersion) return <>hello skeleton</>;
+
+  const statusBarsData = [
+    {
+      title: "Loans per month",
+      statusBars: [
+        { amount: 1, fullAmount: 4, title: "Ebooks", outOf: "out of" },
+        { amount: 2, fullAmount: 10, title: "Audiobooks", outOf: "out of" },
+      ],
+    },
+  ];
+
+  const branches = [
+    {
+      title: "Copenhagen",
+    },
+    {
+      title: "New York",
+    },
+    {
+      title: "The Moon",
+    },
+  ];
+
+  return (
+    <form className="dpl-patron-page">
+      <h1 className="text-header-h1 my-32">Patron profile page</h1>
+
+      <h2 className="text-header-h4 mt-32 mb-16">Basic details</h2>
+
+      {/* Patron info section */}
+      <PatronInfo
+        name="Professor Utonium"
+        nameLabel="Name"
+        address="The Utonium Residence, 107 Pokey Oaks South, Townsville, USA"
+        addressLabel="Address"
+      />
+
+      <div className="patron-page-info">
+        {/* Contact info section */}
+        <section data-cy="patron-page-contact-info">
+          <h2 className="text-header-h4 mt-64 mb-16">Contact information</h2>
+          <p className="text-body-small-regular mb-32">
+            Patron contact info body text
+          </p>
+          <Input label="Phone number" type="text" id="phone" description="" />
+          <Checkbox
+            label="Receive text messages about your loans, reservations, and so forth"
+            isChecked={false}
+            hiddenLabel={false}
+            classNames="checkbox mt-8 mb-16"
+          />
+          <Input label="E-mail" type="text" id="email" description="" />
+          <Checkbox
+            label="Receive emails about your loans, reservations, and so forth"
+            isChecked={false}
+            hiddenLabel={false}
+            classNames="checkbox mt-8 mb-16"
+          />
+        </section>
+
+        {/* Digital loans section */}
+        <section className="dpl-status-loans">
+          <StatusLoans
+            statusBarsData={statusBarsData}
+            title="Digital loans (eReolen)"
+            link={{
+              link: "https://www.figma.com/file/xouARmJCONbzbZhpD8XpcM/Brugerprofil?node-id=1239%3A66855",
+              text: "Click here, to see titles always eligible to be loaned",
+            }}
+            bread="There is a number of materials without limitation to amounts of loans per month."
+            reservationsText="You can reserve 4 ebooks and 10 audiobooks"
+          />
+        </section>
+
+        {/* Pickup branch section */}
+        <section>
+          <h2 className="text-header-h4 mt-64 mb-16">Reservations</h2>
+          <p className="text-body-small-regular mb-8">
+            Change pickup body text
+          </p>
+          <label
+            htmlFor="branches-dropdown"
+            className="text-body-medium-medium mt-32 mb-8"
+          >
+            Choose pickup branch
+          </label>
+          <Dropdown
+            list={branches}
+            ariaLabel="branches"
+            arrowIcon="chevron"
+            classNames="dropdown__desktop"
+          />
+        </section>
+
+        {/* Pin code section */}
+        <section>
+          <h2 className="text-header-h4 mt-64 mb-16">Pincode</h2>
+          <p className="text-body-small-regular mb-8">
+            Change current pin by entering a new pin and saving
+          </p>
+          <div className="dpl-pincode-container">
+            <div className="patron__input patron__input--desktop">
+              <Input
+                label="New pin"
+                type="password"
+                id="pincode-input"
+                description=""
+              />
+            </div>
+            <div className="patron__input patron__input--desktop">
+              <Input
+                label="Confirm new pin"
+                type="password"
+                id="pincode-input-2"
+                description=""
+              />
+            </div>
+          </div>
+        </section>
+
+        <button
+          className="mt-48 btn-primary btn-filled btn-small"
+          type="submit"
+        >
+          Save
+        </button>
+
+        {/* Delete profile link */}
+        <div className="text-body-small-regular mt-32">
+          Do you wish to delete your library profile?{" "}
+          <Links
+            href="https://www.figma.com/file/xouARmJCONbzbZhpD8XpcM/Brugerprofil?node-id=1239%3A66855"
+            linkText="Delete your profile"
+            classNames="link-tag"
+          />
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default PatronPage;

--- a/src/stories/Blocks/patron-page/PatronPageSkeleton.tsx
+++ b/src/stories/Blocks/patron-page/PatronPageSkeleton.tsx
@@ -1,0 +1,15 @@
+import PatronInfoSkeleton from "../../Library/patron-info/PatronInfoSkeleton";
+import ContactInfoSection from "./ContactInfoSection";
+
+const PatronPageSkeleton: React.FC = () => {
+  return (
+    <form className="dpl-patron-page">
+      <h1 className="text-header-h1 my-32">Patron profile page</h1>
+      <h2 className="text-header-h4 mt-32 mb-16">Basic details</h2>
+      <PatronInfoSkeleton />
+      <ContactInfoSection />
+    </form>
+  );
+};
+
+export default PatronPageSkeleton;

--- a/src/stories/Blocks/status-loans/statusLoans.stories.tsx
+++ b/src/stories/Blocks/status-loans/statusLoans.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { StatusLoans as StatusLoansComp } from "./statusLoans";
 
 export default {
-  title: "Blocks / Userprofile / Status loans",
+  title: "Blocks / User Profile / Status loans",
   component: StatusLoansComp,
   parameters: {
     design: {
@@ -28,6 +28,9 @@ export default {
     bread: {
       defaultValue:
         "På mange digitale materialer, er der er begrænsning på, hvor mange du kan låne pr. måned. Der findes dog en række materialer uden begrænsning.",
+    },
+    reservationsText: {
+      defaultValue: "You can reserve 3 ebooks and 3 audiobooks",
     },
     link: {
       defaultValue: {

--- a/src/stories/Blocks/status-loans/statusLoans.tsx
+++ b/src/stories/Blocks/status-loans/statusLoans.tsx
@@ -33,7 +33,7 @@ export const StatusLoans = (props: StatusLoansProps) => {
 
   return (
     <>
-      <h1 className="text-header-h4 mt-64 mb-16">{statusBarsTitle}</h1>
+      <h2 className="text-header-h4 mt-64 mb-16">{statusBarsTitle}</h2>
       <div className="text-body-small-regular mb-8">
         {`${bread} `}
         <a href={url} className="text-links">

--- a/src/stories/Blocks/status-loans/statusLoans.tsx
+++ b/src/stories/Blocks/status-loans/statusLoans.tsx
@@ -18,25 +18,35 @@ export type StatusLoansProps = {
   title: string;
   link: LinkProps;
   bread: string;
+  reservationsText: string;
 };
 
 export const StatusLoans = (props: StatusLoansProps) => {
-  const { statusBarsData, title: statusBarsTitle, link, bread } = props;
+  const {
+    statusBarsData,
+    title: statusBarsTitle,
+    link,
+    bread,
+    reservationsText,
+  } = props;
   const { link: url, text: linkText } = link;
 
   return (
     <>
-      <h1 className="text-header-h1 m-8">{statusBarsTitle}</h1>
-      <div className="m-8 text-body-small-regular">
+      <h1 className="text-header-h4 mt-64 mb-16">{statusBarsTitle}</h1>
+      <div className="text-body-small-regular mb-8">
         {`${bread} `}
         <a href={url} className="text-links">
           {linkText}
         </a>
       </div>
-      <div className="dpl-status-loans">
+      <div className="text-body-small-regular mt-8 mb-8">
+        {reservationsText}
+      </div>
+      <div className="dpl-status mt-32">
         {statusBarsData.map(({ statusBars, title }) => (
-          <div className="dpl-status-loans__container m-8">
-            <h2 className="text-header-h2">{title}</h2>
+          <div className="dpl-status-loans__container">
+            <h3 className="text-small-caption">{title}</h3>
             {statusBars.map(
               ({ title: statusBarTitle, amount, fullAmount, outOf }) => (
                 <ProgressBar

--- a/src/stories/Blocks/status-userprofile/statusUserprofile.stories.tsx
+++ b/src/stories/Blocks/status-userprofile/statusUserprofile.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { StatusUserprofile as StatusUserprofileComp } from "./statusUserprofile";
 
 export default {
-  title: "Blocks / Userprofile / Loans and Reservations",
+  title: "Blocks / User Profile / Loans and Reservations",
   component: StatusUserprofileComp,
   parameters: {
     design: {

--- a/src/stories/Library/patron-info/PatronInfo.stories.tsx
+++ b/src/stories/Library/patron-info/PatronInfo.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import PatronInfo from "./PatronInfo";
+import PatronInfoSkeleton from "./PatronInfoSkeleton";
 
 export default {
   title: "Library / User info",
@@ -33,3 +34,9 @@ const Template: ComponentStory<typeof PatronInfo> = (props) => (
 );
 
 export const PatronInfoExample = Template.bind({});
+
+const SkeletonTemplate: ComponentStory<typeof PatronInfoSkeleton> = () => (
+  <PatronInfoSkeleton />
+);
+
+export const PatronInfoSkeletonExample = SkeletonTemplate.bind({});

--- a/src/stories/Library/patron-info/PatronInfoSkeleton.tsx
+++ b/src/stories/Library/patron-info/PatronInfoSkeleton.tsx
@@ -1,0 +1,20 @@
+const PatronInfoSkeleton = () => {
+  return (
+    <div className="dpl-patron-info ssc">
+      <div className="dpl-patron-info__label">
+        <div className="ssc-head-line w-10" />
+      </div>
+      <div className="dpl-patron-info__text">
+        <div className="ssc-head-line w-20 mts" />
+      </div>
+      <div className="dpl-patron-info__label">
+        <div className="ssc-head-line w-10" />
+      </div>
+      <div className="dpl-patron-info__text">
+        <div className="ssc-head-line w-40 mts" />
+      </div>
+    </div>
+  );
+};
+
+export default PatronInfoSkeleton;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-486

#### Description

Based on the version of the Patron page from the dpl-react project, I have constructed a Patron page with an accompanying skeleton. Some decisions were made to reuse parts of dpl-react where immediately possible, but also to use components from the design system where they already existed, instead of the version that emerged in dpl-react.

#### Screenshot of the result

<img width="1394" alt="Skærmbillede 2024-04-10 kl  13 00 50" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/c12d2c67-1239-41a6-bcbc-5ca4ed758829">

#### Additional comments or questions

*
