### PR TITLE
Refactor blockquote CSS in `rich-text.scss`

### DIFF
--- a/src/stories/Library/rich-text/rich-text.scss
+++ b/src/stories/Library/rich-text/rich-text.scss
@@ -68,12 +68,19 @@ $_max-width-rich-text: $block-max-width__small;
   }
 
   blockquote {
-    $_quote-indicator-width: 10px;
+    $_quote-indicator-width: 3px;
+    $_padding-left: $_quote-indicator-width + $s-lg;
+    $_position-left--large-screen: $s-md;
 
+    @include typography($typo_quotes);
     position: relative;
-    padding-top: $s-md;
-    padding-bottom: $s-md;
-    padding-left: $_quote-indicator-width + $s-md;
+    padding-top: $s-sm;
+    padding-bottom: $s-sm;
+    padding-left: $_padding-left;
+
+    @include media-query__small {
+      padding-left: $_padding-left + $_position-left--large-screen;
+    }
 
     &::before {
       position: absolute;
@@ -83,6 +90,15 @@ $_max-width-rich-text: $block-max-width__small;
       bottom: 0;
       width: $_quote-indicator-width;
       background-color: $color__identity-primary;
+
+      @include media-query__small {
+        left: $_position-left--large-screen;
+      }
+    }
+
+    // Make space between elements in a blockquote.
+    & > *:not(:last-child) {
+      margin-bottom: $s-lg;
     }
   }
 

--- a/src/styles/scss/tools/variables.typography.scss
+++ b/src/styles/scss/tools/variables.typography.scss
@@ -359,3 +359,17 @@ $typo__card-placeholder--grid: (
       line-height: 24px,
     ),
 );
+
+$typo_quotes: (
+  mobile: (
+    color: $color__global-grey,
+    font-family: $font__body,
+    font-weight: 600,
+    font-size: 16px,
+    line-height: 24px,
+  ),
+  medium: (
+    font-size: 18px,
+    line-height: 32px,
+  ),
+);


### PR DESCRIPTION
#### Link to issue
[Figma Design System](https://www.figma.com/design/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=15296-51574&t=xFP5EmqluakmKgeF-4)

https://reload.atlassian.net/browse/DDFFORM-399


#### Description

This pull request refactors the CSS for blockquotes in the `rich-text.scss` file to align with the new design specifications. The following changes have been made:

- Added a new typography variable `$typo_quotes`.
- Updated the CSS for `blockquote` elements to align with the new design


#### Test
http://varnish.pr-1334.dpl-cms.dplplat01.dpl.reload.dk/artikler/test-citat