### PR TITLE
Add focus on next item after "show more" click in `nav-grid`

### DIFF
--- a/src/stories/Library/nav-grid/init-nav-grid.js
+++ b/src/stories/Library/nav-grid/init-nav-grid.js
@@ -13,6 +13,15 @@ window.addEventListener("load", () => {
 
     button.addEventListener("click", () => {
       grid.classList.remove("nav-grid--folded");
+
+      // The 7th item is the first one that is initially hidden.
+      // For more details, refer to the ".nav-grid--folded" class in design-system src/stories/Library/nav-grid/nav-grid.scss
+      const seventhNavGridItem = grid.querySelector(
+        ".nav-grid__item:nth-child(7)"
+      );
+      if (seventhNavGridItem) {
+        seventhNavGridItem.querySelector("a").focus();
+      }
     });
   });
 });

--- a/src/stories/Library/nav-grid/init-nav-grid.js
+++ b/src/stories/Library/nav-grid/init-nav-grid.js
@@ -11,16 +11,15 @@ window.addEventListener("load", () => {
       return;
     }
 
+    const firstHiddenLink = Array.from(grid.querySelectorAll(".nav-grid__item"))
+      .find((item) => window.getComputedStyle(item).display === "none")
+      ?.querySelector("a");
+
     button.addEventListener("click", () => {
       grid.classList.remove("nav-grid--folded");
 
-      // The 7th item is the first one that is initially hidden.
-      // For more details, refer to the ".nav-grid--folded" class in design-system src/stories/Library/nav-grid/nav-grid.scss
-      const seventhNavGridItem = grid.querySelector(
-        ".nav-grid__item:nth-child(7)"
-      );
-      if (seventhNavGridItem) {
-        seventhNavGridItem.querySelector("a").focus();
+      if (firstHiddenLink) {
+        firstHiddenLink.focus();
       }
     });
   });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-612

#### Description
This pull request ensures that the next item link in the `nav-grid` receives focus after the "show more" button is clicked.


#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/49920322/847b75e1-ac7c-4335-b7be-2209082ade20

