### PR TITLE
DDFHER-98 - Hide the drupal "Apply" button in `search-full-text` form

### DIFF
--- a/src/stories/Library/search-full-text/search-full-text.scss
+++ b/src/stories/Library/search-full-text/search-full-text.scss
@@ -26,3 +26,9 @@
   display: grid;
   place-items: center;
 }
+
+// Hide the submit button from the Drupal form with CSS
+// The button cannot be removed directly in the Drupal view, so we hide it using CSS
+.search-full-text input[value="Apply"] {
+  display: none;
+}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-98
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1678

#### Description
The "Apply" button in the Drupal form cannot be removed directly in the view, so it is hidden using CSS to prevent it from displaying.

**Before:**
<img width="414" alt="Skærmbillede 2024-10-24 kl  11 00 44" src="https://github.com/user-attachments/assets/7efde312-45ff-43b5-a7f2-13839e148ed3">
**After:**
<img width="414" alt="Skærmbillede 2024-10-24 kl  11 01 45" src="https://github.com/user-attachments/assets/c2e6b016-11bd-4fde-904d-26b537dd43f1">
