### PR TITLE
DDFHER-96 - Add `@media print` to enable printing of articles in modals

### DIFF
--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -119,18 +119,18 @@
 // Adjust the modal to display all content when printing
 @media print {
   .modal {
-    position: static !important;
-    overflow: visible !important;
-    width: auto !important;
-    height: auto !important;
-    opacity: 1 !important;
-    display: block !important;
+    position: static;
+    overflow: visible;
+    width: auto;
+    height: auto;
+    opacity: 1;
+    display: block;
   }
 
   // Hide elements that shouldn't appear in print
   .modal-backdrop,
   .modal-btn-close,
   .modal-btn-fallback {
-    display: none !important;
+    display: none;
   }
 }

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -115,3 +115,22 @@
   justify-content: flex-end;
   padding: 20px;
 }
+
+// Adjust the modal to display all content when printing
+@media print {
+  .modal {
+    position: static !important;
+    overflow: visible !important;
+    width: auto !important;
+    height: auto !important;
+    opacity: 1 !important;
+    display: block !important;
+  }
+
+  // Hide elements that shouldn't appear in print
+  .modal-backdrop,
+  .modal-btn-close,
+  .modal-btn-fallback {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-96

#### Description
This pull request adds `@media print` CSS styles to our modal component to enable proper printing of articles displayed within modals. While this solution addresses the immediate issue, we might want to consider using a library like `react-to-print` for a more beautiful approach in the future.

#### Screenshot of the result
[print.pdf](https://github.com/user-attachments/files/17375746/print.pdf)


#### Test
https://varnish.pr-1657.dpl-cms.dplplat01.dpl.reload.dk/work/work-of%3A870971-avis%3A89724244?type=artikel&modal=infomedia-modal-870971-avis%3A89724244


