### PR TITLE
Add a Dependabot group for React dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
     labels:
       - dependencies
     groups:
+      react:
+        patterns:
+          - "react"
+          - "@types/react"
+          - "react-dom"
+          - "@types/react-dom"
       storybook:
         patterns:
           - "storybook"


### PR DESCRIPTION
#### Description

We want to ensure that React and React DOM is updated in parallel.

This is especially relevant for React 19.