### PR TITLE
Add `isHiddenFromScreenReaders` to `Cover`

### DIFF
--- a/src/stories/Library/cover/Cover.tsx
+++ b/src/stories/Library/cover/Cover.tsx
@@ -14,6 +14,7 @@ const Cover: FC<CoverProps> = ({
   alt,
   shadow,
   ariaLabel = "Link to the material",
+  isHiddenFromScreenReaders,
 }) => {
   const [imageLoaded, setImageLoaded] = useState<boolean | null>(null);
 
@@ -28,7 +29,7 @@ const Cover: FC<CoverProps> = ({
     ),
   };
 
-  if (coverUrl && alt) {
+  if (coverUrl) {
     // Images inside links must have an non-empty alt text to meet accessibility requirements.
     // Only render the cover as a link if we have both an url and a description.
     return (
@@ -38,6 +39,8 @@ const Cover: FC<CoverProps> = ({
         aria-label={ariaLabel}
         aria-labelledby="cover labelled by"
         title="cover title text"
+        tabIndex={isHiddenFromScreenReaders ? -1 : 0}
+        aria-hidden={isHiddenFromScreenReaders}
       >
         <CoverImage
           setImageLoaded={() => setImageLoaded(true)}

--- a/src/stories/Library/cover/types.ts
+++ b/src/stories/Library/cover/types.ts
@@ -11,4 +11,5 @@ export type CoverProps = {
   alt?: string;
   shadow?: "small" | "medium";
   ariaLabel?: string;
+  isHiddenFromScreenReaders?: boolean;
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-719
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1313

#### Description
This pull request introduces the isHiddenFromScreenReaders property to the Cover component to ensure alignment with the updates made in https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1313.

The design system does not have an equivalent Link component, so this addition is exclusive to the Cover component.

We don't have the same `Link` component in the design system therefore it's only added in the `Cover` component