### PR TITLE
Apply `word-break: break-word` CSS property to hero title

### DIFF
--- a/src/stories/Library/Heros/hero/hero.scss
+++ b/src/stories/Library/Heros/hero/hero.scss
@@ -111,6 +111,7 @@ $_hero-column-breakpoint: "small";
 
 .hero__title {
   @include typography($typo__h1);
+  word-break: break-word;
   margin-bottom: $s-md;
 
   @include media-query__name($_hero-column-breakpoint) {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-491

#### Description
Long words in the hero title can disrupt the page layout. To address this issue, I have applied the `word-break: break-word` property to enhance layout stability and ensure text remains within its container. We can consider whether this should be inside `typography($typo__h1)`

#### Screenshot of the result
<img width="386" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/49920322/c5e87c7e-a475-4464-883e-2bb07f2bafd8">


<img width="1321" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/49920322/0e402a70-6719-421a-a173-294cedf564f8">
