### PR TITLE
Add "Description" for materialgrid.

### DIFF
--- a/src/stories/Library/material-grid/MaterialGrid.stories.tsx
+++ b/src/stories/Library/material-grid/MaterialGrid.stories.tsx
@@ -10,6 +10,10 @@ export default {
       control: "text",
       description: "Title of the recommendation",
     },
+    description: {
+      control: "text",
+      description: "This is a description of the materials selected",
+    },
     selectedAmountOfMaterialsForDisplay: {
       control: {
         type: "select",
@@ -28,6 +32,8 @@ export default {
   },
   args: {
     title: "Recommended materials",
+    description:
+      "This is a long description of the materials selected, or whatever else you want to put in here",
     selectedAmountOfMaterialsForDisplay: 4,
     materials: MaterialGridData,
     buttonText: "Show more",

--- a/src/stories/Library/material-grid/MaterialGrid.stories.tsx
+++ b/src/stories/Library/material-grid/MaterialGrid.stories.tsx
@@ -53,6 +53,20 @@ const Template: ComponentStory<typeof MaterialGrid> = (args) => (
 export const Default = Template.bind({});
 
 export const GridWithMoreMaterials = Template.bind({});
+
 GridWithMoreMaterials.args = {
   selectedAmountOfMaterialsForDisplay: 8,
+};
+
+export const GridWithNoDescription = Template.bind({});
+
+GridWithNoDescription.args = {
+  description: "",
+};
+
+export const GridWithNoTitleOrDescription = Template.bind({});
+
+GridWithNoTitleOrDescription.args = {
+  title: "",
+  description: "",
 };

--- a/src/stories/Library/material-grid/MaterialGrid.tsx
+++ b/src/stories/Library/material-grid/MaterialGrid.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import clsx from "clsx";
 import {
   RecommendedMaterial,
   RecommendedMaterialProps,
@@ -6,6 +7,7 @@ import {
 
 export type MaterialGridProps = {
   title: string;
+  description: string;
   selectedAmountOfMaterialsForDisplay: 4 | 8 | 12 | 16 | 20 | 24 | 28 | 32;
   materials: RecommendedMaterialProps[];
   buttonText: string;
@@ -13,6 +15,7 @@ export type MaterialGridProps = {
 
 export const MaterialGrid: React.FC<MaterialGridProps> = ({
   title,
+  description,
   selectedAmountOfMaterialsForDisplay,
   materials,
   buttonText,
@@ -38,9 +41,20 @@ export const MaterialGrid: React.FC<MaterialGridProps> = ({
     setCurrentMaterialsDisplayed(selectedAmountOfMaterialsForDisplay);
   }
 
+  const titleClasses = clsx("material-grid__title", {
+    "material-grid__title--no-description": !description,
+  });
+
   return (
     <div className="material-grid">
-      <h2 className="material-grid__title">{title}</h2>
+      {(title || description) && (
+        <div className="material-grid__text-wrapper">
+          {title && <h2 className={titleClasses}>{title}</h2>}
+          {description && (
+            <p className="material-grid__description">{description}</p>
+          )}
+        </div>
+      )}
       <ul className="material-grid__items">
         {materials
           .slice(0, currentMaterialsDisplayed)

--- a/src/stories/Library/material-grid/material-grid.scss
+++ b/src/stories/Library/material-grid/material-grid.scss
@@ -2,13 +2,30 @@
   @include layout-container($layout__max-width--large, 0);
 }
 
+.material-grid__text-wrapper {
+  @include layout-container();
+  margin-bottom: $s-lg;
+  display: flex;
+  flex-direction: column;
+  gap: $s-lg;
+}
+
 .material-grid__title {
   @include typography($typo__h2);
-  @include layout-container();
-
   @extend %title-underline--narrow;
-  margin-bottom: calc($s-lg * 2);
+
+  &--no-description {
+    margin-bottom: $s-lg;
+  }
 }
+
+.material-grid__description {
+  @include typography($typo__body-placeholder);
+  @include media-query__medium {
+    max-width: 600px;
+  }
+}
+
 .material-grid__items {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -19,7 +36,7 @@
   margin: $s-lg auto 0 auto;
 }
 
-@include media-query__medium {
+@include media-query__small {
   .material-grid__items {
     grid-template-columns: repeat(4, 1fr);
   }


### PR DESCRIPTION
#### Link to issue

Jira ticket: [DDFFORM-520](https://reload.atlassian.net/browse/DDFFORM-520)

React pr: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1238
CMS pr: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1198

#### Description

This PR updates the mark and css for the material grid component with a new prop for displaying a description for the material grid. 


#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/8ac661fc-f258-47c1-9fcd-319490da901c)


[DDFFORM-520]: https://reload.atlassian.net/browse/DDFFORM-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ