### PR TITLE
Add workflow that creates a pr externally in the dpl-cms repo

### DIFF
--- a/.github/workflows/create-cms-pr.yml
+++ b/.github/workflows/create-cms-pr.yml
@@ -1,0 +1,65 @@
+name: Create CMS PR
+on:
+  workflow_run:
+    workflows: ["Create release on branch changes"]
+    types:
+      - completed
+
+jobs:
+  invoke-external-pr-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-info.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Set env variables
+        run: |
+          RELEASE_BRANCH=$(jq -r '.release_branch' release-info.json)
+          RELEASE_DOWNLOAD_URL=$(jq -r '.release_download_url' release-info.json)
+          DEPENDENCY_PACKAGE=$(jq -r '.dependency_package' release-info.json)
+          echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> $GITHUB_ENV
+          echo "RELEASE_DOWNLOAD_URL=$RELEASE_DOWNLOAD_URL" >> $GITHUB_ENV
+          echo "DEPENDENCY_PACKAGE=$DEPENDENCY_PACKAGE" >> $GITHUB_ENV
+
+      - name: Invoke external PR workflow
+        id: invoke_external_pr_workflow
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url:  ${{ env.REQUEST_URL}}
+          method: 'POST'
+          customHeaders: |
+            {
+              "Accept": "application/vnd.github+json",
+              "Authorization": "Bearer ${{ secrets.CMS_PR_CREATION_PAT }}"
+            }
+          data: |
+            {
+              "event_type": "create_pr",
+              "client_payload": {
+                "branch": "${{ env.RELEASE_BRANCH }}",
+                "build_url": "${{ env.RELEASE_DOWNLOAD_URL }}",
+                "dependency_package": "${{ env.DEPENDENCY_PACKAGE }}"
+              }
+            }
+        env:
+          REQUEST_URL: ${{ format('https://api.github.com/repos/{0}/dispatches', vars.REMOTE_REPO_GITHUB_HANDLE) }}
+        # Only invoke external PR workflow if the release branch is not develop or main
+        if: ${{ !contains(fromJSON('["develop", "main"]'), env.RELEASE_BRANCH) }}
+
+      - name: Adding summary
+        run: |
+          echo "Requested external PR at: ${REMOTE_REPO_GITHUB_HANDLE}" >> $GITHUB_STEP_SUMMARY
+          echo "Based on the [${{ env.RELEASE_BRANCH }}](${{ env.BRANCH_URL }}) branch" >> $GITHUB_STEP_SUMMARY
+        if: ${{ steps.invoke_external_pr_workflow.outcome == 'success' }}
+        env:
+          BRANCH_URL: "${{ github.event.repository.html_url }}/tree/${{ env.RELEASE_BRANCH }}"
+          REMOTE_REPO_GITHUB_HANDLE: "${{ vars.REMOTE_REPO_GITHUB_HANDLE }}"
+
+      - name: Adding summary about skip if branch is develop or main
+        run: |
+          echo "Skipped PR creation because the branch was: $RELEASE_BRANCH " >> $GITHUB_STEP_SUMMARY
+          echo "...which is not considered being a release branch. " >> $GITHUB_STEP_SUMMARY
+        if: ${{ contains(fromJSON('["develop", "main"]'), env.RELEASE_BRANCH) }}

--- a/.github/workflows/create-cms-pr.yml
+++ b/.github/workflows/create-cms-pr.yml
@@ -1,3 +1,11 @@
+# This workflow is triggered when the "Create release on branch changes" workflow is completed.
+# It downloads the release information from the previous workflow and invokes the external PR workflow.
+# The external PR workflow is invoked only if the release branch is not develop or main.
+# Needed secrets:
+#   GITHUB_TOKEN - for downloading the release information from the previous workflow
+#   CMS_PR_CREATION_PAT - for invoking the external PR workflow. A Token with the "repo" scope is needed.
+# Needed env variables:
+#   REMOTE_REPO_GITHUB_HANDLE - is the GitHub handle ([ORG]/[REPO]) of the repository where the external PR workflow is located.
 name: Create CMS PR
 on:
   workflow_run:

--- a/.github/workflows/create-cms-pr.yml
+++ b/.github/workflows/create-cms-pr.yml
@@ -12,9 +12,6 @@ on:
       releaseBranch:
         description: 'Release Branch'
         required: true
-      releaseDownloadUrl:
-        description: 'Release Download Url'
-        required: true
       dependencyPackage:
         description: 'Dependency Package'
         required: true
@@ -39,7 +36,6 @@ jobs:
               "event_type": "create_pr",
               "client_payload": {
                 "branch": "${{ inputs.releaseBranch }}",
-                "build_url": "${{ inputs.releaseDownloadUrl }}",
                 "dependency_package": "${{ inputs.dependencyPackage }}"
               }
             }

--- a/.github/workflows/create-cms-pr.yml
+++ b/.github/workflows/create-cms-pr.yml
@@ -2,36 +2,27 @@
 # It downloads the release information from the previous workflow and invokes the external PR workflow.
 # The external PR workflow is invoked only if the release branch is not develop or main.
 # Needed secrets:
-#   GITHUB_TOKEN - for downloading the release information from the previous workflow
 #   CMS_PR_CREATION_PAT - for invoking the external PR workflow. A Token with the "repo" scope is needed.
 # Needed env variables:
 #   REMOTE_REPO_GITHUB_HANDLE - is the GitHub handle ([ORG]/[REPO]) of the repository where the external PR workflow is located.
 name: Create CMS PR
 on:
-  workflow_run:
-    workflows: ["Create release on branch changes"]
-    types:
-      - completed
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'Release Branch'
+        required: true
+      releaseDownloadUrl:
+        description: 'Release Download Url'
+        required: true
+      dependencyPackage:
+        description: 'Dependency Package'
+        required: true
 
 jobs:
   invoke-external-pr-workflow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-info.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Set env variables
-        run: |
-          RELEASE_BRANCH=$(jq -r '.release_branch' release-info.json)
-          RELEASE_DOWNLOAD_URL=$(jq -r '.release_download_url' release-info.json)
-          DEPENDENCY_PACKAGE=$(jq -r '.dependency_package' release-info.json)
-          echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> $GITHUB_ENV
-          echo "RELEASE_DOWNLOAD_URL=$RELEASE_DOWNLOAD_URL" >> $GITHUB_ENV
-          echo "DEPENDENCY_PACKAGE=$DEPENDENCY_PACKAGE" >> $GITHUB_ENV
-
       - name: Invoke external PR workflow
         id: invoke_external_pr_workflow
         uses: fjogeleit/http-request-action@v1
@@ -47,27 +38,27 @@ jobs:
             {
               "event_type": "create_pr",
               "client_payload": {
-                "branch": "${{ env.RELEASE_BRANCH }}",
-                "build_url": "${{ env.RELEASE_DOWNLOAD_URL }}",
-                "dependency_package": "${{ env.DEPENDENCY_PACKAGE }}"
+                "branch": "${{ inputs.releaseBranch }}",
+                "build_url": "${{ inputs.releaseDownloadUrl }}",
+                "dependency_package": "${{ inputs.dependencyPackage }}"
               }
             }
         env:
           REQUEST_URL: ${{ format('https://api.github.com/repos/{0}/dispatches', vars.REMOTE_REPO_GITHUB_HANDLE) }}
         # Only invoke external PR workflow if the release branch is not develop or main
-        if: ${{ !contains(fromJSON('["develop", "main"]'), env.RELEASE_BRANCH) }}
+        if: ${{ !contains(fromJSON('["develop", "main"]'), inputs.releaseBranch) }}
 
       - name: Adding summary
         run: |
           echo "Requested external PR at: ${REMOTE_REPO_GITHUB_HANDLE}" >> $GITHUB_STEP_SUMMARY
-          echo "Based on the [${{ env.RELEASE_BRANCH }}](${{ env.BRANCH_URL }}) branch" >> $GITHUB_STEP_SUMMARY
+          echo "Based on the [${{ inputs.releaseBranch }}](${{ env.BRANCH_URL }}) branch" >> $GITHUB_STEP_SUMMARY
         if: ${{ steps.invoke_external_pr_workflow.outcome == 'success' }}
         env:
-          BRANCH_URL: "${{ github.event.repository.html_url }}/tree/${{ env.RELEASE_BRANCH }}"
+          BRANCH_URL: "${{ github.event.repository.html_url }}/tree/${{ inputs.releaseBranch }}"
           REMOTE_REPO_GITHUB_HANDLE: "${{ vars.REMOTE_REPO_GITHUB_HANDLE }}"
 
       - name: Adding summary about skip if branch is develop or main
         run: |
           echo "Skipped PR creation because the branch was: $RELEASE_BRANCH " >> $GITHUB_STEP_SUMMARY
           echo "...which is not considered being a release branch. " >> $GITHUB_STEP_SUMMARY
-        if: ${{ contains(fromJSON('["develop", "main"]'), env.RELEASE_BRANCH) }}
+        if: ${{ contains(fromJSON('["develop", "main"]'), inputs.releaseBranch) }}

--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -85,6 +85,21 @@ jobs:
           body: ${{ env.RELEASE_DESCRIPTION }}
           files: ${{ env.DIST_FILENAME }}
 
+      - name: Write release information in artifact file
+        run: |
+            printf '{
+              "release_branch": "${{ env.RELEASE_BRANCH }}",
+              "dependency_package": "danskernesdigitalebibliotek/dpl-design-system",
+              "release_download_url": "${{ env.DOWNLOAD_URL }}"
+            }' >> release-info.json
+        env:
+          DOWNLOAD_URL: "${{ github.event.repository.html_url }}/releases/download/${{ env.TAG_NAME }}/${{ env.DIST_FILENAME }}"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-info.json
+          path: ./release-info.json
+
       - name: Adding summary
         run: |
           echo "Release created 🚀😎 at: ${{ steps.create-release.outputs.url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -85,20 +85,15 @@ jobs:
           body: ${{ env.RELEASE_DESCRIPTION }}
           files: ${{ env.DIST_FILENAME }}
 
-      - name: Write release information in artifact file
+      - name: Dispatch CMS PR creation workflow
         run: |
-            printf '{
-              "release_branch": "${{ env.RELEASE_BRANCH }}",
-              "dependency_package": "danskernesdigitalebibliotek/dpl-design-system",
-              "release_download_url": "${{ env.DOWNLOAD_URL }}"
-            }' >> release-info.json
+          gh workflow run create-cms-pr.yml \
+          -f releaseBranch=${{ env.RELEASE_BRANCH }} \
+          -f releaseDownloadUrl=${{ env.DOWNLOAD_URL }} \
+          -f dependencyPackage=danskernesdigitalebibliotek/dpl-design-system
         env:
+          GH_TOKEN: ${{ github.token }}
           DOWNLOAD_URL: "${{ github.event.repository.html_url }}/releases/download/${{ env.TAG_NAME }}/${{ env.DIST_FILENAME }}"
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: release-info.json
-          path: ./release-info.json
 
       - name: Adding summary
         run: |

--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -89,11 +89,9 @@ jobs:
         run: |
           gh workflow run create-cms-pr.yml \
           -f releaseBranch=${{ env.RELEASE_BRANCH }} \
-          -f releaseDownloadUrl=${{ env.DOWNLOAD_URL }} \
           -f dependencyPackage=danskernesdigitalebibliotek/dpl-design-system
         env:
           GH_TOKEN: ${{ github.token }}
-          DOWNLOAD_URL: "${{ github.event.repository.html_url }}/releases/download/${{ env.TAG_NAME }}/${{ env.DIST_FILENAME }}"
 
       - name: Adding summary
         run: |


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-643

#### Description

This PR adds a Github Workflow `create-cms-pr` that requests [dpl-cms to create a PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1158).
For separation of concerns the workflow is triggered by the `create-release-on-branch-changes` workflow. In that way we try to avoid leaving all steps in the `create-release-on-branch-changes` and isolate the remote pr action steps in a separate yml file.

The changes here are similar to the changes in the [dpl-react repo](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1208).

#### Additional comments or questions
We need to set secrret and variables similiar to what has been set in:
https://github.com/reload/poc-dpl-design-system-pr-trigger