### PR TITLE
Enhance accessibility of input and textarea fields [DDFLSBP-631]

### DIFF
--- a/src/stories/Library/Forms/input/Input.stories.tsx
+++ b/src/stories/Library/Forms/input/Input.stories.tsx
@@ -9,15 +9,24 @@ export default {
   argTypes: {
     label: {
       defaultValue: "Navn",
+      control: { type: "text" },
     },
     type: {
       defaultValue: "text",
+      control: { type: "select", options: ["text", "password"] },
     },
     id: {
       defaultValue: "id",
+      control: { type: "text" },
     },
-    description: { defaultValue: "Dit fulde navn" },
-    validation: { defaultValue: "Fejlbesked lorem ipsum dolor" },
+    description: {
+      defaultValue: "Dit fulde navn",
+      control: { type: "text" },
+    },
+    validation: {
+      defaultValue: "Fejlbesked lorem ipsum dolor",
+      control: { type: "text" },
+    },
   },
   parameters: {
     design: {

--- a/src/stories/Library/Forms/input/Input.tsx
+++ b/src/stories/Library/Forms/input/Input.tsx
@@ -15,9 +15,9 @@ const Input = (props: InputProps) => {
   const invalid = validation ? "true" : "false";
   return (
     <div
-      className={clsx("dpl-input", classNames, [
-        { "dpl-input--invalid": !!validation },
-      ])}
+      className={clsx("dpl-input", classNames, {
+        "dpl-input--invalid": !!validation,
+      })}
     >
       <Label id={id}>{label}</Label>
       <input

--- a/src/stories/Library/Forms/input/input.scss
+++ b/src/stories/Library/Forms/input/input.scss
@@ -11,7 +11,7 @@
   input {
     background-color: transparent;
     border: none;
-    border-bottom: 1px solid $color__global-tertiary-1;
+    border-bottom: 1px solid $color__global-tertiary-2;
     height: 40px;
 
     &:focus {

--- a/src/stories/Library/Forms/textarea/textarea.scss
+++ b/src/stories/Library/Forms/textarea/textarea.scss
@@ -6,7 +6,7 @@
 
     textarea {
       @include typography($typo__body-placeholder);
-      border: solid 1px $color__global-tertiary-1;
+      border: solid 1px $color__global-tertiary-2;
       width: 100%;
       padding: $s-md;
       resize: none;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-631

#### Description

Enhanced accessibility by increasing input and textarea contrast (and also fixed Input component re-renders and clsx class assignment in Storybook)

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/e56f8c11-9ec4-4606-aa42-58f3845cd767)

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/4449a8b0-f2e5-4db5-aea7-41df197f20f2)

![Skærmbillede 2024-05-30 kl  12 17 16](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/68874fe0-8f58-4908-baa0-e16e098f228a)


