### PR TITLE
Fix "pause reservations" popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-scripts": "^4.0.3",
-    "sass": "^1.79.4",
+    "sass": "1.78.0",
     "skeleton-screen-css": "^1.1.0",
     "storybook-addon-designs": "^6.2.1",
     "stylelint": "^14.16.1",

--- a/src/stories/Library/Modals/modal-pause/modal-pause.scss
+++ b/src/stories/Library/Modals/modal-pause/modal-pause.scss
@@ -19,7 +19,7 @@
 
 .modal-pause__container {
   margin: 0 $s-lg;
-  padding-top: 96px;
+  padding-top: $s-4xl;
   max-width: 550px;
 
   @include media-query__small {

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -26,7 +26,6 @@ $selected-date-background: rgb(0, 105, 255);
     }
   }
 
-
   &.inline {
     box-shadow: none;
     border-radius: 0;

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -20,10 +20,10 @@ $selected-date-background: rgb(0, 105, 255);
   // People had troubles scrolling when the calendar is open (possible, but users
   // can't figure it out.
   &.open.rangeMode {
-      @include media-query(calc(map_get($breakpoints, "x-small") + 1px), "max-width") {
-        left: -$s-xl;
-        top: -$s-4xl;
-      }
+    @include media-query(calc(map_get($breakpoints, "x-small") + 1px), "max-width") {
+      left: -$s-xl;
+      top: -$s-4xl;
+    }
   }
 
 

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -20,7 +20,10 @@ $selected-date-background: rgb(0, 105, 255);
   // People had troubles scrolling when the calendar is open (possible, but users
   // can't figure it out.
   &.open.rangeMode {
-    @include media-query(calc(map_get($breakpoints, "x-small") + 1px), "max-width") {
+    @include media-query(
+      calc(map_get($breakpoints, "x-small") + 1px),
+      "max-width"
+    ) {
       left: -$s-xl;
       top: -$s-4xl;
     }

--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -16,6 +16,17 @@ $selected-date-background: rgb(0, 105, 255);
   padding: $s-md !important;
   width: fit-content !important;
 
+  // On small devices, we need to make sure that the calendar is visible.
+  // People had troubles scrolling when the calendar is open (possible, but users
+  // can't figure it out.
+  &.open.rangeMode {
+      @include media-query(calc(map_get($breakpoints, "x-small") + 1px), "max-width") {
+        left: -$s-xl;
+        top: -$s-4xl;
+      }
+  }
+
+
   &.inline {
     box-shadow: none;
     border-radius: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5268,6 +5268,21 @@ chokidar@3.5.3, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+"chokidar@>=3.0.0 <4.0.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -5286,13 +5301,6 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.1.tgz#4a6dff66798fb0f72a94f616abbd7e1a19f31d41"
-  integrity sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==
-  dependencies:
-    readdirp "^4.0.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -13791,11 +13799,6 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.1.tgz#b2fe35f8dca63183cd3b86883ecc8f720ea96ae6"
-  integrity sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -14370,12 +14373,12 @@ sass-loader@^10.0.5:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.79.4:
-  version "1.79.4"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.79.4.tgz#f9c45af35fbeb53d2c386850ec842098d9935267"
-  integrity sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==
+sass@1.78.0:
+  version "1.78.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.78.0.tgz#cef369b2f9dc21ea1d2cf22c979f52365da60841"
+  integrity sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==
   dependencies:
-    chokidar "^4.0.0"
+    chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-52

#### Description
This PR fixes an issue where the date picker for pausing reservations was bleeding outside the screen on small devices. It is possible to scroll, but the users couldn't figure it out because one needs to scroll inside the date picker overlay window. But now they should be able to see the whole window at all times.

#### Screenshot of the result
AFTER:
![image](https://github.com/user-attachments/assets/38967f80-6a5c-488d-a56f-c7131011f4ec)


BEFORE:
![image](https://github.com/user-attachments/assets/c5eb0764-8ca9-4d2e-9246-13f9d1d8a241)

#### Additional comments or questions
-

