### PR TITLE
Center calendar horizontally on mobile and hide box arrow

### DIFF
--- a/src/stories/Library/date-calendar/date-calendar.scss
+++ b/src/stories/Library/date-calendar/date-calendar.scss
@@ -19,13 +19,18 @@ $selected-date-background: rgb(0, 105, 255);
   // On small devices, we need to make sure that the calendar is visible.
   // People had troubles scrolling when the calendar is open (possible, but users
   // can't figure it out.
-  &.open.rangeMode {
-    @include media-query(
-      calc(map_get($breakpoints, "x-small") + 1px),
-      "max-width"
-    ) {
-      left: -$s-xl;
+  &.open.static {
+    @include media-query(map-get($breakpoints, "small"), "max-width") {
       top: -$s-4xl;
+      left: 0;
+      right: 0;
+      margin: 0 auto;
+
+      // Hide arrow
+      &::after,
+      &::before {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-364

#### Description

It seems the previous CSS rule was targeting a too small device size, as many phones are larger than 375px. 
I also tweaked the CSS, so the calendar is centered horizontally. 
As for the issue with scrolling, it should have been fixed in #809

#### Screenshot of the result
![image](https://github.com/user-attachments/assets/3fa9761a-fe99-4ee1-bf59-5eedc63dfe93)

