### PR TITLE
Adjust layout for .warning-bar component for smaller screens [DDFLSBP-679]

### DIFF
--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -10,46 +10,46 @@
     flex-direction: row;
     padding: $s-md;
   }
-}
 
-.warning-bar__icon {
-  margin-right: $s-md;
-  min-width: 40px;
-}
-
-.warning-bar__left {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  justify-content: flex-start;
-  margin-bottom: $s-md;
-
-  @include media-query__small {
-    margin-bottom: 0;
-    width: auto;
+  &__icon {
+    margin-right: $s-md;
+    min-width: 40px;
   }
-}
 
-.warning-bar__right {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  width: 100%;
-
-  @include media-query__small {
-    flex-direction: row;
-    justify-content: flex-start;
+  &__left {
+    display: flex;
     align-items: center;
-    width: auto;
+    width: 100%;
+    justify-content: flex-start;
+    margin-bottom: $s-md;
+
+    @include media-query__small {
+      margin-bottom: 0;
+      width: auto;
+    }
   }
-}
 
-.warning-bar__owes {
-  margin-right: $s-sm;
-  margin-bottom: $s-sm;
+  &__right {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    width: 100%;
 
-  @include media-query__small {
-    margin-right: $s-lg;
-    margin-bottom: 0;
+    @include media-query__small {
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      width: auto;
+    }
+  }
+
+  &__owes {
+    margin-right: $s-sm;
+    margin-bottom: $s-sm;
+
+    @include media-query__small {
+      margin-right: $s-lg;
+      margin-bottom: 0;
+    }
   }
 }

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -7,6 +7,7 @@
 
   @include media-query__small {
     flex-direction: row;
+    padding: $s-md $s-xl;
   }
 
   &__icon {
@@ -19,10 +20,8 @@
     align-items: center;
     width: 100%;
     justify-content: flex-start;
-    margin-bottom: $s-md;
 
     @include media-query__small {
-      margin-bottom: 0;
       width: auto;
     }
   }
@@ -32,12 +31,18 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
+    margin-top: $s-md;
+    
+    &:empty {
+      margin-top: 0;
+    }
 
     @include media-query__small {
       flex-direction: row;
       justify-content: flex-start;
       align-items: center;
       width: auto;
+      margin-top: 0;
     }
   }
 

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -31,7 +31,7 @@
   &__right {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: center;
     width: 100%;
 
     @include media-query__small {

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: $s-md;
   flex-direction: column;
   padding: $s-md $s-xl;
 

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -32,7 +32,7 @@
     align-items: center;
     width: 100%;
     margin-top: $s-md;
-    
+
     &:empty {
       margin-top: 0;
     }

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -3,9 +3,12 @@
   align-items: center;
   justify-content: space-between;
   padding: $s-md;
+  flex-direction: column;
+  padding: $s-md $s-xl;
 
   @include media-query__small {
-    padding: $s-md $s-xl;
+    flex-direction: row;
+    padding: $s-md;
   }
 }
 
@@ -17,17 +20,36 @@
 .warning-bar__left {
   display: flex;
   align-items: center;
+  width: 100%;
+  justify-content: flex-start;
+  margin-bottom: $s-md;
+
+  @include media-query__small {
+    margin-bottom: 0;
+    width: auto;
+  }
 }
 
 .warning-bar__right {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-end;
+  width: 100%;
+
+  @include media-query__small {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    width: auto;
+  }
 }
 
 .warning-bar__owes {
   margin-right: $s-sm;
+  margin-bottom: $s-sm;
 
   @include media-query__small {
     margin-right: $s-lg;
+    margin-bottom: 0;
   }
 }

--- a/src/stories/Library/warning-status/warning-status.scss
+++ b/src/stories/Library/warning-status/warning-status.scss
@@ -3,11 +3,10 @@
   align-items: center;
   justify-content: space-between;
   flex-direction: column;
-  padding: $s-md $s-xl;
+  padding: $s-md;
 
   @include media-query__small {
     flex-direction: row;
-    padding: $s-md;
   }
 
   &__icon {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-679

#### Description

Adjust layout for .warning-bar component for smaller screens and refactored to use nested selectors following the BEM methodology.

#### Screenshot of the result

<img width="373" alt="Skærmbillede 2024-06-14 kl  09 52 26" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/4c936832-c77c-4959-82e5-5f368c2b5c2e">

<img width="857" alt="Skærmbillede 2024-06-14 kl  09 52 43" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/489fc708-fea1-406b-9e0e-0ed0b406869f">

<img width="1701" alt="Skærmbillede 2024-06-14 kl  09 53 05" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/15ee9fb9-43c2-4d01-8725-613537395caf">

<img width="343" alt="Skærmbillede 2024-06-14 kl  09 53 30" src="https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/105956/f0acd25c-91df-4342-9043-2fd24aff667b">
