### PR TITLE
Add nowrap style for horizontal term line

### DIFF
--- a/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
+++ b/src/stories/Library/horizontal-term-line/horizontal-term-line.scss
@@ -9,4 +9,8 @@
   * {
     font-size: 12px;
   }
+
+  &.horizontal-term-line--no-wrap {
+    flex-wrap: nowrap;
+  }
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-175

#### Description
This PR add an option to make horizontal term line have a no-wrap modifier.

#### Screenshot of the result
![image](https://github.com/user-attachments/assets/0673a61c-b0ec-404d-a403-7c7078094991)

#### Additional comments or questions
Sibling: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1530