### PR TITLE
DDFLSBP-528/add status message story and styling for succesful webform submission

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -135,6 +135,7 @@
 @import "./src/stories/Library/icon-text-link/icon-text-link";
 @import "./src/stories/Library/material-grid/material-grid";
 @import "./src/stories/Library/error-message/error-message";
+@import "./src/stories/Library/status-message/status-message";
 @import "./src/stories/Library/dialog/dialog";
 @import "./src/stories/Library/opening-hours-editor/opening-hours-editor";
 @import "./src/stories/Library/opening-hours/opening-hours";

--- a/src/stories/Library/status-message/StatusMessage.stories.tsx
+++ b/src/stories/Library/status-message/StatusMessage.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+
+import { StatusMessage } from "./StatusMessage";
+
+export default {
+  title: "Library / Status Message",
+  component: StatusMessage,
+  decorators: [withDesign],
+  argTypes: {},
+  parameters: {},
+} as ComponentMeta<typeof StatusMessage>;
+
+const Template: ComponentStory<typeof StatusMessage> = (args) => (
+  <StatusMessage {...args} />
+);
+
+export const ShortStatus = Template.bind({});
+ShortStatus.args = {
+  message: "Handling gennemført.",
+};
+export const LongStatus = Template.bind({});
+LongStatus.args = {
+  message:
+    "Handling gennemført. Du kan nu consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Prøv igen senere.",
+};

--- a/src/stories/Library/status-message/StatusMessage.tsx
+++ b/src/stories/Library/status-message/StatusMessage.tsx
@@ -1,0 +1,28 @@
+import { ReactComponent as CheckIcon } from "../../../public/icons/basic/icon-check.svg";
+
+export type StatusMessageProps = {
+  message: string;
+};
+
+export const StatusMessage = ({ message }: StatusMessageProps) => {
+  return (
+    <div className="status-message">
+      <CheckIcon className="status-message__icon" />
+      <div className="status-message__description">
+        <div id="dpl-react-apps-status-messages">{message}</div>
+      </div>
+
+      <button
+        type="button"
+        aria-describedby="describemodal"
+        className="status-message__btn-close"
+        aria-label="close modal"
+      >
+        <img
+          src="icons/collection/CloseLarge.svg"
+          alt="close status message button"
+        />
+      </button>
+    </div>
+  );
+};

--- a/src/stories/Library/status-message/status-message.scss
+++ b/src/stories/Library/status-message/status-message.scss
@@ -1,0 +1,60 @@
+.status-message {
+  background-color: $color__global-secondary;
+  padding: $s-md;
+  display: flex;
+  align-items: center;
+
+  @include media-query__x-small {
+    display: flex;
+    align-items: center;
+    padding: $s-md $s-xl $s-md $s-xl;
+  }
+
+  &__icon {
+    margin-right: $s-sm;
+    min-width: 40px;
+  }
+
+  &__description {
+    color: $color__text-primary-black;
+    @include typography($typo__body-placeholder);
+    padding: $s-md $s-sm;
+    max-width: 82%;
+    line-height: 120%;
+
+    @include media-query__large {
+      max-width: 85%;
+    }
+  }
+
+  &__btn-close {
+    background-color: transparent;
+    position: fixed;
+    top: 0;
+    right: 0;
+    padding: $s-sm;
+    transition: 0.3s;
+    z-index: $z-15;
+    margin: $s-sm;
+
+    @include media-query__small {
+      position: relative;
+      top: auto;
+      right: auto;
+      margin: $s-sm $s-sm $s-sm auto;
+      padding: 0;
+    }
+
+    &:hover {
+      transform: rotateZ(90deg);
+    }
+
+    & > img {
+      width: 15px;
+
+      @include media-query__small {
+        width: 18px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-528

#### Description

When the user submits a webform, the submission notification status message was not styled. Thus I created a new story for status-messages. It largely resembles the error-message styling, but using the icon-check instead of icon-warning.

#### Screenshot of the result

Design system: short message:
<img width="1433" alt="Screenshot 2024-04-24 at 00 03 31" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/6142323/40d16f66-0a92-4408-aed1-37fccbf7aa9b">

Design system: long message:
<img width="1433" alt="Screenshot 2024-04-24 at 00 04 44" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/6142323/3a126f88-5e56-4f78-a435-7a510374837f">
