### PR TITLE
fix backdrop on autosuggest search header

### DIFF
--- a/src/stories/Blocks/autosuggest/autosuggest.scss
+++ b/src/stories/Blocks/autosuggest/autosuggest.scss
@@ -1,13 +1,54 @@
 .autosuggest {
   background-color: $color__global-primary;
-  outline: 1px solid $color__global-tertiary-1;
+
   position: absolute;
   left: 0;
   right: 0;
   top: calc(100% + 1px);
-  z-index: $z-5;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding-top: $s-md;
+
+  &--open {
+    padding-top: $s-md;
+    padding-bottom: $s-md;
+    filter: drop-shadow(0 23px 23px rgb(0 0 0 / 0.2));
+    outline: 1px solid $color__global-tertiary-1;
+  }
+}
+
+// This is the backdrop for the autosuggest component
+// Its dom structure is placed in the body tag the autosuggest component by the use of portals
+.autosuggest-backdrop {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  top: 0;
+  right: 0;
+  width: 100vw;
+  height: 100%;
+  pointer-events: none;
+  z-index: $z-autosuggest-backdrop;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    background-color: $color__global-black;
+    transition: opacity 0.3s ease-in-out;
+    opacity: 0;
+  }
+
+  &--open {
+    visibility: visible;
+    pointer-events: all;
+
+    &::before {
+      opacity: 0.5;
+    }
+  }
 }

--- a/src/stories/Blocks/header/header.scss
+++ b/src/stories/Blocks/header/header.scss
@@ -7,7 +7,7 @@
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 500ms;
-  z-index: $z-20;
+  z-index: $z-header;
 }
 
 .header__logo-desktop {
@@ -135,6 +135,7 @@
   align-items: center;
   position: relative;
   height: 100%;
+  width: 100%;
 }
 
 .header__menu-search-input {

--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -10,6 +10,7 @@
   transition: opacity 0.3s;
   height: 100dvh;
   overflow: auto;
+  z-index: $z-modal;
 
   &__screen-reader-description {
     @include hide-visually;

--- a/src/styles/scss/tools/variables.z-indexes.scss
+++ b/src/styles/scss/tools/variables.z-indexes.scss
@@ -5,3 +5,7 @@ $z-10: 10;
 $z-15: 15;
 $z-20: 20;
 $z-25: 25;
+
+$z-header: 200;
+$z-autosuggest-backdrop: 100;
+$z-modal: 400;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/jira/software/c/projects/DDFSAL/boards/539?assignee=712020%3Abfac20a1-e872-46b1-afff-2f008a684012&selectedIssue=DDFSAL-208

#### Description

- add autosuggest backdrop
- add comment that autosuggest-backdrop is using react portals
- z-index variables and enhance autosuggest and modal styles
