### PR TITLE
DDFFORM 611 backend anbefalings komp

### DIFF
--- a/admin-base.scss
+++ b/admin-base.scss
@@ -1,0 +1,6 @@
+@import "./src/styles/scss/tools";
+
+// CSS sheets that are used to style the admin interface.
+@import "./src/stories/Library/opening-hours-editor/opening-hours-editor";
+@import "./src/stories/Library/material-search/material-search";
+@import "./src/stories/Library/cover/cover";

--- a/base.scss
+++ b/base.scss
@@ -142,6 +142,7 @@
 @import "./src/stories/Library/opening-hours/opening-hours-skeleton";
 @import "./src/stories/Library/filtered-event-list/filtered-event-list";
 @import "./src/stories/Library/event-list-stacked/event-list-stacked";
+@import "./src/stories/Library/material-search/material-search";
 
 // Autosuggest block styling needs to be loaded before the rest of the scss for autosuggest
 @import "./src/stories/Blocks/autosuggest/autosuggest";

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "css:lint": "concurrently 'yarn:css:stylelint' 'yarn:css:prettier -- --check' --raw",
     "css:lint:watch": "chokidar 'src/**/*.scss' -c 'yarn css:lint'",
     "css:format": "concurrently 'yarn:css:stylelint -- --fix' 'yarn:css:prettier -- --write' --max-processes 1 --raw",
-    "css:build": "sass base.scss:src/styles/css/base.css wysiwyg.scss:src/styles/css/wysiwyg.css src/stories/Library/opening-hours-editor/opening-hours-editor.scss:src/styles/css/opening-hours-editor.css --style compressed",
+    "css:build": "sass base.scss:src/styles/css/base.css wysiwyg.scss:src/styles/css/wysiwyg.css admin-base.scss:src/styles/css/admin-base.css --style compressed",
     "css:watch": "yarn css:build -- --watch",
     "build": "concurrently 'yarn:css:build' --raw",
     "markdown:lint": "markdownlint-cli2",

--- a/src/stories/Library/cover/Cover.tsx
+++ b/src/stories/Library/cover/Cover.tsx
@@ -6,6 +6,7 @@ import { CoverProps } from "./types";
 
 const Cover: FC<CoverProps> = ({
   size,
+  displaySize,
   animate,
   src,
   tint,
@@ -16,11 +17,13 @@ const Cover: FC<CoverProps> = ({
 }) => {
   const [imageLoaded, setImageLoaded] = useState<boolean | null>(null);
 
+  const coverDisplaySize = displaySize || size;
+
   const classes = {
     wrapper: clsx(
       "cover",
-      `cover--size-${size}`,
-      `cover--aspect-${size}`,
+      `cover--size-${coverDisplaySize}`,
+      `cover--aspect-${coverDisplaySize}`,
       imageLoaded || tintClasses[tint || "default"]
     ),
   };

--- a/src/stories/Library/cover/cover.scss
+++ b/src/stories/Library/cover/cover.scss
@@ -1,3 +1,5 @@
+$MATERIAL_2XSMALL_MOBILE: 52px;
+$MATERIAL_2XSMALL_DESKTOP: 68.5px;
 $MATERIAL_XSMALL_MOBILE: 104px;
 $MATERIAL_XSMALL_DESKTOP: 104px;
 $MATERIAL_SMALL_MOBILE: 104px;
@@ -10,6 +12,14 @@ $MATERIAL_XLARGE_MOBILE: 284px;
 $MATERIAL_XLARGE_DESKTOP: 460px;
 
 .cover--size {
+  &-2xsmall {
+    border-radius: 3px;
+    height: $MATERIAL_2XSMALL_MOBILE;
+    @include media-query__small {
+      height: $MATERIAL_2XSMALL_DESKTOP;
+    }
+  }
+
   &-xsmall {
     border-radius: 3px;
     height: $MATERIAL_XSMALL_MOBILE;
@@ -48,6 +58,10 @@ $MATERIAL_XLARGE_DESKTOP: 460px;
 }
 
 .cover--aspect {
+  &-2xsmall {
+    aspect-ratio: 0.69;
+  }
+
   &-xsmall {
     aspect-ratio: 0.69;
   }

--- a/src/stories/Library/cover/types.ts
+++ b/src/stories/Library/cover/types.ts
@@ -1,7 +1,11 @@
+type Sizes = "xsmall" | "small" | "medium" | "large" | "xlarge";
+type DisplaySizes = "2xsmall" | Sizes;
+
 export type CoverProps = {
   src: string;
   animate: boolean;
-  size: "xsmall" | "small" | "medium" | "large" | "xlarge";
+  size: Sizes;
+  displaySize?: DisplaySizes;
   tint?: "20" | "40" | "80" | "100" | "120";
   coverUrl?: string;
   alt?: string;

--- a/src/stories/Library/material-search/MaterialSearch.stories.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.stories.tsx
@@ -1,0 +1,51 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import MaterialSearch from "./MaterialSearch";
+
+export default {
+  title: "Library / Material Search",
+  component: MaterialSearch,
+  argTypes: {},
+} as ComponentMeta<typeof MaterialSearch>;
+
+const uniqueIdentifier = Math.floor(Math.random() * 10000);
+
+const Template: ComponentStory<typeof MaterialSearch> = () => {
+  return (
+    <div className="material-search">
+      <div className="material-search__inputs-container">
+        <label
+          className="material-search__label"
+          htmlFor="hidden-work-id-input"
+        >
+          Hidden Work ID field
+          <input
+            data-field-input-work-id={uniqueIdentifier}
+            id="hidden-work-id-input"
+            type="text"
+            placeholder=""
+            className="material-search__input"
+            disabled
+          />
+        </label>
+        <label
+          className="material-search__label"
+          htmlFor="hidden-material-type-input"
+        >
+          Hidden Material Type field
+          <input
+            type="text"
+            id="hidden-material-type-input"
+            data-field-input-material-type-id={uniqueIdentifier}
+            className="material-search__input"
+            disabled
+          />
+        </label>
+      </div>
+
+      <MaterialSearch />
+    </div>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/stories/Library/material-search/MaterialSearch.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.tsx
@@ -1,0 +1,35 @@
+import { FC, useState } from "react";
+import MaterialSearchInputs from "./MaterialSearchInputs";
+import MaterialSearchPreview from "./MaterialSearchPreview";
+import MaterialSearchList from "./MaterialSearchList";
+import { PreviewData } from "./MaterialSearchExampleData";
+
+const MaterialSearch: FC = () => {
+  const [searchInput, setSearchInput] = useState("");
+  const [selectedMaterialType, setSelectedMaterialType] = useState("");
+  const [selectedWorkId] = useState(PreviewData.workId);
+
+  const handleSetSearchInput = (value: string) => {
+    setSearchInput(value);
+  };
+
+  return (
+    <div className="material-search">
+      <MaterialSearchInputs
+        searchInput={searchInput}
+        setSearchInput={handleSetSearchInput}
+        selectedMaterialType={selectedMaterialType}
+        onMaterialTypeChange={setSelectedMaterialType}
+      />
+      <div className="material-search__materials-wrapper">
+        <MaterialSearchPreview displayMaterial={searchInput.length > 1} />
+        <MaterialSearchList
+          showListResults={searchInput.length > 1}
+          selectedWorkId={selectedWorkId}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MaterialSearch;

--- a/src/stories/Library/material-search/MaterialSearchExampleData.ts
+++ b/src/stories/Library/material-search/MaterialSearchExampleData.ts
@@ -1,0 +1,69 @@
+export const MaterialTypes = [
+  "bog",
+  "artikel",
+  "tidsskrift",
+  "lydbog",
+  "film",
+  "musik",
+  "spil",
+];
+
+export interface PreviewDataProps {
+  coverUrl: string;
+  title: string;
+  author: string;
+  publicationYear: number;
+  source: string;
+  workId: string;
+}
+export const PreviewData: PreviewDataProps = {
+  coverUrl: "images/book_cover_6.jpg",
+  title: "Rødhals",
+  author: "Jo Nesbø",
+  publicationYear: 2022,
+  source: "eReolen",
+  workId: "work-of:800010-katalog:99122475830405763",
+};
+
+export const ListResultData: PreviewDataProps[] = [
+  {
+    coverUrl: "images/book_cover_3.jpg",
+    title: "Book Title 3",
+    author: "Author 3",
+    publicationYear: 2019,
+    source: "Library",
+    workId: "work-of:800010-katalog:98432897",
+  },
+  {
+    coverUrl: "images/book_cover_2.jpg",
+    title: "Book Title 2",
+    author: "Author 2",
+    publicationYear: 2020,
+    source: "eReolen",
+    workId: "work-of:800010-katalog:2389129",
+  },
+  {
+    coverUrl: "images/book_cover_6.jpg",
+    title: "Rødhals",
+    author: "Jo Nesbø",
+    publicationYear: 2022,
+    source: "eReolen",
+    workId: "work-of:800010-katalog:99122475830405763",
+  },
+  {
+    coverUrl: "images/book_cover_4.jpg",
+    title: "Book Title 4",
+    author: "Author 4",
+    publicationYear: 2018,
+    source: "eReolen",
+    workId: "work-of:800010-katalog:9778817",
+  },
+  {
+    coverUrl: "images/book_cover_5.jpg",
+    title: "Book Title 5",
+    author: "Author 5",
+    publicationYear: 2017,
+    source: "Library",
+    workId: "work-of:800010-katalog:2093",
+  },
+];

--- a/src/stories/Library/material-search/MaterialSearchInputs.tsx
+++ b/src/stories/Library/material-search/MaterialSearchInputs.tsx
@@ -1,0 +1,55 @@
+import { MaterialTypes } from "./MaterialSearchExampleData";
+
+interface MaterialSearchInputsProps {
+  searchInput: string;
+  selectedMaterialType: string;
+  setSearchInput: (value: string) => void;
+  onMaterialTypeChange: (value: string) => void;
+}
+
+const MaterialSearchInputs = ({
+  searchInput,
+  selectedMaterialType,
+  setSearchInput,
+  onMaterialTypeChange,
+}: MaterialSearchInputsProps) => {
+  return (
+    <div className="material-search__inputs-container">
+      <label className="material-search__label" htmlFor="material-search-input">
+        Search for materials
+        <input
+          id="material-search-input"
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Enter search terms"
+          className="material-search__input"
+        />
+      </label>
+      <label
+        className="material-search__label"
+        htmlFor="material-type-selector"
+      >
+        Choose material type
+        <select
+          id="material-type-selector"
+          className="material-search__selector"
+          disabled={!searchInput}
+          onChange={(e) => onMaterialTypeChange(e.target.value)}
+          value={selectedMaterialType || ""}
+        >
+          <option value="" disabled>
+            -- Choose material type --
+          </option>
+          {MaterialTypes.map((materialType: string) => (
+            <option key={materialType} value={materialType}>
+              {materialType}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+};
+
+export default MaterialSearchInputs;

--- a/src/stories/Library/material-search/MaterialSearchList.tsx
+++ b/src/stories/Library/material-search/MaterialSearchList.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import Cover from "../cover/Cover";
+import { ListResultData } from "./MaterialSearchExampleData";
+import MaterialSearchLoading from "./MaterialSearchLoading";
+
+interface MaterialSearchListResultsProps {
+  showListResults: boolean;
+  selectedWorkId: string;
+}
+
+const MaterialSearchList = ({
+  showListResults,
+  selectedWorkId,
+}: MaterialSearchListResultsProps) => {
+  const [fictiveLoading, setFictiveLoading] = useState(showListResults);
+
+  useEffect(() => {
+    if (showListResults) {
+      setFictiveLoading(true);
+      const timer = setTimeout(() => {
+        setFictiveLoading(false);
+      }, 1500);
+
+      return () => clearTimeout(timer);
+    }
+
+    return () => {};
+  }, [showListResults]);
+
+  if (fictiveLoading && showListResults) {
+    return (
+      <div className="material-search-list">
+        <div className="material-search-list__header" />
+        <ul className="material-search-list__results">
+          <li className="material-search-list__loading">
+            <MaterialSearchLoading loadingText="Loading..." />
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  if (!showListResults) {
+    return null;
+  }
+
+  return (
+    <div className="material-search-list">
+      <div className="material-search-list__header">Total results: 5</div>
+      <ul className="material-search-list__results">
+        {ListResultData.map((work) => {
+          return (
+            <li
+              key={work.workId}
+              className={`material-search-list__item ${
+                selectedWorkId === work.workId
+                  ? "material-search-list__item--highlighted"
+                  : ""
+              }`}
+            >
+              <button
+                className="material-search-list__button"
+                data-work-id={work.workId}
+              >
+                <Cover
+                  size="large"
+                  displaySize="2xsmall"
+                  src={work.coverUrl}
+                  animate
+                />
+                <div>
+                  <div className="material-search-list__detail-item">
+                    <span className="material-search-list__term">Title:</span>
+                    <span className="material-search-list__detail">
+                      {work.title}
+                    </span>
+                  </div>
+                  <div className="material-search-list__detail-item">
+                    <span className="material-search-list__term">Author:</span>
+                    <span className="material-search-list__detail">
+                      {work.author}
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+        <li className="material-search-list__loading">
+          <MaterialSearchLoading loadingText="Loading..." />
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default MaterialSearchList;

--- a/src/stories/Library/material-search/MaterialSearchLoading.tsx
+++ b/src/stories/Library/material-search/MaterialSearchLoading.tsx
@@ -1,0 +1,20 @@
+import LoadingLogo from "../../../public/icons/logo/reload_logo_black.svg";
+
+interface ReloadLoadingIconProps {
+  loadingText: string;
+}
+
+const MaterialSearchLoading = ({ loadingText }: ReloadLoadingIconProps) => {
+  return (
+    <div className="material-search__loading">
+      <img
+        src={LoadingLogo}
+        alt=""
+        className="material-search__loading-spinner"
+      />
+      <span className="material-search__loading-text">{loadingText}</span>
+    </div>
+  );
+};
+
+export default MaterialSearchLoading;

--- a/src/stories/Library/material-search/MaterialSearchPreview.tsx
+++ b/src/stories/Library/material-search/MaterialSearchPreview.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from "react";
+import Cover from "../cover/Cover";
+import { PreviewData } from "./MaterialSearchExampleData";
+import MaterialSearchLoading from "./MaterialSearchLoading"; // Assuming this is the correct import
+
+interface MaterialSearchPreviewProps {
+  displayMaterial: boolean;
+}
+
+const MaterialSearchPreview = ({
+  displayMaterial,
+}: MaterialSearchPreviewProps) => {
+  const [fictiveLoading, setFictiveLoading] = useState(false);
+
+  useEffect(() => {
+    if (displayMaterial) {
+      setFictiveLoading(true);
+      const timer = setTimeout(() => {
+        setFictiveLoading(false);
+      }, 1500);
+
+      return () => clearTimeout(timer);
+    }
+
+    return () => {};
+  }, [displayMaterial]);
+
+  if (fictiveLoading) {
+    return (
+      <div className="material-search__preview">
+        <div className="material-search__preview-loading">
+          <MaterialSearchLoading loadingText="Loading..." />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="material-search__preview">
+      {displayMaterial ? (
+        <div className="material-search__preview-material">
+          <Cover
+            src={PreviewData.coverUrl}
+            animate
+            size="large"
+            displaySize="small"
+          />
+          <div>
+            <div className="material-search__preview-item">
+              <span className="material-search__preview-term">Title:</span>
+              <span className="material-search__preview-detail">
+                {PreviewData.title}
+              </span>
+            </div>
+            <div className="material-search__preview-item">
+              <span className="material-search__preview-term">Author:</span>
+              <span className="material-search__preview-detail">
+                {PreviewData.author}
+              </span>
+            </div>
+            <div className="material-search__preview-item">
+              <span className="material-search__preview-term">
+                Publication Year:
+              </span>
+              <span className="material-search__preview-detail">
+                {PreviewData.publicationYear}
+              </span>
+            </div>
+            <div className="material-search__preview-item">
+              <span className="material-search__preview-term">Source:</span>
+              <span className="material-search__preview-detail">
+                {PreviewData.source}
+              </span>
+            </div>
+            <div className="material-search__preview-item">
+              <span className="material-search__preview-term">Work Id:</span>
+              <span className="material-search__preview-detail">
+                {PreviewData.workId}
+              </span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="material-search__preview-empty">
+          No material selected
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MaterialSearchPreview;

--- a/src/stories/Library/material-search/material-search.scss
+++ b/src/stories/Library/material-search/material-search.scss
@@ -1,0 +1,223 @@
+// Variables
+$_gin_xs_spacing: 0.5rem;
+$_gin_m_spacing: 1rem;
+$_gin_xl_spacing: 2rem;
+$_gin_border_color: #8e929c;
+$_gin_font_weight_semibold: 525;
+$_gin-header-bg-color: #e1eafc;
+
+$_color__background-light: #eeeeed;
+$_color__hover-background: #8e929c;
+
+$_box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.25);
+$_loading-spinner-size: 40px;
+$_highlighted-item-bg-color: $_gin-header-bg-color;
+
+// Fixed preview height so the size doesn't jump if nothing is selected.
+$_preview-height: 170px;
+$_max-select-input-width: 220px;
+$_material-search-max-width: 800px;
+$list_header_height: 50px;
+
+// Material Search
+.material-search {
+  max-width: $_material-search-max-width;
+  margin-bottom: $_gin_m_spacing;
+}
+
+.material-search__label {
+  display: flex;
+  flex-direction: column;
+  gap: $_gin_xs_spacing;
+  margin-bottom: $_gin_xs_spacing;
+  font-weight: $_gin_font_weight_semibold;
+}
+
+.material-search__inputs-container {
+  display: grid;
+  grid-template-columns: 2fr minmax(auto, $_max-select-input-width);
+  gap: $_gin_m_spacing;
+  margin-bottom: $_gin_xs_spacing;
+}
+
+.material-search__inputs-container--hidden {
+  display: none; // This class is only applied in Drupal.
+}
+
+// Preview
+.material-search__preview {
+  color: $color__global-grey;
+  cursor: not-allowed;
+  display: grid;
+  background-color: $_highlighted-item-bg-color;
+  height: $_preview-height;
+  align-items: center;
+  border: 1px solid $_gin_border_color;
+  border-radius: $_gin_xs_spacing;
+  overflow: hidden;
+}
+
+.material-search__preview-material {
+  display: grid;
+  padding: 0 $_gin_m_spacing;
+  grid-template-columns: min-content auto;
+  column-gap: $_gin_m_spacing;
+  align-items: center;
+  height: 100%;
+}
+
+.material-search__preview-empty {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  background: $color__global-tertiary-1;
+  align-items: center;
+  color: $color__global-grey;
+}
+
+.material-search__preview-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  flex-direction: column;
+}
+
+.material-search__input,
+.material-search__selector {
+  border: 1px solid $_gin_border_color;
+  padding: $_gin_xs_spacing;
+  border-radius: $_gin_xs_spacing;
+  height: 100%;
+  font-family: inherit;
+
+  &:disabled {
+    background-color: $color__global-tertiary-1;
+  }
+}
+
+.material-search__preview-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: $_gin_xs_spacing;
+}
+
+.material-search__preview-term {
+  font-weight: 700;
+}
+.material-search__preview-detail {
+  width: max-content;
+}
+
+// Loading
+.material-search__loading {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.material-search__loading-spinner {
+  width: $_loading-spinner-size;
+  height: $_loading-spinner-size;
+  animation: spin 0.9s linear infinite;
+  animation-timing-function: ease-in-out;
+}
+
+.material-search__loading-text {
+  font-size: 1rem;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+// Search List
+.material-search-list {
+  border: 1px solid $_gin_border_color;
+  margin-top: $_gin_xl_spacing;
+  overflow: hidden;
+  border-radius: $_gin_xs_spacing;
+  background-color: $color__global-white;
+  position: relative;
+  overflow-y: auto;
+  height: 100%;
+  max-height: 500px;
+}
+
+.material-search-list__results {
+  display: flex;
+  flex-direction: column;
+  justify-content: left;
+  row-gap: $_gin_xs_spacing;
+  padding: $_gin_xs_spacing;
+  padding-bottom: 20px;
+  background-color: $_color__background-light;
+  margin: 0;
+}
+
+.material-search-list__item {
+  background-color: $color__global-white;
+  &--highlighted {
+    background-color: $_highlighted-item-bg-color;
+  }
+}
+
+.material-search-list__button {
+  width: 100%;
+  border: 1px solid $_gin_border_color;
+  border-radius: $_gin_xs_spacing;
+  padding: $_gin_xs_spacing;
+  display: grid;
+  grid-template-columns: min-content auto;
+  column-gap: $_gin_m_spacing;
+  justify-items: baseline;
+  align-items: center;
+  transition: scale 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+  background-color: transparent;
+
+  &:hover,
+  &:focus {
+    transform: scale(1.005);
+    box-shadow: $_box-shadow;
+    cursor: pointer;
+  }
+}
+
+.material-search-list__header {
+  display: flex;
+  width: 100%;
+  border-bottom: 1px solid $_gin_border_color;
+  height: $list_header_height;
+  align-items: center;
+  padding: 0 $_gin_m_spacing;
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  background: $color__global-white;
+  gap: $_gin_xs_spacing;
+}
+
+.material-search-list__detail-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: $_gin_xs_spacing;
+  font-size: 14px;
+}
+
+.material-search-list__term {
+  font-weight: 700;
+}
+.material-search-list__detail {
+  width: max-content;
+}
+
+.material-search-list__loading {
+  margin-top: $_gin_m_spacing;
+}


### PR DESCRIPTION
#### Link to issue

Ticket: [DDFFORM-611](https://reload.atlassian.net/browse/DDFFORM-611)

This PR Depends on: 

React PR: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1223
CMS PR: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1169

#### Description

This PR introduces the markup and styling for MaterialSearch, a component that will be used to allow searching for materials and selecting them for display in the admin interface for paragraphs using the the work_id field with the new field widget. Currently this is Recommandation and MaterialGridManual. 

You can either go commit by commit or view it as a whole. 


#### Additional comments or questions

Consider the introduction of admin-base css and comment if there are any relevant details i have missed. 

Consider both the comment and approach in the css file regarding covers. 

Remember to thoroughly test this in drupal with all changes in cohesion.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/13272656/f0164b4f-1c60-41f4-92f1-2fc4222ce5ad)

[DDFFORM-611]: https://reload.atlassian.net/browse/DDFFORM-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ