### PR TITLE
Set an explicit limit for open pull requests to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: weekly
       day: monday
@@ -12,6 +13,7 @@ updates:
       - github_actions
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
#### Description

If not defined then Dependabot will default to 5. This is much lower than we want.
