### PR TITLE
Advanced search header dropdown

### DIFF
--- a/src/stories/Blocks/header/Header.tsx
+++ b/src/stories/Blocks/header/Header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import clsx from "clsx";
 import Logo from "../../Library/logo/Logo";
 import MenuItemList from "../../Library/header-menu-list/HeaderMenuList";
 import { menuItems } from "../../Library/header-menu-list/HeaderMenuListData";
@@ -109,7 +110,9 @@ export const Header = (props: HeaderProps) => {
                 <SearchIcon className="header__menu-search-icon" />
               </form>
               <ExpandMoreIcon
-                className="header__menu-dropdown-icon"
+                className={clsx("header__menu-dropdown-icon", {
+                  "header__menu-dropdown-icon--expanded": isDropdownOpen,
+                })}
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               />
               {isDropdownOpen && (

--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -174,6 +174,13 @@
   position: absolute;
   cursor: pointer;
   right: $s-lg;
+  transition: transform 0.3s ease-in-out;
+  transform: scaleY(1);
+
+  &.header__menu-dropdown-icon--expanded {
+    transition: transform 0.3s ease-in-out;
+    transform: scaleY(-1);
+  }
 }
 
 .header__clock {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-636

#### Description
Animate advanced search header dropdown icon on click to indicate state and make it crisp.

#### Screenshot of the result
https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/28546954/e519bdc5-0329-4b0c-b0af-c17ca8e1fefe


#### Additional comments or questions
[Sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1236)

