### PR TITLE
DDFFORM 812 burger menu

### DIFF
--- a/src/stories/Blocks/header/Header.tsx
+++ b/src/stories/Blocks/header/Header.tsx
@@ -54,21 +54,21 @@ export const Header = (props: HeaderProps) => {
           >
             <div>
               <div className="header__menu-navigation-mobile">
-                <Pagefold
-                  isInheriting={false}
-                  isAContainer={false}
-                  size="small"
+                <button
+                  id="header-sidebar-nav__toggle"
                   className="header__menu-navigation-button header__button"
-                  compProps={{
-                    id: "header-sidebar-nav__toggle",
-                    "aria-controls": "sidebarNav",
-                    "aria-expanded": "false",
-                    role: "button",
-                    tabIndex: 0,
-                  }}
+                  aria-controls="sidebarNav"
+                  aria-expanded="false"
                 >
-                  <MenuIcon />
-                </Pagefold>
+                  <Pagefold
+                    isInheriting={false}
+                    isAContainer={false}
+                    size="small"
+                    className="header__menu-navigation-pagefold"
+                  >
+                    <MenuIcon />
+                  </Pagefold>
+                </button>
                 <div className="header__menu-navigation-logo">
                   <Logo
                     hasImage

--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -55,6 +55,13 @@
   align-items: center;
   border-right: 1px solid $color__global-tertiary-1;
 }
+.header__menu-navigation-pagefold {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 
 .header__menu-profile,
 .header__menu-bookmarked {

--- a/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
+++ b/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
@@ -16,10 +16,6 @@ $_menu_animation_delay: 0.2s;
   transform: translateX(-100%);
   transition: transform $_transition_speed $_bezier_transition;
 
-  @include media-query__small {
-    display: none;
-  }
-
   ul.header__menu-navigation {
     padding: 0;
     display: flex;
@@ -115,6 +111,10 @@ $_menu_animation_delay: 0.2s;
     --sidebar-padding: #{$s-lg};
   }
 
+  .header-sidebar-nav {
+    display: none;
+  }
+
   .header-sidebar-nav__menu-wrapper {
     max-width: 375px;
     grid-gap: $s-lg;
@@ -123,4 +123,12 @@ $_menu_animation_delay: 0.2s;
   .header-sidebar-nav__menu-items {
     padding-top: 120px;
   }
+}
+
+// This reflects the current override of the burger menu state, which is
+// controlled by the .has-burger-menu class on the html element.
+// This takes effect when the desktop-menu has too many items, and gets
+// changed to a burger menu.
+.has-burger-menu .header-sidebar-nav {
+  display: block;
 }

--- a/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
+++ b/src/stories/Library/header-sidebar-nav/header-sidebar-nav.scss
@@ -42,6 +42,8 @@ $_menu_animation_delay: 0.2s;
     text-decoration: none;
     position: relative;
     display: inline-block;
+    white-space: normal;
+    word-break: break-word;
   }
 
   .header__menu-navigation-link::after {


### PR DESCRIPTION
- **Ensure that burgermenu is not hidden when desktop is hidden.**
- **Ensure sidebar menu items do not overflow container.**

#### Link to issue

Jira : [DDFFORM-812](https://reload.atlassian.net/browse/DDFFORM-812)

cms pr: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1246

#### Description

This PR aims to ensure that the header-sidebar-nav(Menu toggled by the burgermenu) is shown, when the current menu being displayed on the site is the burgermenu. 

Whenever the burgermenu is displayed and toggled/clicked, it should now shown the menu. 

Also added a change to menu items cant overflow the sidebar container.


If chromatic is failing it should be unrelated to the issue.



[DDFFORM-812]: https://reload.atlassian.net/browse/DDFFORM-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ