### PR TITLE
Use action-gh-release version v2.2.2

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           prerelease: true
           target_commitish: ${{ env.RELEASE_SHA }}

--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           files: ${{ env.DIST_FILENAME }}
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-703

#### Description

There is a bug with version `2.3.0` of `softprops/action-gh-release`. The solution I found on GitHub is to temporarily switch to a specific commit of the action.

This pull request updates the GitHub Actions workflows to use a specific commit hash for the `softprops/action-gh-release` action, instead of relying on the `v2` version tag.

Refs:
- https://github.com/softprops/action-gh-release/issues/627
- https://github.com/softprops/action-gh-release/issues/628