### PR TITLE
Fix iOS 15 and later blue button text color [DDFLSBP-504]

### DIFF
--- a/src/stories/Blocks/advanced-search/advanced-search.scss
+++ b/src/stories/Blocks/advanced-search/advanced-search.scss
@@ -19,6 +19,7 @@
 
   &__clauses {
     @include typography($typo__button);
+    color: $color__global-grey;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/src/stories/Library/Buttons/row-button/row-button.scss
+++ b/src/stories/Library/Buttons/row-button/row-button.scss
@@ -1,6 +1,7 @@
 .row-button {
   height: 40px;
   background-color: $color__global-secondary;
+  color: $color__global-grey;
   padding: 9px $s-md;
   display: flex;
   align-items: center;

--- a/src/stories/Library/Lists/list-reservation/list-reservation.scss
+++ b/src/stories/Library/Lists/list-reservation/list-reservation.scss
@@ -123,6 +123,7 @@ $list-reservation-space-desktop: 24px;
 
 .list-reservation__header {
   @include typography($typo__h4);
+  color: $color__global-black;
   padding: 0;
   cursor: pointer;
 

--- a/src/stories/Library/Modals/modal-facet-browser/facet-browser.scss
+++ b/src/stories/Library/Modals/modal-facet-browser/facet-browser.scss
@@ -17,6 +17,10 @@
     display: flex;
     gap: $s-sm;
     flex-wrap: wrap;
+
+    .tag {
+      color: $color__global-grey;
+    }
   }
 
   &__clear-btn {

--- a/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
+++ b/src/stories/Library/Modals/modal-find-on-shelf/ModalFindOnShelf.tsx
@@ -66,7 +66,7 @@ const ModalFindOnShelf: React.FC<ModalFindOnShelfProps> = ({
             headingLevel="h2"
             withAvailability
             fullWidth
-            headline="Bibliotek fliale navn"
+            headline="Bibliotek filial navn"
             icon="Various"
             key={branchKey}
           >

--- a/src/stories/Library/card-list-page/facet-line.scss
+++ b/src/stories/Library/card-list-page/facet-line.scss
@@ -3,6 +3,10 @@
   display: inline-block;
   margin-right: $s-sm;
   margin-top: $s-md;
+
+  .tag {
+    color: $color__global-grey;
+  }
 }
 
 .facet-line-selected-terms {

--- a/src/stories/Library/footer-accordions/footer-accordions.scss
+++ b/src/stories/Library/footer-accordions/footer-accordions.scss
@@ -22,6 +22,7 @@ $footer-content-width: $s-2xl;
 }
 
 .footer-accordion__header-button {
+  color: $color__global-black;
   padding-left: $footer-content-width;
   padding-right: $footer-content-width;
   width: 100%;

--- a/src/stories/Library/tag/tag.scss
+++ b/src/stories/Library/tag/tag.scss
@@ -1,4 +1,5 @@
 .tag {
+  color: $color__global-black;
   display: inline-flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-504

#### Description

Corrects the issue where, in iOS 15 and later, if no color is specified in CSS for the button element, the text color defaults to blue. As a side effect, buttons defined in Figma to have the color #484848 now display the correct color in other browsers as well, where previously they defaulted to #000, the standard when no color is specified.

Fixed for:
- Footer
- Advanced Search
- Search Result Page
- Buttons / RowButton
- Lists / ReservationsAndLoans
- Modals / Facet browser
- Tag / Tag Button