### PR TITLE
Refactor material description styles and update class names

### DIFF
--- a/src/stories/Library/material-description/MaterialDescription.tsx
+++ b/src/stories/Library/material-description/MaterialDescription.tsx
@@ -68,7 +68,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({
   return (
     <section className="material-description">
       <h2 className="text-header-h4 pb-16">Beskrivelse</h2>
-      <p className="text-body-large material-description__content">
+      <p className="text-body-large material-description__abstract">
         {description}
       </p>
       <div className="material-description__links mt-32">

--- a/src/stories/Library/material-description/material-description.scss
+++ b/src/stories/Library/material-description/material-description.scss
@@ -7,9 +7,14 @@
     font-size: 24px;
   }
 
-  &__content {
+  &__abstract {
     max-width: 750px;
     line-height: 160%;
+  }
+
+  &__content {
+    list-style: initial;
+    padding-left: $s-md;
   }
 
   @include media-query__medium {


### PR DESCRIPTION
- Renamed the class from `material-description__content` to `material-description__abstract` for better semantic clarity.
- Introduced a new class `material-description__content` with specific styles for list items.

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.

