### PR TITLE
DDFFORM 69

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -137,6 +137,7 @@
 @import "./src/stories/Library/opening-hours-editor/opening-hours-editor";
 @import "./src/stories/Library/opening-hours/opening-hours";
 @import "./src/stories/Library/opening-hours/opening-hours-skeleton";
+@import "./src/stories/Library/filtered-event-list/filtered-event-list";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Library/filtered-event-list/FilteredEventList.stories.tsx
+++ b/src/stories/Library/filtered-event-list/FilteredEventList.stories.tsx
@@ -1,0 +1,43 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import FilteredEventList from "./FilteredEventlist";
+import FilteredListData from "./FilteredEventListData";
+
+export default {
+  title: "Library/ Filtered Event List",
+
+  component: FilteredEventList,
+  argTypes: {
+    title: {
+      defaultValue: "Aktiviteter på biblioteket",
+      control: "text",
+      description: "Title of the recommendation",
+    },
+    events: {
+      defaultValue: FilteredListData,
+      control: "object",
+      description: "List of events to be displayed",
+    },
+    buttonText: {
+      defaultValue: "Se alle",
+      control: "text",
+      description: "Text for the button",
+    },
+    buttonShowLessText: {
+      defaultValue: "Se færre",
+      control: "text",
+      description: "Text for the button",
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?type=design&node-id=7567-80202&mode=design&t=eZs7Tgx4a1ebZQiO-4",
+    },
+  },
+} as ComponentMeta<typeof FilteredEventList>;
+
+const Template: ComponentStory<typeof FilteredEventList> = (args) => (
+  <FilteredEventList {...args} />
+);
+
+export const FilteredList = Template.bind({});

--- a/src/stories/Library/filtered-event-list/FilteredEventListData.tsx
+++ b/src/stories/Library/filtered-event-list/FilteredEventListData.tsx
@@ -1,0 +1,59 @@
+import { ContentListItemProps } from "../content-list-item/ContentListItem";
+import ImageCredited from "../image-credited/ImageCredited";
+
+const FilteredListData: ContentListItemProps[] = [
+  {
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
+    tagText: "Foredrag",
+    title: "Kunst og kultur i middelalderen",
+    description: "En dybdegåendenalysef kunst og kultur i middelalderen.",
+    location: "Kulturhuset",
+    price: "50 - 100 KR",
+    href: "/",
+    date: "2023-01-10",
+    time: "15:00 - 17:00",
+  },
+  {
+    image: (
+      <ImageCredited src="https://plus.unsplash.com/premium_photo-1696886122527-e4303b76aa8f?q=80&w=5156&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
+    tagText: "arrangement",
+    title: "Fars Legestue",
+    description: "Kom forbi til hygge i Fars Legestue",
+    location: "Hovedbiblioteket",
+    price: "60 KR",
+    href: "/",
+    date: "2023-01-12",
+    time: "18:00 - 20:00",
+  },
+  {
+    image: (
+      <ImageCredited src="https://images.unsplash.com/photo-1549277513-f1b32fe1f8f5?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
+    tagText: "arrangement",
+    title: "Fars Legestue",
+    description: "Kom forbi til hygge i Fars Legestue",
+    location: "Hovedeblibloteket",
+    price: "60 KR",
+    href: "/",
+    date: "2023-01-13",
+    time: "18:00 - 20:00",
+  },
+  {
+    image: (
+      <ImageCredited src="https://plus.unsplash.com/premium_photo-1696886122527-e4303b76aa8f?q=80&w=5156&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" />
+    ),
+    tagText: "arrangement",
+    title: "Fars Legestue",
+    description: "Kom forbi til hygge i Fars Legestue",
+    location: "Hovedeblibloteket",
+    price: "60 KR",
+    href: "/",
+    date: "2023-01-14",
+    time: "18:00 - 20:00",
+  },
+];
+
+export default FilteredListData;

--- a/src/stories/Library/filtered-event-list/FilteredEventlist.tsx
+++ b/src/stories/Library/filtered-event-list/FilteredEventlist.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from "react";
+import {
+  ContentListItem,
+  ContentListItemProps,
+} from "../content-list-item/ContentListItem";
+
+interface PromoteEventsListProps {
+  title: string;
+  events: ContentListItemProps[];
+  buttonText: string;
+  buttonShowLessText?: string;
+}
+
+const PromoteEventsList: React.FC<PromoteEventsListProps> = ({
+  title,
+  events,
+  buttonText,
+  buttonShowLessText,
+}) => {
+  useEffect(() => {
+    require("../../utils/show-more");
+  }, []);
+
+  return (
+    <div className="filtered-event-list" data-show-more-list-wrapper>
+      <h2 className="filtered-event-list__heading">{title}</h2>
+      <ul
+        className="filtered-event-list__list"
+        data-show-more-list
+        data-initial-visible-items="2"
+        data-hide-list-button-after-expand="false"
+        data-show-more-list-id="filtered-event-list"
+      >
+        {events.map((event) => (
+          <li className="filtered-event-list__list-item" data-show-more-item>
+            <ContentListItem {...event} />
+          </li>
+        ))}
+      </ul>
+      <button
+        className="filtered-event-list__button btn-primary btn-outline btn-medium"
+        type="button"
+        data-show-more-button
+        data-show-more-text={buttonText}
+        data-show-less-text={buttonShowLessText}
+      >
+        {buttonText}
+      </button>
+    </div>
+  );
+};
+export default PromoteEventsList;

--- a/src/stories/Library/filtered-event-list/filtered-event-list.scss
+++ b/src/stories/Library/filtered-event-list/filtered-event-list.scss
@@ -1,0 +1,28 @@
+.filtered-event-list {
+  @include layout-container($layout__max-width--medium);
+}
+.filtered-event-list__heading {
+  @include typography($typo__h2);
+  margin-bottom: $s-xl;
+}
+.filtered-event-list__list-item {
+  border-bottom: 1px solid $color__global-tertiary-1;
+
+  &--hidden {
+    display: none;
+  }
+
+  &:first-child {
+    border-top: 1px solid $color__global-tertiary-1;
+  }
+}
+
+.filtered-event-list__button {
+  width: min-content;
+  margin: 0 auto;
+  margin-top: $s-xl;
+
+  &--hidden {
+    display: none;
+  }
+}

--- a/src/stories/Library/tag/tag-list/TagList.tsx
+++ b/src/stories/Library/tag/tag-list/TagList.tsx
@@ -17,8 +17,13 @@ const TagList: FC<TagListProps> = ({ tags }) => {
   return (
     <>
       {tags.length > 1 && (
-        <div data-show-more-list className="tag-list">
-          <ul>
+        <div data-show-more-list-wrapper className="tag-list">
+          <ul
+            data-show-more-list
+            data-initial-visible-items="3"
+            data-hide-list-button-after-expand="false"
+            data-show-more-list-id="tag-list"
+          >
             {tags.map((tag, index) => (
               <li data-show-more-item>
                 <Tag key={index} hasBackground size="large">
@@ -31,6 +36,8 @@ const TagList: FC<TagListProps> = ({ tags }) => {
             className="tag tag--fill cursor-pointer"
             aria-expanded="false"
             data-show-more-button
+            data-show-more-text="..."
+            data-show-less-text="-"
           >
             ...
           </button>

--- a/src/stories/utils/show-more.md
+++ b/src/stories/utils/show-more.md
@@ -9,33 +9,45 @@ Follow these steps to implement this feature effectively:
 Structure your HTML elements as follows for implementing the
 "Show More/Less" feature:
 
-- **List Element**:
-Use an wrapper element with the `data-show-more-list` attribute
-This element will contain both the list items and the toggle button.
+- **List wrapper**:
+Assign this value to the element that will wrap both the list and the button  
+associated with the list. Use a wrapper element with the  
+`data-show-more-list-wrapper` attribute.
+- **List**:
+Assign this to the list you want to control. Include the following data  
+attributes for the element:
+  - `data-show-more-list`: Indicates that this list is controlled by the show  
+  more/less functionality.
+  - `[data-show-more-list-id`: Indicates a an ID for the list. The ID is used  
+  to set aria-controls on the button to the list, and sets a list-id-X  
+  attribute on the list.
+  - `data-initial-visible-items`: Specifies the initial number of items visible.
+   This is optional and defaults to the total number of items if not set.
+  - `data-hide-list-button-after-expand="true"`: Specifies whether to hide the  
+  button  after expanding the list. Add this with value of `true` if you do  
+  not want the button to be displayed after the list is  
+expanded, otherwise do not add it.
 - **List Items**:
 Assign the `data-show-more-item` attribute to each list item that you want
 to show or hide.
 - **Toggle Button**:
-Place a button within the list element with the `data-show-more-button`
+Place a button within the list element with the data-show-more-button  
 attribute. This button is used by users to toggle the visibility of list items.
-- **ARIA Expanded**:
-Add the `aria-expanded="false"` attribute to the button to indicate the current
-state (expanded or collapsed) of the additional content.
-- **Show More Text (Optional)**:
-Use the `data-show-more-text` attribute on the button to specify the text
-displayed when there's more content to show.
-- **Show Less Text (Optional)**:
-Use the `data-show-more-hide-text` attribute on the button to specify the text
-displayed when the list is in its collapsed state.
-- **Initial Visible Items (Optional)**:
-Set the initial number of visible items with the
-`data-show-more-initial-visible-items` attribute. It defaults to 2 if not set.
+  - `data-show-more-text`: Specifies the text displayed on the button when  
+  there are more items to show.
+  - `data-show-less-text`: Specifies the text displayed on the button when  
+  the list is fully expanded.
+- **AARIA Attributes**:
+  - `aria-expanded`: Add the aria-expanded="false" attribute to the button to  
+   indicate the initial state (expanded or collapsed) of the additional content.
+  - `aria-controls`: This will be added to the button with a reference to  
+  the list it controls.
 
 ### Example HTML Markup
 
 ```html
-<div data-show-more-list>
-  <ul>
+<div data-show-more-list-wrapper>
+  <ul data-show-more-list="true" data-initial-visible-items="2" data-hide-list-button-after-expand>
     <li data-show-more-item>Item 1</li>
     <li data-show-more-item>Item 2</li>
     <!-- additional items are hidden by default -->
@@ -44,12 +56,12 @@ Set the initial number of visible items with the
   <button
     class="cursor-pointer"
     aria-expanded="false"
-    data-show-more-button
+    data-show-more-button="true"
     data-show-more-text="Show more"
-    data-show-more-hide-text="Show less"
-    data-show-more-initial-visible-items="2"
+    data-show-less-text="Show less"
   >
     Show more
   </button>
 </div>
+
 ``````


### PR DESCRIPTION
#### Link to issue

[DDFFORM-69](https://reload.atlassian.net/browse/DDFFORM-69)

This PR depends on a PR in the design system : https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1002

#### Description

This PR adds the markup for the new component "Filtered event list". 

- Add component, story, test data and css for filtered event list. 
- extend/refactor `show-more.js` logic with more functionality for controlling wheter a button should be displayed or not after a list is expanded. Moved some namings/data-attributes around. 

Comment on this logic and test it out please. 

- Update existing components using `show-more.js` logic. Currently this should only be `<TagList/>`. If you think this is incorrect comment it. 


Chromatic is left unaccepted on purpose to see changes. Will accept once approved. 

Once again, we see weird chromatic changes that should not be associated with these changes. 


#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-cms/assets/13272656/c3ce6edb-7497-481e-8b29-2028276e672f)


[DDFFORM-69]: https://reload.atlassian.net/browse/DDFFORM-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ