### PR TITLE
DDFSAL-92 - Enhance styling in advance search + Add CQL help link

### DIFF
--- a/src/stories/Blocks/advanced-search/AdvancedSearch.stories.tsx
+++ b/src/stories/Blocks/advanced-search/AdvancedSearch.stories.tsx
@@ -25,6 +25,10 @@ export default {
       name: "Is CQL search?",
       control: { type: "boolean" },
     },
+    cqlSearchExternalHelpLinkText: {
+      name: "CQL search external help link text",
+      control: { type: "text" },
+    },
   },
   args: {
     inputPlaceholder: "Søgeterm",
@@ -32,6 +36,7 @@ export default {
     cqlPreviewText:
       "title = harry potter AND subtitle = and the philosophers stone",
     isCqlSearch: false,
+    cqlSearchExternalHelpLinkText: "Læs mere om CQL-søgning",
   },
   parameters: {
     design: {

--- a/src/stories/Blocks/advanced-search/AdvancedSearch.tsx
+++ b/src/stories/Blocks/advanced-search/AdvancedSearch.tsx
@@ -105,29 +105,33 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
               name="name"
               label="CQL"
               className="advanced-search-cql-form__input focus-styling__input"
+              labelClassName="advanced-search-cql-form__label"
               cols={100}
               rows={5}
               placeholder="e.g. 'harry potter'"
             />
             <Links
-              classNames="link-tag"
+              classNames="link-tag advanced-search-cql-form__external-help-link"
               href="https://danbib.dk/soegekoder-complex-search"
               linkText={cqlSearchExternalHelpLinkText}
             />
           </div>
           <Input
+            labelClassName="advanced-search-cql-form__label"
             label="Location"
             type="text"
             id="location"
             description="Add a comma separated list for multiple locations"
           />
           <Input
+            labelClassName="advanced-search-cql-form__label"
             label="Sublocation"
             type="text"
             id="sublocation"
             description="Add a comma separated list for multiple sublocations"
           />
           <Checkbox
+            labelClassName="advanced-search-cql-form__label"
             isChecked={false}
             hiddenLabel={false}
             label=" Holding Status On Shelf"

--- a/src/stories/Blocks/advanced-search/AdvancedSearch.tsx
+++ b/src/stories/Blocks/advanced-search/AdvancedSearch.tsx
@@ -10,12 +10,14 @@ import { ReactComponent as PlusButtonIcon } from "../../../public/icons/collecti
 import Input from "../../Library/Forms/input/Input";
 import { Checkbox } from "../../Library/Forms/checkbox/Checkbox";
 import Textarea from "../../Library/Forms/textarea/Textarea";
+import { Links } from "../../Library/links/Links";
 
 export interface AdvancedSearchProps {
   inputPlaceholder: string;
   inputAmount: number;
   cqlPreviewText: string;
   isCqlSearch: boolean;
+  cqlSearchExternalHelpLinkText: string;
 }
 
 export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
@@ -23,6 +25,7 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
   inputAmount,
   cqlPreviewText,
   isCqlSearch,
+  cqlSearchExternalHelpLinkText,
 }) => {
   return (
     <div className="advanced-search">
@@ -96,15 +99,22 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
       )}
       {isCqlSearch && (
         <form className="advanced-search-cql-form">
-          <Textarea
-            id="cql"
-            name="name"
-            label="CQL"
-            className="advanced-search-cql-form__input focus-styling__input"
-            cols={100}
-            rows={5}
-            placeholder="e.g. 'harry potter'"
-          />
+          <div>
+            <Textarea
+              id="cql"
+              name="name"
+              label="CQL"
+              className="advanced-search-cql-form__input focus-styling__input"
+              cols={100}
+              rows={5}
+              placeholder="e.g. 'harry potter'"
+            />
+            <Links
+              classNames="link-tag"
+              href="https://danbib.dk/soegekoder-complex-search"
+              linkText={cqlSearchExternalHelpLinkText}
+            />
+          </div>
           <Input
             label="Location"
             type="text"

--- a/src/stories/Blocks/advanced-search/advanced-search.scss
+++ b/src/stories/Blocks/advanced-search/advanced-search.scss
@@ -104,6 +104,11 @@
   }
 }
 
+.dpl-input .advanced-search-cql-form__label {
+  @include typography($typo__h4);
+  margin-bottom: $s-sm;
+}
+
 .advanced-search-cql-form__input {
   @include typography($typo__body-placeholder);
   border: solid 1px $color__global-tertiary-1;
@@ -112,6 +117,10 @@
   padding: $s-md;
   resize: none;
   background-color: $color__global-primary;
+}
+
+.advanced-search-cql-form__external-help-link {
+  @include typography($typo__small-caption);
 }
 
 .input-and-preview {

--- a/src/stories/Library/Forms/checkbox/Checkbox.tsx
+++ b/src/stories/Library/Forms/checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React, { useState, useRef } from "react";
 
 export type CheckboxProps = {
@@ -10,6 +11,7 @@ export type CheckboxProps = {
   callback?: (isChecked: boolean) => void;
   hiddenLabel: boolean;
   classNames?: string;
+  labelClassName?: string;
 };
 
 export const Checkbox: React.FC<CheckboxProps> = ({
@@ -22,6 +24,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   validation,
   hiddenLabel = false,
   classNames,
+  labelClassName,
 }) => {
   const checkboxId = useRef(`checkbox_id__${Math.random()}`);
   const [checked, setChecked] = useState(isChecked);
@@ -43,7 +46,10 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         checked={checked}
         onClick={handleClick}
       />
-      <label className="checkbox__label" htmlFor={checkboxId.current}>
+      <label
+        className={clsx("checkbox__label", labelClassName)}
+        htmlFor={checkboxId.current}
+      >
         <span className="checkbox__icon">
           {/* The svg is inline since it should be white.
           The stroke color is manipulated with css. */}
@@ -59,9 +65,10 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         <div>
           {label && (
             <span
-              className={`checkbox__text text-small-caption color-secondary-gray ${
-                hiddenLabel ? "checkbox__text--hide-visually" : ""
-              }`}
+              className={clsx(
+                "checkbox__text text-small-caption color-secondary-gray",
+                hiddenLabel && "checkbox__text--hide-visually",
+              )}
             >
               {label}
             </span>

--- a/src/stories/Library/Forms/input/Input.tsx
+++ b/src/stories/Library/Forms/input/Input.tsx
@@ -8,10 +8,19 @@ export type InputProps = {
   description?: string;
   validation?: string;
   classNames?: string;
+  labelClassName?: string;
 };
 
 const Input = (props: InputProps) => {
-  const { label, type, id, description, validation, classNames } = props;
+  const {
+    label,
+    type,
+    id,
+    description,
+    validation,
+    classNames,
+    labelClassName,
+  } = props;
   const invalid = validation ? "true" : "false";
   return (
     <div
@@ -19,7 +28,9 @@ const Input = (props: InputProps) => {
         "dpl-input--invalid": !!validation,
       })}
     >
-      <Label id={id}>{label}</Label>
+      <Label id={id} className={labelClassName}>
+        {label}
+      </Label>
       <input
         aria-invalid={invalid}
         aria-describedby={`description-${id}`}

--- a/src/stories/Library/Forms/textarea/Textarea.tsx
+++ b/src/stories/Library/Forms/textarea/Textarea.tsx
@@ -9,6 +9,7 @@ export interface TextareaProps {
   rows?: number;
   cols?: number;
   className?: string;
+  labelClassName?: string;
   placeholder?: string;
 }
 
@@ -20,10 +21,13 @@ const Textarea: FC<TextareaProps> = ({
   cols = 80,
   className,
   placeholder,
+  labelClassName,
 }) => {
   return (
     <div className="dpl-input">
-      <Label id={id}>{label}</Label>
+      <Label id={id} className={labelClassName}>
+        {label}
+      </Label>
       <div>
         <textarea
           className={clsx(className)}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-92


#### Description
Originally, the link was intended to be placed under the title. However, this caused spacing issues when toggling between CQL and Advanced Search modes. Therefore, the link is now placed below the CQL textfeild.

To ensure it aligns correctly under the CQL textfeild without being affected by grid gaps, it has been wrapped in a separate div.


**AI:**
This pull request enhances the `AdvancedSearch` component by adding support for an external help link when CQL search is enabled. The changes include updates to the component's props, story configuration, and rendering logic.

### Enhancements to `AdvancedSearch` component:

* **Support for external help link text:**
  - Added a new prop `cqlSearchExternalHelpLinkText` to the `AdvancedSearchProps` interface and included it in the component's props. (`src/stories/Blocks/advanced-search/AdvancedSearch.tsx`, [src/stories/Blocks/advanced-search/AdvancedSearch.tsxR13-R28](diffhunk://#diff-ca8d86ecffa1e42b2d5f968e6b97e1f626360d6bd6e55ebdb660bf7e4503c5d3R13-R28))
  - Updated the `AdvancedSearch` story to include a control for `cqlSearchExternalHelpLinkText` and set a default value ("Læs mere om CQL-søgning"). (`src/stories/Blocks/advanced-search/AdvancedSearch.stories.tsx`, [src/stories/Blocks/advanced-search/AdvancedSearch.stories.tsxR28-R39](diffhunk://#diff-9b022a20e0f06bb7e30dbeee1fe1e8ab68f0366673c2f577c0ba77341453284fR28-R39))

* **Rendering the external help link:**
  - Added a `Links` component to display the external help link below the CQL textarea when `isCqlSearch` is true. The link uses the provided `cqlSearchExternalHelpLinkText` and a predefined URL. (`src/stories/Blocks/advanced-search/AdvancedSearch.tsx`, [src/stories/Blocks/advanced-search/AdvancedSearch.tsxR112-R117](diffhunk://#diff-ca8d86ecffa1e42b2d5f968e6b97e1f626360d6bd6e55ebdb660bf7e4503c5d3R112-R117))