### PR TITLE
DDFFORM 900 material warning backend

### DIFF
--- a/src/stories/Library/material-search/Errors/ErrorState.ts
+++ b/src/stories/Library/material-search/Errors/ErrorState.ts
@@ -1,0 +1,7 @@
+const enum ErrorState {
+  NoError = "NoError",
+  WorkError = "WorkError",
+  MaterialTypeError = "MaterialTypeError",
+}
+
+export default ErrorState;

--- a/src/stories/Library/material-search/Errors/MaterialSearchBaseError.tsx
+++ b/src/stories/Library/material-search/Errors/MaterialSearchBaseError.tsx
@@ -12,7 +12,9 @@ const MaterialSearchBaseError: React.FC<MaterialSearchBaseErrorProps> = ({
     <div className="material-search__error">
       <div className="material-search__error-header">
         <WarningIcon className="material-search__error-icon" />
-        <h3>This material is outdated.</h3>
+        <h3 className="material-search__error-header-text">
+          This material is outdated.
+        </h3>
       </div>
       {children}
     </div>

--- a/src/stories/Library/material-search/Errors/MaterialSearchBaseError.tsx
+++ b/src/stories/Library/material-search/Errors/MaterialSearchBaseError.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ReactComponent as WarningIcon } from "../../../../public/icons/basic/icon-warning.svg";
+
+interface MaterialSearchBaseErrorProps {
+  children: React.ReactNode;
+}
+
+const MaterialSearchBaseError: React.FC<MaterialSearchBaseErrorProps> = ({
+  children,
+}) => {
+  return (
+    <div className="material-search__error">
+      <div className="material-search__error-header">
+        <WarningIcon className="material-search__error-icon" />
+        <h3>This material is outdated.</h3>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default MaterialSearchBaseError;

--- a/src/stories/Library/material-search/Errors/MaterialTypeNotFoundError.tsx
+++ b/src/stories/Library/material-search/Errors/MaterialTypeNotFoundError.tsx
@@ -1,0 +1,47 @@
+import { PreviewData } from "../MaterialSearchExampleData";
+import MaterialSearchBaseError from "./MaterialSearchBaseError";
+
+const MaterialTypeNotFoundError: React.FC = () => {
+  const { protocol } = window.location;
+
+  const exampleUrl = `${protocol}/hostname/work/${PreviewData.workId}`;
+
+  return (
+    <MaterialSearchBaseError>
+      <div className="material-search__error-content">
+        <p className="material-search__error-description">
+          The currently selected type of the material is no longer available in
+          the system. As a result of this, the link is likely broken. Use the
+          title or link underneath to find and update the material and its type.
+        </p>
+        <div className="material-search__error-material-content">
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">Title:</span>
+            <span className="material-search__error-detail">
+              {PreviewData.title}
+            </span>
+          </div>
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">Author:</span>
+            <span className="material-search__error-detail">
+              {PreviewData.author}
+            </span>
+          </div>
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">Link: </span>
+            <a
+              href={exampleUrl}
+              target="_blank"
+              className="material-search__error-link"
+              rel="noreferrer noopener"
+            >
+              {exampleUrl}
+            </a>
+          </div>
+        </div>
+      </div>
+    </MaterialSearchBaseError>
+  );
+};
+
+export default MaterialTypeNotFoundError;

--- a/src/stories/Library/material-search/Errors/WorkNotFoundError.tsx
+++ b/src/stories/Library/material-search/Errors/WorkNotFoundError.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import MaterialSearchBaseError from "./MaterialSearchBaseError";
+
+const WorkNotFoundError: React.FC = () => {
+  return (
+    <MaterialSearchBaseError>
+      <div className="material-search__error-content">
+        <p className="material-search__error-description">
+          The material that was previously selected is no longer available in
+          the system. Either delete this entry or search for a new material to
+          replace it.
+        </p>
+      </div>
+    </MaterialSearchBaseError>
+  );
+};
+
+export default WorkNotFoundError;

--- a/src/stories/Library/material-search/MaterialSearch.stories.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.stories.tsx
@@ -1,27 +1,20 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-
 import MaterialSearch from "./MaterialSearch";
+import ErrorState from "./Errors/ErrorState";
 
 export default {
   title: "Library / Material Search",
   component: MaterialSearch,
   argTypes: {
-    displayWorkError: {
-      defaultValue: false,
+    errorState: {
       control: {
-        type: "boolean",
-      },
-    },
-    displayMaterialTypeError: {
-      defaultValue: false,
-      control: {
-        type: "boolean",
+        type: "select",
+        options: ["NoError", "WorkError", "MaterialTypeError"],
       },
     },
   },
   args: {
-    displayWorkError: false,
-    displayMaterialTypeError: false,
+    errorState: "NoError",
   },
 } as ComponentMeta<typeof MaterialSearch>;
 
@@ -69,12 +62,10 @@ export const Default = Template.bind({});
 
 export const withWorkError = Template.bind({});
 withWorkError.args = {
-  displayWorkError: true,
-  displayMaterialTypeError: false,
+  errorState: ErrorState.WorkError,
 };
 
 export const withMaterialTypeError = Template.bind({});
 withMaterialTypeError.args = {
-  displayWorkError: false,
-  displayMaterialTypeError: true,
+  errorState: ErrorState.MaterialTypeError,
 };

--- a/src/stories/Library/material-search/MaterialSearch.stories.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.stories.tsx
@@ -5,12 +5,29 @@ import MaterialSearch from "./MaterialSearch";
 export default {
   title: "Library / Material Search",
   component: MaterialSearch,
-  argTypes: {},
+  argTypes: {
+    displayWorkError: {
+      defaultValue: false,
+      control: {
+        type: "boolean",
+      },
+    },
+    displayMaterialTypeError: {
+      defaultValue: false,
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+  args: {
+    displayWorkError: false,
+    displayMaterialTypeError: false,
+  },
 } as ComponentMeta<typeof MaterialSearch>;
 
 const uniqueIdentifier = Math.floor(Math.random() * 10000);
 
-const Template: ComponentStory<typeof MaterialSearch> = () => {
+const Template: ComponentStory<typeof MaterialSearch> = (args) => {
   return (
     <div className="material-search">
       <div className="material-search__inputs-container">
@@ -43,9 +60,21 @@ const Template: ComponentStory<typeof MaterialSearch> = () => {
         </label>
       </div>
 
-      <MaterialSearch />
+      <MaterialSearch {...args} />
     </div>
   );
 };
 
 export const Default = Template.bind({});
+
+export const withWorkError = Template.bind({});
+withWorkError.args = {
+  displayWorkError: true,
+  displayMaterialTypeError: false,
+};
+
+export const withMaterialTypeError = Template.bind({});
+withMaterialTypeError.args = {
+  displayWorkError: false,
+  displayMaterialTypeError: true,
+};

--- a/src/stories/Library/material-search/MaterialSearch.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.tsx
@@ -4,7 +4,15 @@ import MaterialSearchPreview from "./MaterialSearchPreview";
 import MaterialSearchList from "./MaterialSearchList";
 import { PreviewData } from "./MaterialSearchExampleData";
 
-const MaterialSearch: FC = () => {
+interface MaterialSearchProps {
+  displayWorkError: boolean;
+  displayMaterialTypeError: boolean;
+}
+
+const MaterialSearch: FC<MaterialSearchProps> = ({
+  displayWorkError,
+  displayMaterialTypeError,
+}) => {
   const [searchInput, setSearchInput] = useState("");
   const [selectedMaterialType, setSelectedMaterialType] = useState("");
   const [selectedWorkId] = useState(PreviewData.workId);
@@ -22,7 +30,11 @@ const MaterialSearch: FC = () => {
         onMaterialTypeChange={setSelectedMaterialType}
       />
       <div className="material-search__materials-wrapper">
-        <MaterialSearchPreview displayMaterial={searchInput.length > 1} />
+        <MaterialSearchPreview
+          displayMaterial={searchInput.length > 1}
+          displayWorkError={displayWorkError}
+          displayMaterialTypeError={displayMaterialTypeError}
+        />
         <MaterialSearchList
           showListResults={searchInput.length > 1}
           selectedWorkId={selectedWorkId}

--- a/src/stories/Library/material-search/MaterialSearch.tsx
+++ b/src/stories/Library/material-search/MaterialSearch.tsx
@@ -1,18 +1,15 @@
 import { FC, useState } from "react";
-import MaterialSearchInputs from "./MaterialSearchInputs";
-import MaterialSearchPreview from "./MaterialSearchPreview";
-import MaterialSearchList from "./MaterialSearchList";
 import { PreviewData } from "./MaterialSearchExampleData";
+import MaterialSearchInputs from "./MaterialSearchInputs";
+import MaterialSearchList from "./MaterialSearchList";
+import MaterialSearchPreview from "./MaterialSearchPreview";
+import ErrorState from "./Errors/ErrorState";
 
 interface MaterialSearchProps {
-  displayWorkError: boolean;
-  displayMaterialTypeError: boolean;
+  errorState: ErrorState;
 }
 
-const MaterialSearch: FC<MaterialSearchProps> = ({
-  displayWorkError,
-  displayMaterialTypeError,
-}) => {
+const MaterialSearch: FC<MaterialSearchProps> = ({ errorState }) => {
   const [searchInput, setSearchInput] = useState("");
   const [selectedMaterialType, setSelectedMaterialType] = useState("");
   const [selectedWorkId] = useState(PreviewData.workId);
@@ -32,8 +29,7 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
       <div className="material-search__materials-wrapper">
         <MaterialSearchPreview
           displayMaterial={searchInput.length > 1}
-          displayWorkError={displayWorkError}
-          displayMaterialTypeError={displayMaterialTypeError}
+          errorState={errorState}
         />
         <MaterialSearchList
           showListResults={searchInput.length > 1}

--- a/src/stories/Library/material-search/MaterialSearchPreview.tsx
+++ b/src/stories/Library/material-search/MaterialSearchPreview.tsx
@@ -1,20 +1,19 @@
 import { useEffect, useState } from "react";
 import Cover from "../cover/Cover";
 import MaterialTypeNotFoundError from "./Errors/MaterialTypeNotFoundError";
+import WorkNotFoundError from "./Errors/WorkNotFoundError";
 import { PreviewData } from "./MaterialSearchExampleData";
 import MaterialSearchLoading from "./MaterialSearchLoading";
-import WorkNotFoundError from "./Errors/WorkNotFoundError";
+import ErrorState from "./Errors/ErrorState";
 
 interface MaterialSearchPreviewProps {
   displayMaterial: boolean;
-  displayWorkError: boolean;
-  displayMaterialTypeError: boolean;
+  errorState: ErrorState;
 }
 
 const MaterialSearchPreview = ({
   displayMaterial,
-  displayWorkError,
-  displayMaterialTypeError,
+  errorState,
 }: MaterialSearchPreviewProps) => {
   const [fictiveLoading, setFictiveLoading] = useState(false);
 
@@ -31,10 +30,10 @@ const MaterialSearchPreview = ({
     return () => {};
   }, [displayMaterial]);
 
-  if (displayWorkError) {
+  if (errorState === ErrorState.WorkError) {
     return <WorkNotFoundError />;
   }
-  if (displayMaterialTypeError) {
+  if (errorState === ErrorState.MaterialTypeError) {
     return <MaterialTypeNotFoundError />;
   }
 

--- a/src/stories/Library/material-search/MaterialSearchPreview.tsx
+++ b/src/stories/Library/material-search/MaterialSearchPreview.tsx
@@ -1,14 +1,20 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Cover from "../cover/Cover";
+import MaterialTypeNotFoundError from "./Errors/MaterialTypeNotFoundError";
 import { PreviewData } from "./MaterialSearchExampleData";
-import MaterialSearchLoading from "./MaterialSearchLoading"; // Assuming this is the correct import
+import MaterialSearchLoading from "./MaterialSearchLoading";
+import WorkNotFoundError from "./Errors/WorkNotFoundError";
 
 interface MaterialSearchPreviewProps {
   displayMaterial: boolean;
+  displayWorkError: boolean;
+  displayMaterialTypeError: boolean;
 }
 
 const MaterialSearchPreview = ({
   displayMaterial,
+  displayWorkError,
+  displayMaterialTypeError,
 }: MaterialSearchPreviewProps) => {
   const [fictiveLoading, setFictiveLoading] = useState(false);
 
@@ -24,6 +30,13 @@ const MaterialSearchPreview = ({
 
     return () => {};
   }, [displayMaterial]);
+
+  if (displayWorkError) {
+    return <WorkNotFoundError />;
+  }
+  if (displayMaterialTypeError) {
+    return <MaterialTypeNotFoundError />;
+  }
 
   if (fictiveLoading) {
     return (

--- a/src/stories/Library/material-search/material-search.scss
+++ b/src/stories/Library/material-search/material-search.scss
@@ -5,13 +5,15 @@ $_gin_xl_spacing: 2rem;
 $_gin_border_color: #8e929c;
 $_gin_font_weight_semibold: 525;
 $_gin-header-bg-color: #e1eafc;
-
+$_gin_color_danger: #cc3d3d;
+$_gin_color_danger_lightest: #fdd9d9;
 $_color__background-light: #eeeeed;
 $_color__hover-background: #8e929c;
 
 $_box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.25);
 $_loading-spinner-size: 40px;
 $_highlighted-item-bg-color: $_gin-header-bg-color;
+$_box_shadow_header: 0 4px 2px -2px rgba(0, 0, 0, 0.171);
 
 // Fixed preview height so the size doesn't jump if nothing is selected.
 $_preview-height: 170px;
@@ -220,4 +222,54 @@ $list_header_height: 50px;
 
 .material-search-list__loading {
   margin-top: $_gin_m_spacing;
+}
+
+// Warning
+.material-search__error {
+  background-color: $color__global-white;
+  border: 1px solid $_gin_color_danger;
+  min-height: $_preview-height;
+  height: 100%;
+  border-radius: $_gin_xs_spacing;
+  font-family: inherit;
+  overflow: hidden;
+}
+
+.material-search__error-header {
+  display: flex;
+  gap: $_gin_xs_spacing;
+  align-items: center;
+  font-size: 1rem;
+  padding: $_gin_m_spacing;
+  background-color: $_gin_color_danger_lightest;
+  font-weight: $font__weight--bold;
+  box-shadow: $_box_shadow_header;
+}
+
+.material-search__error-icon {
+  height: 25px;
+  width: 25px;
+}
+
+.material-search__error-content {
+  padding: $_gin_m_spacing;
+}
+.material-search__error-material-content {
+  margin-top: $_gin_m_spacing;
+}
+.material-search__error-item {
+  display: flex;
+  gap: $_gin_xs_spacing;
+  flex-direction: row;
+  align-items: center;
+}
+.material-search__error-term {
+  font-weight: $font__weight--bold;
+}
+.material-search__error-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/src/stories/Library/material-search/material-search.scss
+++ b/src/stories/Library/material-search/material-search.scss
@@ -9,6 +9,8 @@ $_gin_color_danger: #cc3d3d;
 $_gin_color_danger_lightest: #fdd9d9;
 $_color__background-light: #eeeeed;
 $_color__hover-background: #8e929c;
+$_gin_font_size: 1rem;
+$_gin_font_size_l: 1.125rem;
 
 $_box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.25);
 $_loading-spinner-size: 40px;
@@ -57,6 +59,8 @@ $list_header_height: 50px;
   border: 1px solid $_gin_border_color;
   border-radius: $_gin_xs_spacing;
   overflow: hidden;
+  font-family: inherit;
+  font-size: $_gin_font_size;
 }
 
 .material-search__preview-material {
@@ -233,17 +237,24 @@ $list_header_height: 50px;
   border-radius: $_gin_xs_spacing;
   font-family: inherit;
   overflow: hidden;
+  font-size: $_gin_font_size;
 }
 
 .material-search__error-header {
   display: flex;
   gap: $_gin_xs_spacing;
   align-items: center;
-  font-size: 1rem;
+  font-size: $_gin_font_size;
   padding: $_gin_m_spacing;
   background-color: $_gin_color_danger_lightest;
   font-weight: $font__weight--bold;
   box-shadow: $_box_shadow_header;
+}
+
+.material-search__error-header-text {
+  font-size: $_gin_font_size_l;
+  font-weight: $_gin_font_weight_semibold;
+  margin: 0;
 }
 
 .material-search__error-icon {


### PR DESCRIPTION
- **Add error components for material search.**
- **Add css for material search error components.**

#### Link to issue

[DDFFORM-900](https://reload.atlassian.net/browse/DDFFORM-900)

[React pr](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1304)
[CMS PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1310)
#### Description

This PR introduceres error/warning components to the material search component. 
They are used to display errors in retrieving the material that was saved before. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/13272656/4d9d99f6-57ca-4243-8e38-f787e1757802)

![image](https://github.com/danskernesdigitalebibliotek/dpl-design-system/assets/13272656/69d5cdd6-0b1e-4d29-9c16-b34a15ee2091)





[DDFFORM-900]: https://reload.atlassian.net/browse/DDFFORM-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ