### PR TITLE
Fix inteligent facets on mobile devices

### DIFF
--- a/src/stories/Library/card-list-page/facet-line.scss
+++ b/src/stories/Library/card-list-page/facet-line.scss
@@ -34,7 +34,7 @@
   white-space: nowrap;
 
   @include media-query__small() {
-    margin-bottom: $s-sm;
+    margin-top: $s-sm;
   }
 
   .tag {

--- a/src/stories/Library/card-list-page/facet-line.scss
+++ b/src/stories/Library/card-list-page/facet-line.scss
@@ -1,12 +1,49 @@
+.facet-line {
+  width: 100vw;
+  max-height: $s-xl;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+  margin-left: -16px;
+  padding-left: 16px;
+  // Hide scrollbar
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+  scrollbar-width: none; /* for Firefox */
+
+  &::-webkit-scrollbar {
+    display: none; /* for Chrome, Safari, and Opera */
+  }
+
+  @include media-query__small() {
+    width: 100%;
+    margin-left: 0px;
+    padding-left: 0px;
+    overflow-y: visible;
+    max-height: none;
+    flex-wrap: wrap;
+  }
+}
+
 .facet-line-selected-terms__item,
 .facet-line__item {
   display: inline-block;
   margin-right: $s-sm;
-  margin-top: $s-md;
+  margin-top: 0px;
+  white-space: nowrap;
+
+  @include media-query__small() {
+    margin-bottom: $s-sm;
+  }
 
   .tag {
     color: $color__global-grey;
   }
+}
+
+.facet-line-selected-terms__item {
+  margin-bottom: $s-sm;
 }
 
 .facet-line-selected-terms {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-518

#### Description
This PR makes the filter facet line horizontally scrollable on mobile in one line in order to save space on smaller devices.

#### Screenshot of the result
Mobile:

https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/267455f3-788e-4910-91f1-029c8629225d


Desktop (stays the same):
![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/a394e32d-479d-4949-a26f-9d1345092b77)

#### Additional comments or questions
-
