### PR TITLE
DDFLSBP-685 - Remove uppercase on dropdown and multiselect elements

### DIFF
--- a/src/stories/Library/dropdown/dropdown.scss
+++ b/src/stories/Library/dropdown/dropdown.scss
@@ -37,6 +37,7 @@ $_dropdown-icon-size: 50px;
   padding-right: $_dropdown-icon-size + $_padding;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-transform: none;
 
   @include typography($typo__button);
 
@@ -49,7 +50,6 @@ $_dropdown-icon-size: 50px;
 }
 
 .dropdown__option {
-  text-transform: capitalize;
   background-color: #f9f9f9;
   height: 400px;
 
@@ -85,6 +85,7 @@ $_dropdown-icon-size: 50px;
   height: 100%;
   padding: $s-sm $s-md;
   min-width: 200px;
+  text-transform: none;
 }
 
 .dropdown__select--inline-body-font {

--- a/src/stories/Library/dropdown/dropdown.scss
+++ b/src/stories/Library/dropdown/dropdown.scss
@@ -21,6 +21,8 @@ $_dropdown-icon-size: 50px;
 .dropdown__select {
   $_padding: 20px;
 
+  @include typography($typo__button);
+
   appearance: none;
   -webkit-appearance: none;
   min-width: 230px;
@@ -38,8 +40,6 @@ $_dropdown-icon-size: 50px;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-transform: none;
-
-  @include typography($typo__button);
 
   // Chromeium based browsers will trigger focus when opening the dropdown
   @extend %default-focus-visible;

--- a/src/stories/Library/multiselect/multiselect.scss
+++ b/src/stories/Library/multiselect/multiselect.scss
@@ -17,6 +17,7 @@
     text-overflow: ellipsis;
     padding: 0 $s-md;
     cursor: pointer;
+    text-transform: none;
   }
 
   &__opener {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-685

#### Description

Removed text-transform: capitalized and added text-transform: none on dropdown and multiselect elements.

This is done to make it consistent throughout the website and on all browser/operation systems, as there are some differences between the way MacOS and Windows show dropdowns. It also adds to the readability of the dropdown and multiselect elements.

#### Screenshot of the result

Advanced search example:
![Screenshot 2024-07-12 at 16 43 55](https://github.com/user-attachments/assets/72f7236b-bf33-49c4-836d-0bdcbe103cbc)

Contact form with dropdown element example:
![Screenshot 2024-07-12 at 16 44 25](https://github.com/user-attachments/assets/bfb1ed18-a8d8-4fb8-8a96-2d1e1471b705)

#### Additional comments or questions

This PR has a sister PR in dpl-cms: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1385

