### PR TITLE
Add a wrapper classes for tags used on pages / article html tags.

### DIFF
--- a/base.scss
+++ b/base.scss
@@ -163,6 +163,7 @@
 @import "./src/stories/Blocks/material-manifestation-item/material-manifestation-item";
 @import "./src/stories/Blocks/advanced-search/advanced-search";
 @import "./src/stories/Blocks/article/article";
+@import "./src/stories/Blocks/page/page";
 @import "./src/stories/Blocks/event-page/event-page";
 @import "./src/stories/Blocks/fee-list/fee-list-page-skeleton";
 @import "./src/stories/Blocks/content-list-page/content-list-page";

--- a/src/stories/Blocks/page/Page.stories.tsx
+++ b/src/stories/Blocks/page/Page.stories.tsx
@@ -17,6 +17,7 @@ export default {
       control: "object",
       description: "Object containing hero details",
     },
+    tags: { control: "object" },
   },
 } as Meta<typeof Page>;
 
@@ -53,4 +54,17 @@ branchPage.args = {
       Sprog: { value: ["Dansk"], type: "standard" },
     },
   },
+};
+
+export const PageWithTags = Template.bind({});
+PageWithTags.args = {
+  hero: {
+    placeholderText: "Denne side har tags, men intet billede",
+    contentType: "Artikel",
+    date: "12 Jan 2025",
+    title: "Alt du skal vide om moderne scenekunst",
+    description:
+      "En introduktion til de mest populære emner i dansk scenekunst lige nu, med fokus på dans, poesi og samtidskunst.",
+  },
+  tags: ["dans", "contemporary", "modern", "scenekunst", "digt", "3-8 årige"],
 };

--- a/src/stories/Blocks/page/Page.tsx
+++ b/src/stories/Blocks/page/Page.tsx
@@ -1,12 +1,26 @@
 import { FC } from "react";
 import Hero, { HeroProps } from "../../Library/Heros/hero/Hero";
 import Paragraph from "../../Library/paragraph/Paragraph";
+import HorizontalTermLine, {
+  HorizontalTermLineProps,
+} from "../../Library/horizontal-term-line/HorizontalTermLine";
 
 type PageProps = {
   hero?: HeroProps;
+  tags?: string[];
 };
 
-const Page: FC<PageProps> = ({ hero }) => {
+const Page: FC<PageProps> = ({ hero, tags }) => {
+  const tagData: HorizontalTermLineProps | null = tags?.length
+    ? {
+        title: "Tags",
+        linkList: tags.map((tag) => ({
+          text: tag,
+          url: "#",
+        })),
+      }
+    : null;
+
   return (
     <article>
       <section className="paragraphs">
@@ -24,6 +38,12 @@ const Page: FC<PageProps> = ({ hero }) => {
           </Paragraph>
         )}
       </section>
+
+      {tagData && (
+        <div className="page__tags">
+          <HorizontalTermLine collapsible={false} {...tagData} />
+        </div>
+      )}
     </article>
   );
 };

--- a/src/stories/Blocks/page/page.scss
+++ b/src/stories/Blocks/page/page.scss
@@ -1,0 +1,4 @@
+.page__tags {
+  margin-top: $s-md;
+  @include layout-container;
+}


### PR DESCRIPTION
DDFFSAL-73

#### Link to issue

[DDFSAL-73](https://reload.atlassian.net/browse/DDFSAL-73)


CMS PR: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2214

#### Description

This PR adds a class for wrapping tags on pages & provides an example usage. 

#### Screenshot of the result

See the new example with a page using tags

![image](https://github.com/user-attachments/assets/d0497988-7c62-45cc-9a5b-7175f6214327)





[DDFSAL-73]: https://reload.atlassian.net/browse/DDFSAL-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ