### PR TITLE
DDFBRA-401 - Fix Release 2025.4.0 - Replace `min-height` with `height` in `dialog--sidebar`

### DIFF
--- a/src/stories/Library/dialog/dialog.scss
+++ b/src/stories/Library/dialog/dialog.scss
@@ -23,7 +23,7 @@
   // Apply custom
   background-color: $color__global-primary;
   position: fixed;
-  min-height: 100dvh;
+  height: 100dvh;
   width: 100%;
   left: auto;
 

--- a/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
+++ b/src/stories/Library/opening-hours-sidebar/OpeningHoursSidebar.stories.tsx
@@ -45,7 +45,7 @@ export default {
 const Template: StoryFn<typeof OpeningHoursSidebar> = (args) => {
   return (
     <div className="storybook-dialog-sidebar">
-      <OpeningHoursSidebar {...args} />;
+      <OpeningHoursSidebar {...args} />
     </div>
   );
 };

--- a/src/stories/Library/opening-hours-sidebar/opening-hours-libraries-data.ts
+++ b/src/stories/Library/opening-hours-sidebar/opening-hours-libraries-data.ts
@@ -25,6 +25,91 @@ const defaultLibraries = [
     name: "Blågårdens Bibliotek",
     openingHoursData,
   },
+  {
+    id: "5",
+    name: "Brønshøj Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "6",
+    name: "Christianshavns Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "7",
+    name: "Husum Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "8",
+    name: "Islands Brygge Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "9",
+    name: "Kildevæld Kulturcenter",
+    openingHoursData,
+  },
+  {
+    id: "10",
+    name: "Kulturstationen Vanløse",
+    openingHoursData,
+  },
+  {
+    id: "11",
+    name: "Nørrebro Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "12",
+    name: "Solvang Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "13",
+    name: "Sundby Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "14",
+    name: "Sydhavnens Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "15",
+    name: "Tingbjerg Bibliotek\\Kulturhus",
+    openingHoursData,
+  },
+  {
+    id: "16",
+    name: "Valby Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "17",
+    name: "Vesterbro Bibliotek og Kulturhus",
+    openingHoursData,
+  },
+  {
+    id: "18",
+    name: "Vigerslev Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "19",
+    name: "Øbro Jagtvej Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "20",
+    name: "Ørestad Bibliotek",
+    openingHoursData,
+  },
+  {
+    id: "21",
+    name: "Østerbro Bibliotek",
+    openingHoursData,
+  },
 ];
 
 export default defaultLibraries;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-401

#### Description

The previous use of `min-height` led to an unexpected layout issue, preventing the branch list from displaying correctly and making scrolling impossible.


**Before:**
<img width="1840" alt="Skærmbillede 2025-01-23 kl  15 03 05" src="https://github.com/user-attachments/assets/cc9f7052-8cee-4cf8-bbb6-522ca7837df8" />

**After**
With few:
<img width="1840" alt="Skærmbillede 2025-01-23 kl  16 38 51" src="https://github.com/user-attachments/assets/03ff4c3c-642a-41f7-a1a1-f1bc0d32dab2" />
with many:
<img width="1840" alt="Skærmbillede 2025-01-23 kl  16 43 52" src="https://github.com/user-attachments/assets/b109b7ae-4006-4ac9-a023-5cd3707caaec" />


On mobile: 
![IMG_1123](https://github.com/user-attachments/assets/397b1d70-402c-4624-a866-88b4511bd813)
Video:
https://github.com/user-attachments/assets/1e0c14f5-8d8a-4502-a922-44af49f5c498

#### Test
https://varnish.pr-2003.dpl-cms.dplplat01.dpl.reload.dk/