### PR TITLE
Align event description (subtitle) with articles

### DIFF
--- a/src/stories/Library/event-description/event-description.scss
+++ b/src/stories/Library/event-description/event-description.scss
@@ -20,15 +20,8 @@
 }
 
 .event-description__description {
-  @extend %rich-text;
-  @include typography($typo__body-large);
-
-  line-height: 24px;
+  @include typography($typo__subtitle);
   margin-bottom: $s-md;
-
-  @include media-query__small {
-    line-height: 32px;
-  }
 }
 
 .event-description__links {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-628

#### Description

This pull request aligns the event description (subtitle) with the articles to ensure a consistent design.

Please take a look at the visual changes in the chromatic. I have intentionally not approved them before this PR is approved

https://www.chromatic.com/build?appId=616ffdab9acbf5003ad5fd2b&number=2634
