### PR TITLE
Revert "Bump chromaui/action from 11.16.1 to 11.16.3"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,7 +34,7 @@ jobs:
       - run: yarn css:build
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v11.16.3
+        uses: chromaui/action@v11.16.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: c6b96f9648b6


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-design-system#761

This bump might have caused issued in #759, so we will revert the change for now