### PR TITLE
Fix facet browser z-index

### DIFF
--- a/src/stories/Library/Modals/modal.scss
+++ b/src/stories/Library/Modals/modal.scss
@@ -61,7 +61,7 @@
   width: 100%;
   height: 100%;
   position: fixed;
-  z-index: $z-20;
+  z-index: $z-modal-backdrop;
   top: 0;
   left: 0;
   background-color: hsla(0, 0%, 15%, 0.5);

--- a/src/styles/scss/tools/variables.z-indexes.scss
+++ b/src/styles/scss/tools/variables.z-indexes.scss
@@ -8,4 +8,5 @@ $z-25: 25;
 
 $z-header: 200;
 $z-autosuggest-backdrop: 100;
+$z-modal-backdrop: 300;
 $z-modal: 400;


### PR DESCRIPTION
#### Link to issue
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1995

#### Description
To gain better clarity and control over fixed and absolutely positioned DOM elements, we use fixed z-index values, each named to correspond with the specific DOM element they are used for. These har located in the [z-indexes.scss](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/961/files#diff-7116d4671743b2c66a79445a488b2523a52ad08ad22b56dc0fdc0ab794f65c7d) file