### PR TITLE
Add EventListStacked component.

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -138,6 +138,7 @@
 @import "./src/stories/Library/opening-hours/opening-hours";
 @import "./src/stories/Library/opening-hours/opening-hours-skeleton";
 @import "./src/stories/Library/filtered-event-list/filtered-event-list";
+@import "./src/stories/Library/event-list-stacked/event-list-stacked";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/src/stories/Library/event-list-stacked/EventListStacked.tsx
+++ b/src/stories/Library/event-list-stacked/EventListStacked.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ContentListItem } from "../content-list-item/ContentListItem";
+import ContentListItemStacked from "../content-list-item/ContentListItemStacked";
+import contentListData from "../content-list/ContentListData";
+
+interface PromoteEventsListProps {
+  title: string;
+}
+
+const EventListStacked: React.FC<PromoteEventsListProps> = ({ title }) => {
+  return (
+    <section className="event-list-stacked">
+      <h2 className="event-list-stacked__heading">{title}</h2>
+      <ContentListItem {...contentListData[0]} />
+      {contentListData.map((event) => (
+        <ContentListItemStacked
+          title={event.title}
+          href={event.href}
+          time={event.time}
+          date={event.date}
+        />
+      ))}
+    </section>
+  );
+};
+export default EventListStacked;

--- a/src/stories/Library/event-list-stacked/event-list-stacked.scss
+++ b/src/stories/Library/event-list-stacked/event-list-stacked.scss
@@ -1,0 +1,9 @@
+.event-list-stacked {
+  @include layout-container($layout__max-width--medium);
+  @include block-spacing();
+}
+
+.event-list-stacked__heading {
+  @include typography($typo__h2);
+  margin-bottom: $s-xl;
+}

--- a/src/stories/Library/event-list-stacked/eventListStacked.stories.tsx
+++ b/src/stories/Library/event-list-stacked/eventListStacked.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import EventListStacked from "./EventListStacked";
+
+export default {
+  title: "Library/ Stacked Event List",
+
+  component: EventListStacked,
+  argTypes: {
+    title: {
+      defaultValue: "Kommende arrangementer",
+      control: "text",
+      description: "Title of the section",
+    },
+  },
+} as ComponentMeta<typeof EventListStacked>;
+
+const Template: ComponentStory<typeof EventListStacked> = (args) => (
+  <EventListStacked {...args} />
+);
+
+export const FilteredList = Template.bind({});


### PR DESCRIPTION

#### Link to issue

[DDFFORM-126](https://reload.atlassian.net/browse/DDFFORM-126)

Related CMS PR https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1054

#### Description

This PR adds a component and styling for "event-list-stacked". 

This is a similar view to the stacked events used on /events, but this will be used on eventseries pages to display the individual instances in the series as a temporary solution. 


Look away form the chromatic changes that are not related to the newly introduced component.



#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/13272656/f8ca26dd-c58f-41d4-88e5-75193646697a)




[DDFFORM-126]: https://reload.atlassian.net/browse/DDFFORM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ