### PR TITLE
DDFLSBP-659 - Add visual indicators on required fields

### DIFF
--- a/src/stories/Library/input-label/InputLabel.stories.tsx
+++ b/src/stories/Library/input-label/InputLabel.stories.tsx
@@ -11,6 +11,9 @@ export default {
     text: {
       defaultValue: "Her er en label",
     },
+    required: {
+      defaultValue: false,
+    },
   },
   parameters: {
     layout: "padded",
@@ -22,3 +25,10 @@ const Template: ComponentStory<DropdownProps> = (args) => (
 );
 
 export const InputLabel = Template.bind({});
+
+export const RequiredInputLabel = Template.bind({});
+
+RequiredInputLabel.args = {
+  text: "Her er en required label",
+  required: true,
+};

--- a/src/stories/Library/input-label/InputLabel.tsx
+++ b/src/stories/Library/input-label/InputLabel.tsx
@@ -1,7 +1,9 @@
 export type InputLabelProps = {
   text: string;
+  required?: boolean;
 };
 
-export const InputLabel: React.FC<InputLabelProps> = ({ text }) => {
-  return <label className="input-label">{text}</label>;
+export const InputLabel: React.FC<InputLabelProps> = ({ text, required }) => {
+  const labelClass = `input-label ${required ? "input-label--required" : ""}`;
+  return <label className={labelClass}>{text}</label>;
 };

--- a/src/stories/Library/input-label/input-label.scss
+++ b/src/stories/Library/input-label/input-label.scss
@@ -6,6 +6,6 @@
   padding-top: $s-xs;
 }
 
-.form-required::after {
-  content: "*";
+.input-label--required::after {
+  content: " *";
 }

--- a/src/stories/Library/input-label/input-label.scss
+++ b/src/stories/Library/input-label/input-label.scss
@@ -5,3 +5,7 @@
   margin-bottom: $s-sm;
   padding-top: $s-xs;
 }
+
+.form-required::after {
+  content: "*";
+}


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-659

#### Description

Added styling for required fields. We simply add a new class `.form-required::after` containing an asterisk ( *). The class is added on fields where the input field is required to be filled out.

#### Screenshot of the result

Showing the contact webform with required fields:
![Screenshot 2024-07-12 at 16 06 36](https://github.com/user-attachments/assets/6f7c4035-fc35-482f-bbf3-a77d1d571901)

#### Additional comments or questions

This PR has a sister PR in dpl-cms: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1363

This PR has a sister PR in dpl-react: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1327


