### PR TITLE
Add tags style to week display in opening hours

### DIFF
--- a/src/stories/Library/opening-hours/opening-hours.scss
+++ b/src/stories/Library/opening-hours/opening-hours.scss
@@ -77,6 +77,7 @@ $_opening-hours-max-width: 600px;
 }
 
 .opening-hours__week-display {
+  @include typography($typo__tags);
   border: $_nav-control-border-width solid $color__global-tertiary-1;
   height: $_nav-control-height;
   display: flex;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-862

#### Description

Add tags style to week display in opening hours due to the design: https://www.figma.com/design/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=7486-63527&t=9ySgYMKGTKS2auc9-4


#### Test

http://varnish.pr-1329.dpl-cms.dplplat01.dpl.reload.dk/hovedbiblioteket