### PR TITLE
Fix/mobile sidebar accessible on desktop

### DIFF
--- a/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
+++ b/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
@@ -16,6 +16,10 @@ $_menu_animation_delay: 0.2s;
   transform: translateX(-100%);
   transition: transform $_transition_speed $_bezier_transition;
 
+  @include media-query__small {
+    display: none;
+  }
+
   ul.header__menu-navigation {
     padding: 0;
     display: flex;

--- a/src/stories/Library/header-sidebar-nav/header-sidebar-nav.stories.tsx
+++ b/src/stories/Library/header-sidebar-nav/header-sidebar-nav.stories.tsx
@@ -27,6 +27,11 @@ export default {
       defaultValue: "open",
       control: { type: "select", options: ["open", "closed"] },
     },
+    isStorybookContext: {
+      name: "Are we in storybook?",
+      defaultValue: true,
+      control: { type: "none" },
+    },
   },
 } as ComponentMeta<typeof HeaderSidebarNav>;
 

--- a/src/stories/Library/header-sidebar-nav/header-sidebar-nav.tsx
+++ b/src/stories/Library/header-sidebar-nav/header-sidebar-nav.tsx
@@ -6,11 +6,13 @@ import MenuItemList from "../header-menu-list/HeaderMenuList";
 export type HeaderSidebarNavProps = {
   menuLinks: MenuItemsProps[];
   menuOpen?: "open" | "closed";
+  isStorybookContext?: boolean;
 };
 
 const HeaderSidebarNav: React.FC<HeaderSidebarNavProps> = ({
   menuLinks,
   menuOpen = "closed",
+  isStorybookContext = false,
 }) => {
   useEffect(() => {
     /* eslint-disable-next-line global-require */
@@ -18,7 +20,13 @@ const HeaderSidebarNav: React.FC<HeaderSidebarNavProps> = ({
   }, []);
 
   return (
-    <div className="header-sidebar-nav" data-open={menuOpen}>
+    <div
+      className="header-sidebar-nav"
+      data-open={menuOpen}
+      // The sidebar normally isn't displayed on larger screens (otherwise it's
+      // accessible using keyboard on desktop), but we want to show it in Storybook.
+      style={isStorybookContext ? { display: "block" } : undefined}
+    >
       <div className="header-sidebar-nav__background-wrapper">
         <div className="header-sidebar-nav__menu-wrapper">
           <div


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-555

#### Description
- Make the header-sidebar-nav not display on desktop. Otherwise it's accessible by keyboard, which is an accessibility issue.
- Make sure the "Header sidebar nav" story displays on desktop. Despite the fact that the sidebar nav isn't supposed to be displayed at all on desktops. We just make sure to display it in storybook.

#### Screenshot of the result
-
#### Additional comments or questions
-
