### PR TITLE
Ddfform 822 modal til abningstider

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,5 +1,8 @@
 {
-  "extends": ["stylelint-config-recommended-scss", "stylelint-prettier/recommended"],
+  "extends": [
+    "stylelint-config-recommended-scss",
+    "stylelint-prettier/recommended"
+  ],
   "rules": {
     "max-nesting-depth": 3,
     "selector-class-pattern": "^[a-z][a-z0-9_-]*$",
@@ -11,6 +14,18 @@
       }
     ],
     "property-no-vendor-prefix": null,
-    "scss/dollar-variable-pattern": null
+    "scss/dollar-variable-pattern": null,
+    "property-no-unknown": [
+      true,
+      {
+        "ignoreProperties": ["transition-behavior"]
+      }
+    ],
+    "scss/at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["starting-style"]
+      }
+    ]
   }
 }

--- a/admin-base.scss
+++ b/admin-base.scss
@@ -1,6 +1,7 @@
 @import "./src/styles/scss/tools";
 
 // CSS sheets that are used to style the admin interface.
+@import "./src/stories/Library/dialog/dialog";
 @import "./src/stories/Library/opening-hours-editor/opening-hours-editor";
 @import "./src/stories/Library/material-search/material-search";
 @import "./src/stories/Library/cover/cover";

--- a/base.scss
+++ b/base.scss
@@ -138,6 +138,7 @@
 @import "./src/stories/Library/opening-hours-editor/opening-hours-editor";
 @import "./src/stories/Library/opening-hours/opening-hours";
 @import "./src/stories/Library/opening-hours/opening-hours-skeleton";
+@import "./src/stories/Library/opening-hours-sidebar/opening-hours-sidebar";
 @import "./src/stories/Library/filtered-event-list/filtered-event-list";
 @import "./src/stories/Library/event-list-stacked/event-list-stacked";
 @import "./src/stories/Library/material-search/material-search";

--- a/src/stories/Blocks/header/Header.tsx
+++ b/src/stories/Blocks/header/Header.tsx
@@ -150,10 +150,10 @@ export const Header = ({
 
         <div className="header__clock">
           <Pagefold isInheriting={false} isAContainer={false} size="medium" />
-          <a href="#" className="header__clock-items">
+          <button className="header__clock-items">
             <WatchStaticIcon className="mb-8" />
             <span className="text-small-caption">Opening hours</span>
-          </a>
+          </button>
         </div>
       </header>
       <HeaderSidebarNav menuLinks={menuItems} />

--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -214,6 +214,7 @@
 }
 
 .header__clock {
+  height: 100%;
   border-left: 1px solid $color__global-tertiary-1;
   display: none;
 
@@ -224,9 +225,12 @@
 
 .header__clock-items {
   text-decoration: none;
+  border: none;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
 }
 
 // has-burger-menu is added dynamically using JS, by calculating if there

--- a/src/stories/Library/dialog/Dialog.tsx
+++ b/src/stories/Library/dialog/Dialog.tsx
@@ -1,15 +1,17 @@
+import clsx from "clsx";
 import React, { forwardRef } from "react";
 
 export type DialogType = {
   children: React.ReactNode;
   closeDialog: () => void;
+  isSidebar?: boolean;
 };
 
 const Dialog = forwardRef<HTMLDialogElement, DialogType>(
-  ({ children, closeDialog }, ref) => {
+  ({ children, closeDialog, isSidebar }, ref) => {
     return (
       <dialog
-        className="dialog"
+        className={clsx("dialog", isSidebar && "dialog--sidebar")}
         ref={ref}
         // Close dialog when clicking outside of it (::backdrop pseudo-element)
         onClick={({ currentTarget, target }) => {

--- a/src/stories/Library/dialog/dialog.scss
+++ b/src/stories/Library/dialog/dialog.scss
@@ -13,3 +13,58 @@
   background-color: transparent;
   padding: 10px;
 }
+
+.dialog--sidebar {
+  // Reset dialog
+  max-height: unset;
+  max-width: unset;
+  border: 0;
+  border-radius: 0;
+  // Apply custom
+  background-color: $color__global-primary;
+  position: fixed;
+  height: 100vh;
+  width: 100%;
+  left: auto;
+
+  @include media-query__small {
+    width: 435px;
+  }
+  // Apply animation
+  // The 'allow-discrete' property is necessary for animating the dialog
+  transition-behavior: allow-discrete;
+  transition-property: translate overlay display;
+  transition-duration: 0.7s;
+  transition-timing-function: ease-out;
+  translate: 100vw 0;
+}
+
+.dialog--sidebar[open] {
+  translate: 0 0;
+}
+
+@starting-style {
+  .dialog--sidebar[open] {
+    translate: 100vw 0;
+  }
+}
+
+.dialog--sidebar[open]::backdrop {
+  animation: backdrop-fade-in 0.25s forwards;
+}
+
+@keyframes backdrop-fade-in {
+  from {
+    background-color: rgb(0 0 0 / 0%);
+  }
+  to {
+    background-color: rgb(0 0 0 / 25%);
+  }
+}
+
+// This sets the correct sidebar width for accurate visual regression testing.
+.storybook-dialog-sidebar {
+  @include media-query__small {
+    width: 435px;
+  }
+}

--- a/src/stories/Library/disclosure-controllable/DisclosureControllable.tsx
+++ b/src/stories/Library/disclosure-controllable/DisclosureControllable.tsx
@@ -25,13 +25,22 @@ const DisclosureControllable: React.FunctionComponent<
     setIsOpen(!isOpen);
   }, [isOpen]);
 
+  const onKeyDown = useCallback(
+    (e: { key: string }) => {
+      if (e.key === "Enter" || e.key === " ") {
+        toggleOpen();
+      }
+    },
+    [toggleOpen]
+  );
+
   const disclosureId = `disclosure-${id}`;
   return (
     <div className={detailsClassName}>
       <div
         className={summaryClassName}
         onClick={toggleOpen}
-        onKeyDown={toggleOpen}
+        onKeyDown={onKeyDown}
         role="button"
         tabIndex={0}
         aria-controls={disclosureId}

--- a/src/stories/Library/opening-hours-editor/opening-hours-editor.scss
+++ b/src/stories/Library/opening-hours-editor/opening-hours-editor.scss
@@ -1,7 +1,3 @@
-// The Opening Hours Editor utilizes the Dialog component.
-// We aim to consolidate all Opening Hours Editor styles into a single file.
-// Because is used in drupal admin area
-@import "../dialog/dialog";
 .opening-hours-editor-form {
   display: grid;
   background: #f8f8f8;

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
@@ -9,13 +9,13 @@ export default {
   decorators: [withDesign],
   argTypes: {
     title: {
-      defaultValue: "Åbningstider",
+      defaultValue: "Dagens åbningstider",
       control: {
         type: "text",
       },
     },
     dateString: {
-      defaultValue: "I dag (fredag 28. maj)",
+      defaultValue: "fredag 28. maj",
       control: {
         type: "text",
       },

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
@@ -1,0 +1,52 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import OpeningHoursSidebar from "./OpeningHoursSidebar";
+import defaultLibraries from "./opening-hours-libraries-data";
+
+export default {
+  title: "Library/Opening Hours Sidebar/Without Dialog",
+  component: OpeningHoursSidebar,
+  decorators: [withDesign],
+  argTypes: {
+    title: {
+      defaultValue: "Åbningstider",
+      control: {
+        type: "text",
+      },
+    },
+    dateString: {
+      defaultValue: "I dag (fredag 28. maj)",
+      control: {
+        type: "text",
+      },
+    },
+    libraries: {
+      control: {
+        type: "object",
+      },
+      defaultValue: defaultLibraries,
+    },
+    link: {
+      defaultValue: "#",
+      control: {
+        type: "text",
+      },
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=7760-59368&t=FtYoMFQsdy52r88A-4",
+    },
+  },
+} as ComponentMeta<typeof OpeningHoursSidebar>;
+
+const Template: ComponentStory<typeof OpeningHoursSidebar> = (args) => {
+  return (
+    <div className="storybook-dialog-sidebar">
+      <OpeningHoursSidebar {...args} />;
+    </div>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.tsx
@@ -45,6 +45,7 @@ const OpeningHoursSidebar: FC<OpeningHoursSidebarType> = ({
           <OpeningHoursSidebarDetails
             openingHoursData={openingHoursData}
             link={link}
+            name={name}
           />
         </DisclosureControllable>
       ))}

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.tsx
@@ -1,0 +1,55 @@
+import { FC } from "react";
+import { ReactComponent as WatchStaticIcon } from "../../../public/icons/basic/icon-watch-static.svg";
+import DisclosureControllable from "../disclosure-controllable/DisclosureControllable";
+import OpeningHoursSidebarSummary from "./OpeningHoursSidebarSummary";
+import OpeningHoursSidebarDetails, {
+  OpeningHoursItemType,
+} from "./OpeningHoursSidebarDetails";
+
+type OpeningHoursSidebarType = {
+  title: string;
+  dateString: string;
+  libraries: {
+    id: string;
+    name: string;
+    openingHoursData: OpeningHoursItemType[];
+  }[];
+  link: string;
+};
+
+const OpeningHoursSidebar: FC<OpeningHoursSidebarType> = ({
+  title,
+  dateString,
+  libraries,
+  link,
+}) => {
+  return (
+    <section className="opening-hours-sidebar">
+      <header className="opening-hours-sidebar__header">
+        <WatchStaticIcon className="opening-hours-sidebar__icon" />
+        <div className="opening-hours-sidebar__texts">
+          <h2 className="opening-hours-sidebar__title">{title}</h2>
+          <p className="opening-hours-sidebar__date">{dateString}</p>
+        </div>
+      </header>
+
+      {libraries.map(({ id, name, openingHoursData }, i) => (
+        <DisclosureControllable
+          showContent={i === 0}
+          key={id}
+          id={id}
+          detailsClassName="opening-hours-sidebar-details"
+          summaryClassName="opening-hours-sidebar-summary"
+          summary={<OpeningHoursSidebarSummary name={name} />}
+        >
+          <OpeningHoursSidebarDetails
+            openingHoursData={openingHoursData}
+            link={link}
+          />
+        </DisclosureControllable>
+      ))}
+    </section>
+  );
+};
+
+export default OpeningHoursSidebar;

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarDetails.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarDetails.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export type OpeningHoursItemType = {
+  term: string;
+  description: string;
+};
+
+type OpeningHoursSidebarDetailsType = {
+  openingHoursData: OpeningHoursItemType[];
+  link: string;
+};
+
+const OpeningHoursSidebarDetails: React.FC<OpeningHoursSidebarDetailsType> = ({
+  openingHoursData,
+  link,
+}) => {
+  return (
+    <div className="opening-hours-sidebar-details__content">
+      <dl className="opening-hours-sidebar-details__list">
+        {openingHoursData.map(({ term, description }, i) => (
+          <div key={i} className="opening-hours-sidebar-details__item">
+            <dt className="opening-hours-sidebar-details__term">{term}</dt>
+            <dd className="opening-hours-sidebar-details__description">
+              {description}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <a href={link} className="opening-hours-sidebar__link">
+        Se alle åbningstider
+      </a>
+    </div>
+  );
+};
+
+export default OpeningHoursSidebarDetails;

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarDetails.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarDetails.tsx
@@ -8,11 +8,13 @@ export type OpeningHoursItemType = {
 type OpeningHoursSidebarDetailsType = {
   openingHoursData: OpeningHoursItemType[];
   link: string;
+  name: string;
 };
 
 const OpeningHoursSidebarDetails: React.FC<OpeningHoursSidebarDetailsType> = ({
   openingHoursData,
   link,
+  name,
 }) => {
   return (
     <div className="opening-hours-sidebar-details__content">
@@ -27,7 +29,7 @@ const OpeningHoursSidebarDetails: React.FC<OpeningHoursSidebarDetailsType> = ({
         ))}
       </dl>
       <a href={link} className="opening-hours-sidebar__link">
-        Se alle åbningstider
+        {`Gå til ${name}`}
       </a>
     </div>
   );

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarSummary.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarSummary.tsx
@@ -1,0 +1,19 @@
+import { FC } from "react";
+import { ReactComponent as ExpandMoreIcon } from "../../../public/icons/collection/ExpandMore.svg";
+
+type OpeningHoursSidebarSummaryType = {
+  name: string;
+};
+
+const OpeningHoursSidebarSummary: FC<OpeningHoursSidebarSummaryType> = ({
+  name,
+}) => {
+  return (
+    <>
+      <h3 className="opening-hours-sidebar-summary__name">{name}</h3>
+      <ExpandMoreIcon className="opening-hours-sidebar-summary__icon" />
+    </>
+  );
+};
+
+export default OpeningHoursSidebarSummary;

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarWithDialog.stories.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebarWithDialog.stories.tsx
@@ -1,0 +1,66 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import OpeningHoursSidebar from "./OpeningHoursSidebar";
+import Dialog from "../dialog/Dialog";
+import useDialog from "../dialog/useDialog";
+import defaultLibraries from "./opening-hours-libraries-data";
+
+export default {
+  title: "Library/Opening Hours Sidebar/With Dialog",
+  component: OpeningHoursSidebar,
+  decorators: [withDesign],
+  argTypes: {
+    title: {
+      defaultValue: "Åbningstider",
+      control: {
+        type: "text",
+      },
+    },
+    dateString: {
+      defaultValue: "I dag (fredag 28. maj)",
+      control: {
+        type: "text",
+      },
+    },
+    libraries: {
+      control: {
+        type: "object",
+      },
+      defaultValue: defaultLibraries,
+    },
+    link: {
+      defaultValue: "#",
+      control: {
+        type: "text",
+      },
+    },
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Zx9GrkFA3l4ISvyZD2q0Qi/Designsystem?node-id=7760-59368&t=FtYoMFQsdy52r88A-4",
+    },
+  },
+} as ComponentMeta<typeof OpeningHoursSidebar>;
+
+const Template: ComponentStory<typeof OpeningHoursSidebar> = (args) => {
+  const { dialogContent, openDialogWithContent, closeDialog, dialogRef } =
+    useDialog();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => openDialogWithContent(<OpeningHoursSidebar {...args} />)}
+      >
+        Open Sidebar
+      </button>
+
+      <Dialog isSidebar closeDialog={closeDialog} ref={dialogRef}>
+        {dialogContent}
+      </Dialog>
+    </>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/stories/Library/opening-hours-sidebar/opening-hours-libraries-data.ts
+++ b/src/stories/Library/opening-hours-sidebar/opening-hours-libraries-data.ts
@@ -1,0 +1,30 @@
+const openingHoursData = [
+  { term: "Selvbetjening & læsesale", description: "7:00 - 22:00" },
+  { term: "Personlig betjening:", description: "9:00 - 16:00" },
+  { term: "Telefon (+45 30 30 30 30):", description: "7:00 - 22:00" },
+];
+
+const defaultLibraries = [
+  {
+    id: "1",
+    name: "Hovedbiblioteket",
+    openingHoursData,
+  },
+  {
+    id: "2",
+    name: "BIBLIOTEKET Rentemestervej",
+    openingHoursData,
+  },
+  {
+    id: "3",
+    name: "Bibliotekshuset",
+    openingHoursData,
+  },
+  {
+    id: "4",
+    name: "Blågårdens Bibliotek",
+    openingHoursData,
+  },
+];
+
+export default defaultLibraries;

--- a/src/stories/Library/opening-hours-sidebar/opening-hours-sidebar.scss
+++ b/src/stories/Library/opening-hours-sidebar/opening-hours-sidebar.scss
@@ -1,0 +1,70 @@
+@mixin opening-hours-sidebar-padding {
+  padding: $s-lg $s-md;
+
+  @include media-query__small {
+    padding: $s-lg $s-xl;
+  }
+}
+
+.opening-hours-sidebar__header {
+  @include opening-hours-sidebar-padding;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.opening-hours-sidebar__texts {
+  align-items: end;
+  text-align: end;
+}
+
+.opening-hours-sidebar__title {
+  @include typography($typo__h4);
+}
+
+.opening-hours-sidebar-details {
+  @include opening-hours-sidebar-padding;
+  border-top: 1px solid $color__global-tertiary-1;
+}
+
+.opening-hours-sidebar-summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.opening-hours-sidebar-summary__icon {
+  transition: transform 0.3s;
+}
+
+.opening-hours-sidebar-summary[aria-expanded="true"]
+  .opening-hours-sidebar-summary__icon {
+  transform: rotateZ(180deg);
+}
+
+.opening-hours-sidebar-summary__name {
+  @include typography($typo__body-placeholder);
+  font-weight: $font__weight--semi-bold;
+}
+
+.opening-hours-sidebar-details__content {
+  @include typography($typo__body-placeholder);
+  margin-top: $s-lg;
+  color: $color__global-grey;
+}
+
+.opening-hours-sidebar-details__item {
+  display: flex;
+  justify-content: space-between;
+}
+
+.opening-hours-sidebar__link {
+  @include link-tag;
+  display: block;
+  margin-top: $s-lg;
+
+  @include media-query__small {
+    font-size: 14px;
+  }
+}

--- a/src/stories/Library/opening-hours-sidebar/opening-hours-sidebar.scss
+++ b/src/stories/Library/opening-hours-sidebar/opening-hours-sidebar.scss
@@ -22,6 +22,11 @@
   @include typography($typo__h4);
 }
 
+.opening-hours-sidebar__date {
+  @include typography($typo__body-medium);
+  font-weight: $font__weight--normal;
+}
+
 .opening-hours-sidebar-details {
   @include opening-hours-sidebar-padding;
   border-top: 1px solid $color__global-tertiary-1;


### PR DESCRIPTION
### Link to Issue
[DDFFORM-822](https://reload.atlassian.net/browse/DDFFORM-822)

### Description
This pull request introduces new `OpeningHoursSidebar` stories for inspecting layout and animation. Additionally, it refactors the `Dialog` component to support sidebar functionality, enhancing the overall flexibility and usability of the dialog system.

I want to use our dialog component as much as possible for accessibility and reduction of JavaScript. However, there are some limitations related to CSS (so far). But I have arrived at a satisfactory result. I had to ignore some CSS linting rules because they do not include the latest CSS features.

<s>I know that Firefox doesn't support @starting-style for display: none (yet). In this case, the animation won't work. However, I believe there are advantages in using simpler HTML, better accessibility, and less JavaScript, so it's worth going with this solution for now.</s>


<S>https://caniuse.com/mdn-css_at-rules_starting-style</s>

**After updating, my Firefox works correctly.**


#### Test
http://varnish.pr-1528.dpl-cms.dplplat01.dpl.reload.dk/frontpage

[DDFFORM-822]: https://reload.atlassian.net/browse/DDFFORM-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ