### PR TITLE
Lock Chromatic GitHub action to 11.4

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn css:build
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v11
+        uses: chromaui/action@v11.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: c6b96f9648b6


### PR DESCRIPTION
#### Description

We have seen Chromatic failing with the following error. This apparently occurs after updating to versio 11.5 of the GitHub Action. Examples include:

- https://github.com/danskernesdigitalebibliotek/dpl-design-system/actions/runs/9343042365/job/25724060490?pr=652
- https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/653
- https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/651

This was the last PR when it did not fail. It uses v11.4 of the Chromatic action:

- https://github.com/danskernesdigitalebibliotek/dpl-design-system/actions/runs/9317798995/job/25648839916?pr=650

Try to lock it at 11.4 to address this. Dependabot should help us update in the future.

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:68:19)
    at Object.createHash (node:crypto:138:10)
    at module.exports (/home/runner/work/dpl-design-system/dpl-design-system/node_modules/@storybook/builder-webpack4/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/dpl-design-system/dpl-design-system/node_modules/@storybook/builder-webpack4/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/runner/work/dpl-design-system/dpl-design-system/node_modules/@storybook/builder-webpack4/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/runner/work/dpl-design-system/dpl-design-system/node_modules/@storybook/builder-webpack4/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/runner/work/dpl-design-system/dpl-design-system/node_modules/@storybook/builder-webpack4/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/runner/work/dpl-design-system/dpl-design-system/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/runner/work/dpl-design-system/dpl-design-system/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at /home/runner/work/dpl-design-system/dpl-design-system/node_modules/loader-runner/lib/LoaderRunner.js:205:4
    at /home/runner/work/dpl-design-system/dpl-design-system/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:85:15
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

#### Additional comments or questions
